### PR TITLE
Create hub commands

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -8,5 +8,6 @@ module.exports = {
   arenas: require('./commands/maps/arenas'),
   //Hub
   info: require('./commands/hub/info'),
+  help: require('./commands/hub/help'),
   prefix: require('./commands/hub/prefix')
 }

--- a/commands.js
+++ b/commands.js
@@ -3,6 +3,9 @@
  * Ceating this extra file for easier readability of commands
  */
 module.exports = {
+  //Maps
   br: require('./commands/maps/battle-royale'),
-  arenas: require('./commands/maps/arenas')
+  arenas: require('./commands/maps/arenas'),
+  //Hub
+  prefix: require('./commands/hub/prefix')
 }

--- a/commands.js
+++ b/commands.js
@@ -9,5 +9,6 @@ module.exports = {
   //Hub
   info: require('./commands/hub/info'),
   help: require('./commands/hub/help'),
-  prefix: require('./commands/hub/prefix')
+  prefix: require('./commands/hub/prefix'),
+  invite: require('./commands/hub/invite')
 }

--- a/commands.js
+++ b/commands.js
@@ -7,5 +7,6 @@ module.exports = {
   br: require('./commands/maps/battle-royale'),
   arenas: require('./commands/maps/arenas'),
   //Hub
+  info: require('./commands/hub/info'),
   prefix: require('./commands/hub/prefix')
 }

--- a/commands/hub/help.js
+++ b/commands/hub/help.js
@@ -1,0 +1,27 @@
+const { defaultPrefix } = require('../../config/nessie.json');
+
+module.exports = {
+  name: 'help',
+  description: 'directory hub of commands',
+  hasArguments: false,
+  execute({message}) {
+    const embed = {
+      color: 3447003,
+      description:
+        'Below you can see all the commands that I know!\n\nMy current prefix is `' +
+        defaultPrefix +
+        '`',
+      fields: [
+        {
+          name: 'Maps',
+          value: '`br`, `br ranked`, `arenas`, `arenas ranked`'
+        },
+        {
+          name: 'Information',
+          value: '`info`, `help`, `prefix`, `invite`'
+        }
+      ]
+    };
+    return message.channel.send({ embeds: [embed] });
+  }
+};

--- a/commands/hub/info.js
+++ b/commands/hub/info.js
@@ -1,0 +1,47 @@
+const { format } = require('date-fns');
+const { version } = require('../../package.json');
+const grvAcnt = '`';
+const { defaultPrefix } = require('../../config/nessie.json');
+
+const sendInfoEmbed = ({message, nessie, prefix}) => {
+  const embed = {
+    title: 'Info',
+    description: `Hi there! I'm Nessie and I provide information about map rotations in Apex Legends! In my final form, I want to be able to automatically notify you which maps you want to play are currently active!\n\nCurrent version: No notifications yet but you can manually check the current map rotation with my commands! I also display the current br pubs map as my activity status.\n\nMy prefix  is ${grvAcnt}${prefix}${grvAcnt} | For a detailed list of my commands, type ${grvAcnt}${prefix}help${grvAcnt}`, //Removed users for now
+    color: 16776960,
+    thumbnail: {
+      url: 'https://cdn.discordapp.com/attachments/889134541615292459/896698383593517066/sir_nessie.png'  
+    },
+    fields: [
+      {
+        name: 'Creator',
+        value: 'Vexuas#8141',
+        inline: true
+      },
+      {
+        name: 'Date Created',
+        value: format(nessie.user.createdTimestamp, 'dd-MMM-yyyy'),
+        inline: true
+      },
+      {
+        name: 'Version',
+        value: version,
+        inline: true
+      },
+      {
+        name: 'Library',
+        value: 'discord.js',
+        inline: true
+      }
+    ]
+  };
+  return message.channel.send({ embeds: [embed] });
+};
+
+module.exports = {
+  name: 'info',
+  description: 'The story and information hub of nessie',
+  execute({message, nessie}) {
+    const prefix = defaultPrefix;
+    sendInfoEmbed({message, nessie, prefix});
+  }
+};

