### PR TITLE
Set current battle royale pub map in activity status

### DIFF
--- a/nessie.js
+++ b/nessie.js
@@ -9,6 +9,12 @@ const { defaultPrefix, token } = require('./config/nessie.json'); //Get config d
 const commands = require('./commands'); //Get list of commands
 const { getBattleRoyalePubs } = require('./adapters');
 
+/**
+ * In charge of correctly displaying current battle royale pubs rotation in nessie's activity status
+ * As the maps have varying durations, needed to figure out a way to dynamically change the timeout after each call
+ * Accomplished this by creating a intervalRequest function that has a setTimeout that calls itself as its callback
+ * Inside the interval function we can then properly get the current timer and update accordingly
+ */
 const setCurrentMapStatus = (data) => {
   const fiveSecondsBuffer = 5000;
   let currentTimer = data.current.remainingSecs*1000 + fiveSecondsBuffer;
@@ -17,7 +23,7 @@ const setCurrentMapStatus = (data) => {
     currentTimer = updatedBrPubsData.current.remainingSecs*1000 + fiveSecondsBuffer;
     setTimeout(intervalRequest, currentTimer);
   }
-  setTimeout(intervalRequest, currentTimer);
+  setTimeout(intervalRequest, currentTimer); //Start initial timer
 }
 
 nessie.login(token); //Login to discord with bot's token

--- a/nessie.js
+++ b/nessie.js
@@ -7,6 +7,18 @@ const Discord = require('discord.js');
 const nessie = new Discord.Client({ intents: [Discord.Intents.FLAGS.GUILDS, Discord.Intents.FLAGS.GUILD_MESSAGES, Discord.Intents.FLAGS.GUILD_MESSAGE_TYPING]});
 const { defaultPrefix, token } = require('./config/nessie.json'); //Get config data from config folder
 const commands = require('./commands'); //Get list of commands
+const { getBattleRoyalePubs } = require('./adapters');
+
+const setCurrentMapStatus = (data) => {
+  const fiveSecondsBuffer = 5000;
+  let currentTimer = data.current.remainingSecs*1000 + fiveSecondsBuffer;
+  const intervalRequest = async () => {
+    const updatedBrPubsData = await getBattleRoyalePubs();
+    currentTimer = updatedBrPubsData.current.remainingSecs*1000 + fiveSecondsBuffer;
+    setTimeout(intervalRequest, currentTimer);
+  }
+  setTimeout(intervalRequest, currentTimer);
+}
 
 nessie.login(token); //Login to discord with bot's token
 //------
@@ -17,8 +29,11 @@ nessie.once('ready', async () => {
   try {
     const testChannel = nessie.channels.cache.get('889212328539725824');
     testChannel && testChannel.send("I'm booting up! (◕ᴗ◕✿)");
+    const brPubsData = await getBattleRoyalePubs();
+    nessie.user.setActivity(brPubsData.current.map);
+    setCurrentMapStatus(brPubsData);
   } catch(e){
-    console.log(e);
+    console.log(e); //Add proper error handling
   }
 })
 //------


### PR DESCRIPTION
#### Context
Had an idea came up from a friend to set the current map rotation for br pubs in the activity status of nessie. This is so that they can easily check the map quickly through the member list. Seemed like a good idea even tho it negates the a br command a lil bit

As for the actual implementation itself, it's fairly simple with the use of setTimeouts and a function that calls itself after the current map duration has ended. Added an extra layer of safety by adding a 5 second buffer before the next interval just to make sure we actually get the next map from the api

![image](https://user-images.githubusercontent.com/42207245/136688802-63434165-cf8d-4263-a581-9b9c6315baba.png)

#### Change
- Create setCurrentMapStatus to auto display current br map

#### Release Notes
Set current battle royale pub map in activity status