### PR TITLE
Update invite link

### DIFF
--- a/commands/hub/invite.js
+++ b/commands/hub/invite.js
@@ -5,7 +5,7 @@ module.exports = {
     const embed = {
       description: `${
         message.author
-      } | [Add me to your servers! (◕ᴗ◕✿)](https://tinyurl.com/apex-legends-map-rotation-bot)`,
+      } | [Add me to your servers! (◕ᴗ◕✿)](https://tinyurl.com/nessie-invite-v021)`,
       color: 3447003
     }
     message.channel.send({ embeds: [embed] });


### PR DESCRIPTION
#### Context
Thought I already changed the invite link but I was probably remembering yagi's. Anyway need to update this as the permissions for it was defaulted to admin and top.gg doesn't like that. I've updated the permissions to reflect only the necessary scopes but this would definitely get changed when notifications go out

#### Change
- Update invite link

#### Release Notes
Update invite link