--- a/commands/hub/info.js
+++ b/commands/hub/info.js
@@ -7,7 +7,7 @@ const sendInfoEmbed = ({message, nessie, prefix}) => {
   const embed = {
     title: 'Info',
     description: `Hi there! I'm Nessie and I provide information about map rotations in Apex Legends! In my final form, I want to be able to automatically notify you which maps you want to play are currently active!\n\nCurrent version: No notifications yet but you can manually check the current map rotation with my commands! I also display the current br pubs map as my activity status.\n\nMy prefix  is ${grvAcnt}${prefix}${grvAcnt} | For a detailed list of my commands, type ${grvAcnt}${prefix}help${grvAcnt}`, //Removed users for now
-    color: 16776960,
+    color: 3447003,
     thumbnail: {
       url: 'https://cdn.discordapp.com/attachments/889134541615292459/896698383593517066/sir_nessie.png'  
     },

--- a/commands/hub/invite.js
+++ b/commands/hub/invite.js
@@ -1,0 +1,13 @@
+module.exports = {
+  name: 'invite',
+  description: 'Generates an invite link for Nessie',
+  execute({message}) {
+    const embed = {
+      description: `${
+        message.author
+      } | [Add me to your servers! (◕ᴗ◕✿)](https://tinyurl.com/apex-legends-map-rotation-bot)`,
+      color: 3447003
+    }
+    message.channel.send({ embeds: [embed] });
+  }
+};

--- a/commands/hub/prefix.js
+++ b/commands/hub/prefix.js
@@ -1,0 +1,32 @@
+//Reminder to add custom prefix before v3
+const { defaultPrefix } = require('../../config/nessie.json');
+
+const generateEmbed = (prefix) => {
+  const embed = {
+    color: 16776960,
+    fields: [
+      {
+        name: 'Current Prefix',
+        value: prefix,
+        inline: true
+      },
+      {
+        name: 'Usage Example',
+        value: `${prefix}help`,
+        inline: true
+      }
+    ]
+  };
+  return [embed];
+};
+
+module.exports = {
+  name: 'prefix',
+  description: 'Shows current prefix',
+  hasArguments: false,
+  execute({message}) {
+    const currentPrefix = defaultPrefix;
+    const embed = generateEmbed(currentPrefix);
+    message.channel.send({ embeds: embed });
+  }
+};

--- a/commands/hub/prefix.js
+++ b/commands/hub/prefix.js
@@ -3,7 +3,7 @@ const { defaultPrefix } = require('../../config/nessie.json');
 
 const generateEmbed = (prefix) => {
   const embed = {
-    color: 16776960,
+    color: 3447003,
     fields: [
       {
         name: 'Current Prefix',

--- a/nessie.js
+++ b/nessie.js
@@ -74,7 +74,7 @@ nessie.on('messageCreate', async (message) => {
         if(arguments.length > 0 && !commands[command].hasArguments){
           await message.channel.send("That command doesn't accept arguments （・□・；）"); //Sends error reply if it doesn't
         } else {
-          await commands[command].execute({message, arguments}); //Executes command
+          await commands[command].execute({message, arguments, nessie}); //Executes command
         }
       } else {
         await message.channel.send("I'm not sure what you meant by that! （・□・；）"); //Sends error reply if command doesn't exist


### PR DESCRIPTION
#### Context
Hub commands for nessie. Consists of `info`, `help`, `prefix` and `invite`. What they each do is self-explanatory. I pretty much carried over a smaller version of how I did it for Yagi, didn't really need any of the more intuitive implementations

![image](https://user-images.githubusercontent.com/42207245/136692252-f5ccad22-7b04-42cc-aff2-476dc0f04314.png)
![image](https://user-images.githubusercontent.com/42207245/136692262-f98d7f28-368d-450e-a2f8-60ecd5d8c59d.png)
![image](https://user-images.githubusercontent.com/42207245/136692266-d0998135-34dc-423c-95ca-645cc40be228.png)
![image](https://user-images.githubusercontent.com/42207245/136692270-84f4b11c-255e-48b2-bd2c-309678c041b8.png)

#### Change
- Create info command
- Create help command
- Create prefix command
- Create invite command

#### Release Notes
Create hub commands