### PR TITLE
Add error ping

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -32,7 +32,7 @@ exports.sendHealthLog = (data, channel, isAccurate) => {
       },
       {
         name: 'Time left',
-        value: codeBlock(data.current.remainingTimer)
+        value: codeBlock(`${data.current.remainingTimer} | ${data.current.remainingSecs} secs`)
       },
       {
         name: 'Requested At',

--- a/nessie.js
+++ b/nessie.js
@@ -133,8 +133,9 @@ const createNessieDatabase = () => {
   let currentBrPubsData = data;
   let currentTimer = data.current.remainingSecs*1000 + fiveSecondsBuffer;
   const intervalRequest = async () => {
-    const updatedBrPubsData = await getBattleRoyalePubs();
-    /**
+    try {
+      const updatedBrPubsData = await getBattleRoyalePubs();
+       /**
      * Checks to see if the data taken from API is accurate
      * Was brought to my attention that the status was displaying the wrong map at one point
      * Not sure why this is happening so just adding a notification when this happens again
@@ -146,6 +147,9 @@ const createNessieDatabase = () => {
     nessie.user.setActivity(updatedBrPubsData.current.map);
     sendHealthLog(updatedBrPubsData, channel, isAccurate);
     setTimeout(intervalRequest, currentTimer);
+    } catch (e){
+      channel.send('<@183444648360935424> WHOOPS SOMETHING WENT WRONG');
+    }
   }
   setTimeout(intervalRequest, currentTimer); //Start initial timer
 }


### PR DESCRIPTION
#### Context
Looks like nessie shat himself again with the automatic status update. Looked at the logs and it seems the intervalRequest didn't get fired. Either the timeout is still running or some other bug related to setTimeout is happening. Those or the data from the api is somehow is messing up which I hope not. In any case this is frustrating to figure out, probably really should add tests but i'm lazy. We'll test in production, we're doing it live

![image](https://user-images.githubusercontent.com/42207245/138349665-55171d33-f3c6-496e-a672-c0b291f4e84d.png)

#### Change
- Send error ping when function throws an error
- Add remainingSecs to health log

#### Release Notes
Add error ping when status function throws an error