### PR TITLE
Add mixpanel events

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -1,0 +1,62 @@
+/**
+ * User and event tracking for Nessie using Mixpanel
+ * Learning from past mistakes so adding this pre-launch
+ * For reference: https://developer.mixpanel.com/docs/nodejs
+ */
+ const sendMixpanelEvent = ({user, channel, guild, command, client, arguments}) => {
+  const eventToSend = `Use ${command} command`; //Name of event; string interpolated with command as best to write an event as an action a user is doing
+  /**
+   * Creates and updates a user profile
+   * Sets properties everytime event is called and overrides if they're different
+   */
+   client.people.set(user.id, {
+    $name: user.username,
+    $created: user.createdAt.toISOString(),
+    tag: user.tag,
+    guild: guild.name,
+    guild_id: guild.id
+  })
+  if(channel.type !== 'dm'){
+    /**
+     * Event to send to mixpanel
+     * Added relevant properties along with event such as user, channel and guild
+     * Important to always send `distinct_id` as mixpanel-nodejs uses this as its unique identifier
+     */
+    client.track(eventToSend, {
+      distinct_id: user.id,
+      user: user.tag,
+      user_name: user.username,
+      channel: channel.name,
+      channel_id: channel.id,
+      guild: guild.name,
+      guild_id: guild.id,
+      command: command,
+      arguments: arguments ? arguments : 'none'
+    })
+    /**
+     * Sets a user profile properties only once
+     * Gets called on every event but doesn't override property if it already exists
+     * Useful for first time stuff
+     */
+    client.people.set_once(user.id, {
+      first_used: (new Date()).toISOString(), //Unfortunately this is only after v2.5
+      first_command: command,
+      first_used_in_guild: guild.name,
+      first_used_in_channel: channel.name
+    })
+  } else {
+    /**
+     * Separate tracking for dms
+     * Currently this is just to see if people actually message yagi privately instead of through a channel
+     */
+    client.track('Use command in private message', {
+      distinct_id: user.id,
+      user: user.tag,
+      user_name: user.username
+    })
+  }
+}
+
+module.exports = {
+  sendMixpanelEvent
+}

--- a/analytics.js
+++ b/analytics.js
@@ -3,7 +3,7 @@
  * Learning from past mistakes so adding this pre-launch
  * For reference: https://developer.mixpanel.com/docs/nodejs
  */
- const sendMixpanelEvent = ({user, channel, guild, command, client, arguments}) => {
+ const sendMixpanelEvent = (user, channel, guild, command, client, arguments) => {
   const eventToSend = `Use ${command} command`; //Name of event; string interpolated with command as best to write an event as an action a user is doing
   /**
    * Creates and updates a user profile
@@ -39,21 +39,13 @@
      * Useful for first time stuff
      */
     client.people.set_once(user.id, {
-      first_used: (new Date()).toISOString(), //Unfortunately this is only after v2.5
+      first_used: (new Date()).toISOString(),
       first_command: command,
       first_used_in_guild: guild.name,
       first_used_in_channel: channel.name
     })
   } else {
-    /**
-     * Separate tracking for dms
-     * Currently this is just to see if people actually message yagi privately instead of through a channel
-     */
-    client.track('Use command in private message', {
-      distinct_id: user.id,
-      user: user.tag,
-      user_name: user.username
-    })
+   //Maybe look into dms someday; dropping this for now from Yagi
   }
 }
 


### PR DESCRIPTION
#### Context
Sends events to track to Mixpanel with relevant properties such as user, channel and guild information for each event used. Also creates/updates user profiles and first time properties.

![image](https://user-images.githubusercontent.com/42207245/136694431-d444ab0d-ee07-4343-9f09-2d446c6c748e.png)

![image](https://user-images.githubusercontent.com/42207245/136693900-96927b67-9eb0-4987-ab2f-93308dd1d2b4.png)

#### Change
- Create analytics file
- Initialise mixpanel

#### Release Notes
Add mixpanel events