### PR TITLE
Add logging for status call

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -1,0 +1,46 @@
+const { format } = require('date-fns');
+
+exports.sendHealthLog = (data, channel) => {
+  const utcStart = new Date(data.current.readableDate_start);
+  const sgtStart = new Date(utcStart.getTime() + 28800000)
+  const utcEnd = new Date(data.current.readableDate_end);
+  const sgtEnd = new Date(utcEnd.getTime() + 28800000);
+
+  const embed = {
+    title: 'Nessie | Status Health Log',
+    description: 'Requested data from API',
+    color: 3066993,
+    thumbnail: {
+      url:
+        'https://cdn.discordapp.com/attachments/889134541615292459/896698383593517066/sir_nessie.png'
+    },
+    fields: [
+      {
+        name: 'Current Map',
+        value: `${codeBlock(data.current.map)} - ${codeBlock(format(sgtStart, 'hh:mm:ss aa'))}`,
+      },
+      {
+        name: 'Next Map',
+        value: `${codeBlock(data.next.map)} - ${codeBlock(format(sgtEnd, 'hh:mm:ss aa'))}`,
+      },
+      {
+        name: 'Time left',
+        value: codeBlock(data.current.remainingTimer)
+      },
+      {
+        name: 'Requested At',
+        value: codeBlock(format(new Date(), 'hh:mm:ss aa, dd MMM yyyy')),
+      },
+    ]
+  }
+  channel.send({embeds: [embed]});
+}
+//----------
+/**
+ * Function to create a text into a discord code block
+ * @param text - text to transform
+ */
+ const codeBlock = (text) => {
+  return "`" + text + "`";
+}
+//----------

--- a/helpers.js
+++ b/helpers.js
@@ -1,5 +1,12 @@
 const { format } = require('date-fns');
 
+//----------
+/**
+ * Function to send health status so that I can monitor how the status update for br pub maps is doing
+ * @data - br data object
+ * @channel - log channel in Nessie's Canyon (#health: 899620845436141609)
+ * @isAccurate - whether the data received is up-to-date
+ */
 exports.sendHealthLog = (data, channel, isAccurate) => {
   const utcStart = new Date(data.current.readableDate_start);
   const sgtStart = new Date(utcStart.getTime() + 28800000)

--- a/helpers.js
+++ b/helpers.js
@@ -1,6 +1,6 @@
 const { format } = require('date-fns');
 
-exports.sendHealthLog = (data, channel) => {
+exports.sendHealthLog = (data, channel, isAccurate) => {
   const utcStart = new Date(data.current.readableDate_start);
   const sgtStart = new Date(utcStart.getTime() + 28800000)
   const utcEnd = new Date(data.current.readableDate_end);
@@ -9,7 +9,7 @@ exports.sendHealthLog = (data, channel) => {
   const embed = {
     title: 'Nessie | Status Health Log',
     description: 'Requested data from API',
-    color: 3066993,
+    color: isAccurate ? 3066993 : 16776960,
     thumbnail: {
       url:
         'https://cdn.discordapp.com/attachments/889134541615292459/896698383593517066/sir_nessie.png'
@@ -31,9 +31,14 @@ exports.sendHealthLog = (data, channel) => {
         name: 'Requested At',
         value: codeBlock(format(new Date(), 'hh:mm:ss aa, dd MMM yyyy')),
       },
+      {
+        name: 'Accurate',
+        value: isAccurate ? 'Yes' : 'No'
+      }
     ]
   }
-  channel.send({embeds: [embed]});
+  isAccurate ? channel.send({ embeds: [embed] }) : channel.send({ content: '<@183444648360935424>', embeds: [embed] });
+  
 }
 //----------
 /**

--- a/nessie.js
+++ b/nessie.js
@@ -24,9 +24,10 @@ const setCurrentMapStatus = (data, channel) => {
   let currentTimer = data.current.remainingSecs*1000 + fiveSecondsBuffer;
   const intervalRequest = async () => {
     const updatedBrPubsData = await getBattleRoyalePubs();
+    const isAccurate = data.next.code === updatedBrPubsData.current.code;
     currentTimer = updatedBrPubsData.current.remainingSecs*1000 + fiveSecondsBuffer;
     nessie.user.setActivity(updatedBrPubsData.current.map);
-    sendHealthLog(updatedBrPubsData, channel);
+    sendHealthLog(updatedBrPubsData, channel, isAccurate);
     setTimeout(intervalRequest, currentTimer);
   }
   setTimeout(intervalRequest, currentTimer); //Start initial timer
@@ -52,7 +53,7 @@ nessie.once('ready', async () => {
     testChannel && testChannel.send("I'm booting up! (◕ᴗ◕✿)");
     const brPubsData = await getBattleRoyalePubs();
     nessie.user.setActivity(brPubsData.current.map);
-    sendHealthLog(brPubsData, logChannel);
+    sendHealthLog(brPubsData, logChannel, true);
     setCurrentMapStatus(brPubsData, logChannel);
   } catch(e){
     console.log(e); //Add proper error handling

--- a/nessie.js
+++ b/nessie.js
@@ -18,7 +18,7 @@ let mixpanel;
  * Accomplished this by creating a intervalRequest function that has a setTimeout that calls itself as its callback
  * Inside the interval function we can then properly get the current timer and update accordingly
  */
-const setCurrentMapStatus = (data) => {
+const setCurrentMapStatus = (data, channel) => {
   const fiveSecondsBuffer = 5000;
   let currentTimer = data.current.remainingSecs*1000 + fiveSecondsBuffer;
   const intervalRequest = async () => {
@@ -46,10 +46,12 @@ initialize();
 nessie.once('ready', async () => {
   try {
     const testChannel = nessie.channels.cache.get('889212328539725824');
+    const logChannel = nessie.channels.cache.get('899620845436141609');
     testChannel && testChannel.send("I'm booting up! (◕ᴗ◕✿)");
     const brPubsData = await getBattleRoyalePubs();
     nessie.user.setActivity(brPubsData.current.map);
-    setCurrentMapStatus(brPubsData);
+    logChannel.send(`Current Map: ${brPubsData.current.map}, Next Map: ${brPubsData.next.map}`)
+    setCurrentMapStatus(brPubsData, logChannel);
   } catch(e){
     console.log(e); //Add proper error handling
   }

--- a/nessie.js
+++ b/nessie.js
@@ -24,7 +24,13 @@ const setCurrentMapStatus = (data, channel) => {
   let currentTimer = data.current.remainingSecs*1000 + fiveSecondsBuffer;
   const intervalRequest = async () => {
     const updatedBrPubsData = await getBattleRoyalePubs();
-    const isAccurate = data.next.code === updatedBrPubsData.current.code;
+    /**
+     * Checks to see if the data taken from API is accurate
+     * Was brought to my attention that the status was displaying the wrong map at one point
+     * Not sure why this is happening so just adding a notification when this happens again
+     * Don't really want to add extra code for now, if it happens again then i'll fix it
+     */
+    const isAccurate = data.next.code === updatedBrPubsData.current.code; 
     currentTimer = updatedBrPubsData.current.remainingSecs*1000 + fiveSecondsBuffer;
     nessie.user.setActivity(updatedBrPubsData.current.map);
     sendHealthLog(updatedBrPubsData, channel, isAccurate);
@@ -51,10 +57,10 @@ nessie.once('ready', async () => {
     const testChannel = nessie.channels.cache.get('889212328539725824');
     const logChannel = nessie.channels.cache.get('899620845436141609');
     testChannel && testChannel.send("I'm booting up! (◕ᴗ◕✿)");
-    const brPubsData = await getBattleRoyalePubs();
-    nessie.user.setActivity(brPubsData.current.map);
-    sendHealthLog(brPubsData, logChannel, true);
-    setCurrentMapStatus(brPubsData, logChannel);
+    const brPubsData = await getBattleRoyalePubs(); //Get data of br map rotation
+    nessie.user.setActivity(brPubsData.current.map); //Set current br map as activity status
+    sendHealthLog(brPubsData, logChannel, true); //For logging purpose
+    setCurrentMapStatus(brPubsData, logChannel); //Calls status display function
   } catch(e){
     console.log(e); //Add proper error handling
   }

--- a/nessie.js
+++ b/nessie.js
@@ -10,6 +10,7 @@ const { defaultPrefix, token, lochnessMixpanel, nessieMixpanel } = require('./co
 const commands = require('./commands'); //Get list of commands
 const { getBattleRoyalePubs } = require('./adapters');
 const { sendMixpanelEvent } = require('./analytics');
+const { sendHealthLog } = require('./helpers');
 let mixpanel;
 
 /**
@@ -25,6 +26,7 @@ const setCurrentMapStatus = (data, channel) => {
     const updatedBrPubsData = await getBattleRoyalePubs();
     currentTimer = updatedBrPubsData.current.remainingSecs*1000 + fiveSecondsBuffer;
     nessie.user.setActivity(updatedBrPubsData.current.map);
+    sendHealthLog(updatedBrPubsData, channel);
     setTimeout(intervalRequest, currentTimer);
   }
   setTimeout(intervalRequest, currentTimer); //Start initial timer
@@ -50,7 +52,7 @@ nessie.once('ready', async () => {
     testChannel && testChannel.send("I'm booting up! (◕ᴗ◕✿)");
     const brPubsData = await getBattleRoyalePubs();
     nessie.user.setActivity(brPubsData.current.map);
-    logChannel.send(`Current Map: ${brPubsData.current.map}, Next Map: ${brPubsData.next.map}`)
+    sendHealthLog(brPubsData, logChannel);
     setCurrentMapStatus(brPubsData, logChannel);
   } catch(e){
     console.log(e); //Add proper error handling


### PR DESCRIPTION
#### Context
Apparently nessie was wrongly displaying the previous map still in its activity status. Only has ever happened once but gonna add logging either way. Not priority enough to add code to prevent it from happening, I'm more curious to see if it happens again.

![image](https://user-images.githubusercontent.com/42207245/137747849-be59aaa5-2676-4058-b2de-c2736e829f83.png)
![image](https://user-images.githubusercontent.com/42207245/137747971-65c80d66-a35e-40a5-a2e8-cd176f14a343.png)

#### Change
- Send health log in health channel in Nessie's Canyon

#### Release Notes
Add logging for status call