### PR TITLE
Investigate application commands

### DIFF
--- a/app_commands.js
+++ b/app_commands.js
@@ -1,0 +1,11 @@
+/**
+ * Application Command list of nessie
+ * Creating this extra file for easier readability of commands
+ * Currently we support prefix commands and application commands
+ * After discord rolls the priviliged message intent at the end of April, verified bots will no longer be able to read messages normally
+ * TODO: Deprecate prefix commands before that happens
+ */
+module.exports = {
+  //Hub
+  about: require('./app_commands/hub/about'),
+};

--- a/app_commands/hub/about.js
+++ b/app_commands/hub/about.js
@@ -1,8 +1,6 @@
-const { format } = require('date-fns');
-const { version } = require('../../package.json');
-const grvAcnt = '`';
+const { SlashCommandBuilder } = require('@discordjs/builders');
 
-const sendInfoEmbed = ({ message, nessie, prefix }) => {
+const sendInfoEmbed = ({ message, nessie, prefix, interaction }) => {
   const embed = {
     title: 'Info',
     description: `Hi there! I'm Nessie and I provide information about map rotations in Apex Legends! In my final form, I want to be able to automatically notify you which maps you want to play are currently active!\n\nCurrent version: No notifications yet but you can manually check the current map rotation with my commands! I also display the current br pubs map as my activity status. And custom prefixes!\n\nMy current prefix  is ${grvAcnt}${prefix}${grvAcnt} | For a detailed list of my commands, type ${grvAcnt}${prefix}help${grvAcnt}`, //Removed users for now
@@ -43,14 +41,19 @@ const sendInfoEmbed = ({ message, nessie, prefix }) => {
       },
     ],
   };
-  return message.channel.send({ embeds: [embed] });
+  return interaction
+    ? interaction.reply({ embeds: [embed] })
+    : message.channel.send({ embeds: [embed] });
 };
 
 module.exports = {
   name: 'info',
   description: 'The story and information hub of nessie',
-  execute({ message, nessie, nessiePrefix }) {
+  data: new SlashCommandBuilder()
+    .setName('info')
+    .setDescription('The story and information hub of nessie'),
+  execute({ message, nessie, nessiePrefix, interaction }) {
     const prefix = nessiePrefix;
-    sendInfoEmbed({ message, nessie, prefix });
+    sendInfoEmbed({ message, nessie, prefix, interaction });
   },
 };

--- a/app_commands/hub/about.js
+++ b/app_commands/hub/about.js
@@ -1,9 +1,9 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 
-const sendInfoEmbed = ({ message, nessie, prefix, interaction }) => {
+const sendAboutEmbed = ({ nessie, prefix, interaction }) => {
   const embed = {
-    title: 'Info',
-    description: `Hi there! I'm Nessie and I provide information about map rotations in Apex Legends! In my final form, I want to be able to automatically notify you which maps you want to play are currently active!\n\nCurrent version: No notifications yet but you can manually check the current map rotation with my commands! I also display the current br pubs map as my activity status. And custom prefixes!\n\nMy current prefix  is ${grvAcnt}${prefix}${grvAcnt} | For a detailed list of my commands, type ${grvAcnt}${prefix}help${grvAcnt}`, //Removed users for now
+    title: 'About',
+    description: `Hi there! I'm Nessie and I provide information about map rotations in Apex Legends! In my final form, I want to be able to automatically notify you which maps you want to play are currently active!\n\nCurrent version: No notifications yet but you can manually check the current map rotation with my commands! I also display the current br pubs map as my activity status\n\nFor a detailed list of my commands, use the help command!`,
     color: 3447003,
     thumbnail: {
       url: 'https://cdn.discordapp.com/attachments/889134541615292459/896698383593517066/sir_nessie.png',
@@ -41,19 +41,14 @@ const sendInfoEmbed = ({ message, nessie, prefix, interaction }) => {
       },
     ],
   };
-  return interaction
-    ? interaction.reply({ embeds: [embed] })
-    : message.channel.send({ embeds: [embed] });
+  return interaction.reply({ embeds: [embed] });
 };
 
 module.exports = {
-  name: 'info',
-  description: 'The story and information hub of nessie',
   data: new SlashCommandBuilder()
     .setName('info')
     .setDescription('The story and information hub of nessie'),
-  execute({ message, nessie, nessiePrefix, interaction }) {
-    const prefix = nessiePrefix;
-    sendInfoEmbed({ message, nessie, prefix, interaction });
+  execute({ nessie, interaction }) {
+    sendAboutEmbed({ message, nessie, prefix, interaction });
   },
 };

--- a/app_commands/hub/about.js
+++ b/app_commands/hub/about.js
@@ -1,6 +1,8 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
+const { format } = require('date-fns');
+const { version } = require('../../package.json');
 
-const sendAboutEmbed = ({ nessie, prefix, interaction }) => {
+const sendAboutEmbed = ({ nessie, interaction }) => {
   const embed = {
     title: 'About',
     description: `Hi there! I'm Nessie and I provide information about map rotations in Apex Legends! In my final form, I want to be able to automatically notify you which maps you want to play are currently active!\n\nCurrent version: No notifications yet but you can manually check the current map rotation with my commands! I also display the current br pubs map as my activity status\n\nFor a detailed list of my commands, use the help command!`,
@@ -46,9 +48,9 @@ const sendAboutEmbed = ({ nessie, prefix, interaction }) => {
 
 module.exports = {
   data: new SlashCommandBuilder()
-    .setName('info')
+    .setName('about')
     .setDescription('The story and information hub of nessie'),
   execute({ nessie, interaction }) {
-    sendAboutEmbed({ message, nessie, prefix, interaction });
+    sendAboutEmbed({ nessie, interaction });
   },
 };

--- a/commands.js
+++ b/commands.js
@@ -12,4 +12,4 @@ module.exports = {
   prefix: require('./commands/hub/prefix'),
   setprefix: require('./commands/hub/setPrefix'),
   invite: require('./commands/hub/invite'),
-}
+};

--- a/commands.js
+++ b/commands.js
@@ -7,7 +7,7 @@ module.exports = {
   br: require('./commands/maps/battle-royale'),
   arenas: require('./commands/maps/arenas'),
   //Hub
-  info: require('./commands/hub/info'),
+  about: require('./commands/hub/about'),
   help: require('./commands/hub/help'),
   prefix: require('./commands/hub/prefix'),
   setprefix: require('./commands/hub/setPrefix'),

--- a/commands/hub/about.js
+++ b/commands/hub/about.js
@@ -2,9 +2,9 @@ const { format } = require('date-fns');
 const { version } = require('../../package.json');
 const grvAcnt = '`';
 
-const sendInfoEmbed = ({ message, nessie, prefix }) => {
+const sendAboutEmbed = ({ message, nessie, prefix }) => {
   const embed = {
-    title: 'Info',
+    title: 'About',
     description: `Hi there! I'm Nessie and I provide information about map rotations in Apex Legends! In my final form, I want to be able to automatically notify you which maps you want to play are currently active!\n\nCurrent version: No notifications yet but you can manually check the current map rotation with my commands! I also display the current br pubs map as my activity status. And custom prefixes!\n\nMy current prefix  is ${grvAcnt}${prefix}${grvAcnt} | For a detailed list of my commands, type ${grvAcnt}${prefix}help${grvAcnt}`, //Removed users for now
     color: 3447003,
     thumbnail: {
@@ -47,10 +47,10 @@ const sendInfoEmbed = ({ message, nessie, prefix }) => {
 };
 
 module.exports = {
-  name: 'info',
+  name: 'about',
   description: 'The story and information hub of nessie',
   execute({ message, nessie, nessiePrefix }) {
     const prefix = nessiePrefix;
-    sendInfoEmbed({ message, nessie, prefix });
+    sendAboutEmbed({ message, nessie, prefix });
   },
 };

--- a/commands/hub/help.js
+++ b/commands/hub/help.js
@@ -2,7 +2,7 @@ module.exports = {
   name: 'help',
   description: 'directory hub of commands',
   hasArguments: false,
-  execute({message, nessiePrefix}) {
+  execute({ message, nessiePrefix }) {
     const embed = {
       color: 3447003,
       description:
@@ -12,14 +12,14 @@ module.exports = {
       fields: [
         {
           name: 'Maps',
-          value: '`br`, `br ranked`, `arenas`, `arenas ranked`'
+          value: '`br`, `br ranked`, `arenas`, `arenas ranked`',
         },
         {
           name: 'Information',
-          value: '`info`, `help`, `prefix`, `setprefix`, `invite`'
-        }
-      ]
+          value: '`about`, `help`, `prefix`, `setprefix`, `invite`',
+        },
+      ],
     };
     return message.channel.send({ embeds: [embed] });
-  }
+  },
 };

--- a/commands/hub/info.js
+++ b/commands/hub/info.js
@@ -3,7 +3,7 @@ const { format } = require('date-fns');
 const { version } = require('../../package.json');
 const grvAcnt = '`';
 
-const sendInfoEmbed = ({ message, nessie, prefix }) => {
+const sendInfoEmbed = ({ message, nessie, prefix, interaction }) => {
   const embed = {
     title: 'Info',
     description: `Hi there! I'm Nessie and I provide information about map rotations in Apex Legends! In my final form, I want to be able to automatically notify you which maps you want to play are currently active!\n\nCurrent version: No notifications yet but you can manually check the current map rotation with my commands! I also display the current br pubs map as my activity status. And custom prefixes!\n\nMy current prefix  is ${grvAcnt}${prefix}${grvAcnt} | For a detailed list of my commands, type ${grvAcnt}${prefix}help${grvAcnt}`, //Removed users for now
@@ -44,7 +44,9 @@ const sendInfoEmbed = ({ message, nessie, prefix }) => {
       },
     ],
   };
-  return message.channel.send({ embeds: [embed] });
+  return interaction
+    ? interaction.reply({ embeds: [embed] })
+    : message.channel.send({ embeds: [embed] });
 };
 
 module.exports = {
@@ -53,8 +55,8 @@ module.exports = {
   data: new SlashCommandBuilder()
     .setName('info')
     .setDescription('The story and information hub of nessie'),
-  execute({ message, nessie, nessiePrefix }) {
+  execute({ message, nessie, nessiePrefix, interaction }) {
     const prefix = nessiePrefix;
-    sendInfoEmbed({ message, nessie, prefix });
+    sendInfoEmbed({ message, nessie, prefix, interaction });
   },
 };

--- a/commands/hub/info.js
+++ b/commands/hub/info.js
@@ -1,47 +1,48 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
 const { format } = require('date-fns');
 const { version } = require('../../package.json');
 const grvAcnt = '`';
 
-const sendInfoEmbed = ({message, nessie, prefix}) => {
+const sendInfoEmbed = ({ message, nessie, prefix }) => {
   const embed = {
     title: 'Info',
     description: `Hi there! I'm Nessie and I provide information about map rotations in Apex Legends! In my final form, I want to be able to automatically notify you which maps you want to play are currently active!\n\nCurrent version: No notifications yet but you can manually check the current map rotation with my commands! I also display the current br pubs map as my activity status. And custom prefixes!\n\nMy current prefix  is ${grvAcnt}${prefix}${grvAcnt} | For a detailed list of my commands, type ${grvAcnt}${prefix}help${grvAcnt}`, //Removed users for now
     color: 3447003,
     thumbnail: {
-      url: 'https://cdn.discordapp.com/attachments/889134541615292459/896698383593517066/sir_nessie.png'  
+      url: 'https://cdn.discordapp.com/attachments/889134541615292459/896698383593517066/sir_nessie.png',
     },
     fields: [
       {
         name: 'Creator',
         value: 'Vexuas#8141',
-        inline: true
+        inline: true,
       },
       {
         name: 'Date Created',
         value: format(nessie.user.createdTimestamp, 'dd-MMM-yyyy'),
-        inline: true
+        inline: true,
       },
       {
         name: 'Version',
         value: version,
-        inline: true
+        inline: true,
       },
       {
         name: 'Library',
         value: 'discord.js',
-        inline: true
+        inline: true,
       },
       {
         name: 'Last Update',
         value: '30-Nov-2021',
-        inline: true
+        inline: true,
       },
       {
         name: 'Source Code',
         value: '[Github](https://github.com/vexuas/nessie)',
-        inline: true 
-      }
-    ]
+        inline: true,
+      },
+    ],
   };
   return message.channel.send({ embeds: [embed] });
 };
@@ -49,8 +50,11 @@ const sendInfoEmbed = ({message, nessie, prefix}) => {
 module.exports = {
   name: 'info',
   description: 'The story and information hub of nessie',
-  execute({message, nessie, nessiePrefix}) {
+  data: new SlashCommandBuilder()
+    .setName('info')
+    .setDescription('The story and information hub of nessie'),
+  execute({ message, nessie, nessiePrefix }) {
     const prefix = nessiePrefix;
-    sendInfoEmbed({message, nessie, prefix});
-  }
+    sendInfoEmbed({ message, nessie, prefix });
+  },
 };

--- a/helpers.js
+++ b/helpers.js
@@ -9,7 +9,7 @@ const { format } = require('date-fns');
  */
 const sendHealthLog = (data, channel, isAccurate) => {
   const utcStart = new Date(data.current.readableDate_start);
-  const sgtStart = new Date(utcStart.getTime() + 28800000)
+  const sgtStart = new Date(utcStart.getTime() + 28800000);
   const utcEnd = new Date(data.current.readableDate_end);
   const sgtEnd = new Date(utcEnd.getTime() + 28800000);
 
@@ -18,8 +18,7 @@ const sendHealthLog = (data, channel, isAccurate) => {
     description: 'Requested data from API',
     color: isAccurate ? 3066993 : 16776960,
     thumbnail: {
-      url:
-        'https://cdn.discordapp.com/attachments/889134541615292459/896698383593517066/sir_nessie.png'
+      url: 'https://cdn.discordapp.com/attachments/889134541615292459/896698383593517066/sir_nessie.png',
     },
     fields: [
       {
@@ -32,7 +31,7 @@ const sendHealthLog = (data, channel, isAccurate) => {
       },
       {
         name: 'Time left',
-        value: codeBlock(`${data.current.remainingTimer} | ${data.current.remainingSecs} secs`)
+        value: codeBlock(`${data.current.remainingTimer} | ${data.current.remainingSecs} secs`),
       },
       {
         name: 'Requested At',
@@ -40,31 +39,28 @@ const sendHealthLog = (data, channel, isAccurate) => {
       },
       {
         name: 'Accurate',
-        value: isAccurate ? 'Yes' : 'No'
-      }
-    ]
-  }
-  isAccurate ? channel.send({ embeds: [embed] }) : channel.send({ content: '<@183444648360935424>', embeds: [embed] });
-  
-}
+        value: isAccurate ? 'Yes' : 'No',
+      },
+    ],
+  };
+  isAccurate
+    ? channel.send({ embeds: [embed] })
+    : channel.send({ content: '<@183444648360935424>', embeds: [embed] });
+};
 //----------
 /**
  * Function to create a text into a discord code block
  * @param text - text to transform
  */
- const codeBlock = (text) => {
-  return "`" + text + "`";
-}
+const codeBlock = (text) => {
+  return '`' + text + '`';
+};
 //----------
 /**
  * Server Embed for when bot joining and leaving a server
  * Add iconURL logic to always return a png extension
  */
-const serverEmbed = async (
-  client,
-  guild,
-  status
-) => {
+const serverEmbed = async (client, guild, status) => {
   let embedTitle;
   let embedColor;
   const defaultIcon =
@@ -88,19 +84,22 @@ const serverEmbed = async (
       {
         name: 'Name',
         value: guild.name,
-        inline: true
+        inline: true,
       },
       {
         name: 'Owner',
-        value: status === 'join' ? await guild.members.fetch(guild.ownerId).then(guildMember => guildMember.user.tag) : '-',
-        inline: true
+        value:
+          status === 'join'
+            ? await guild.members.fetch(guild.ownerId).then((guildMember) => guildMember.user.tag)
+            : '-',
+        inline: true,
       },
       {
         name: 'Members',
         value: `${guild.memberCount}`,
-        inline: true
-      }
-    ]
+        inline: true,
+      },
+    ],
   };
   return [embed];
 };
@@ -116,28 +115,30 @@ const sendGuildUpdateNotification = async (client, guild, type) => {
   const embed = await serverEmbed(client, guild, type);
   const channelId = checkIfInDevelopment(client) ? '889212328539725824' : '896710863459844136';
   const channelToSend = client.channels.cache.get(channelId);
-  
+
   channelToSend.send({ embeds: embed });
-  if(!checkIfInDevelopment(client)){
+  if (!checkIfInDevelopment(client)) {
     channelToSend.setTopic(`Servers: ${client.guilds.cache.size}`);
   }
-}
+};
 //----------
 /**
  * As I use Lochness for development and testing of new features, it is a bit annoying to clear testing notifications from channels that Nessie stores data in
- * This comes from hardcoding channels to log data in the event handlers. 
+ * This comes from hardcoding channels to log data in the event handlers.
  * To avoid dirtying the data and cluttering production channels, this function determines if the client is Bisolen and is being used for development
+ * *** Updating to use Shizuka Test for all bot development needs ***
  * Lochness ID - 889208189017538572
  * Nessie ID - 889135055430111252
+ * Shizuka Test ID - 929421200797626388
  */
- const checkIfInDevelopment = (client) => {
-  return client.user.id === '889208189017538572'; //Lochnesss' id (Development Bot)
-}
+const checkIfInDevelopment = (client) => {
+  return client.user.id === '929421200797626388'; //Lochnesss' id (Development Bot)
+};
 //----------
 module.exports = {
   checkIfInDevelopment,
   sendGuildUpdateNotification,
   serverEmbed,
   codeBlock,
-  sendHealthLog
-}
+  sendHealthLog,
+};

--- a/nessie.js
+++ b/nessie.js
@@ -6,12 +6,30 @@
 const Discord = require('discord.js');
 const Mixpanel = require('mixpanel');
 const sqlite = require('sqlite3').verbose();
-const nessie = new Discord.Client({ intents: [Discord.Intents.FLAGS.GUILDS, Discord.Intents.FLAGS.GUILD_MESSAGES, Discord.Intents.FLAGS.GUILD_MESSAGE_TYPING]});
-const { token, lochnessMixpanel, nessieMixpanel, topggToken, guildIDs } = require('./config/nessie.json'); //Get config data from config folder
+const nessie = new Discord.Client({
+  intents: [
+    Discord.Intents.FLAGS.GUILDS,
+    Discord.Intents.FLAGS.GUILD_MESSAGES,
+    Discord.Intents.FLAGS.GUILD_MESSAGE_TYPING,
+  ],
+});
+const {
+  token,
+  lochnessMixpanel,
+  nessieMixpanel,
+  topggToken,
+  guildIDs,
+} = require('./config/nessie.json'); //Get config data from config folder
 const commands = require('./commands'); //Get list of commands
+const appCommands = require('./app_commands'); //Get list of application commands
 const { getBattleRoyalePubs } = require('./adapters');
 const { sendMixpanelEvent } = require('./analytics');
-const { sendHealthLog, sendGuildUpdateNotification, checkIfInDevelopment, codeBlock } = require('./helpers');
+const {
+  sendHealthLog,
+  sendGuildUpdateNotification,
+  checkIfInDevelopment,
+  codeBlock,
+} = require('./helpers');
 const { createGuildTable, insertNewGuild } = require('./database/guild-db');
 const { AutoPoster } = require('topgg-autoposter');
 const { REST } = require('@discordjs/rest');
@@ -27,7 +45,7 @@ const initialize = async () => {
   await nessie.login(token);
   mixpanel = Mixpanel.init(checkIfInDevelopment(nessie) ? lochnessMixpanel : nessieMixpanel); //Checks if client is initialising as the development bot
   !checkIfInDevelopment(nessie) && AutoPoster(topggToken, nessie); //Check if this is a one time thing per reboot or it actually auto posts when stats change
-}
+};
 initialize();
 //------
 /**
@@ -43,7 +61,7 @@ nessie.once('ready', async () => {
      * Initialise Database and its tables
      * Will create them if they don't exist
      * See relevant files under database/* for more information
-     */ 
+     */
     const nessieDatabase = createNessieDatabase();
     createGuildTable(nessieDatabase, nessie.guilds.cache, nessie);
     /**
@@ -54,10 +72,10 @@ nessie.once('ready', async () => {
     nessie.user.setActivity(brPubsData.current.map); //Set current br map as activity status
     sendHealthLog(brPubsData, logChannel, true); //For logging purpose
     setCurrentMapStatus(brPubsData, logChannel); //Calls status display function
-  } catch(e){
+  } catch (e) {
     console.log(e); //Add proper error handling
   }
-})
+});
 //------
 /**
  * Event handlers for when nessie is invited to a new server and when he is kicked. Will be opting out of guild update as I don't really need to do anything with that
@@ -70,14 +88,14 @@ nessie.on('guildCreate', (guild) => {
   try {
     insertNewGuild(guild);
     sendGuildUpdateNotification(nessie, guild, 'join');
-  } catch(e){
+  } catch (e) {
     console.log(e); // Add proper handling
   }
 });
 nessie.on('guildDelete', (guild) => {
   try {
     removeServerDataFromNessie(guild);
-  } catch(e){
+  } catch (e) {
     console.log(e); // Add proper handling
   }
 });
@@ -93,11 +111,11 @@ nessie.on('messageCreate', async (message) => {
    * This is primarily to know the current prefix of the guild; important when users are using a custom prefix
    */
   database.get(`SELECT * FROM Guild WHERE uuid = ${message.guildId}`, async (error, row) => {
-    if(error){
+    if (error) {
       console.log(error);
-    };
+    }
     const nessiePrefix = row.prefix;
-    
+
     //Refactor this into its own function and pass as a callback for better readability in the future
     try {
       /**
@@ -105,40 +123,52 @@ nessie.on('messageCreate', async (message) => {
        * If it does and if one of the mentions contains nessie's user, returns a message with the current prefix i.e @Nessie
        */
       message.mentions.users.forEach((user) => {
-        if(user === nessie.user){
-          return message.channel.send('My current prefix is ' + '`' + `${nessiePrefix}` + '`' + '\nTo set a new custom prefix, type ' + ` ${codeBlock(`${nessiePrefix}setprefix`)}`);
+        if (user === nessie.user) {
+          return message.channel.send(
+            'My current prefix is ' +
+              '`' +
+              `${nessiePrefix}` +
+              '`' +
+              '\nTo set a new custom prefix, type ' +
+              ` ${codeBlock(`${nessiePrefix}setprefix`)}`
+          );
         }
       });
       //Ignores messages without a prefix
-      if(message.content.startsWith(nessiePrefix)){
+      if (message.content.startsWith(nessiePrefix)) {
         const args = message.content.slice(nessiePrefix.length).split(' ', 1); //takes off prefix and returns first word as an array
         const command = args.shift().toLowerCase(); //gets command as a string from array
         const arguments = message.content.slice(nessiePrefix.length + command.length + 1); //gets arguments if there are any
 
         //Check if command exists in the command file
-        if(commands[command]){
+        if (commands[command]) {
           //If it does check if there are any arguments passed and if the command expects an argument
-          if(arguments.length > 0 && !commands[command].hasArguments){
+          if (arguments.length > 0 && !commands[command].hasArguments) {
             await message.channel.send("That command doesn't accept arguments （・□・；）"); //Sends error reply if it doesn't
           } else {
-            await commands[command].execute({message, arguments, nessie, nessiePrefix}); //Executes command
-            sendMixpanelEvent(message.author, message.channel, message.channel.guild, command, mixpanel, arguments); //Send tracking event to mixpanel
+            await commands[command].execute({ message, arguments, nessie, nessiePrefix }); //Executes command
+            sendMixpanelEvent(
+              message.author,
+              message.channel,
+              message.channel.guild,
+              command,
+              mixpanel,
+              arguments
+            ); //Send tracking event to mixpanel
           }
         }
       }
-    } catch(e){
+    } catch (e) {
       console.log(e);
     }
-  })
+  });
 });
 
 nessie.on('interactionCreate', async (interaction) => {
   if (!interaction.isCommand()) return;
-  const { commandName } = interaction
-  await commands[commandName].execute({interaction, nessie});
+  const { commandName } = interaction;
+  await appCommands[commandName].execute({ interaction, nessie });
 });
-
-
 
 //TODO: Maybe move these functions in their separate files at some point
 
@@ -146,7 +176,7 @@ nessie.on('interactionCreate', async (interaction) => {
 const createNessieDatabase = () => {
   let db = new sqlite.Database('./database/nessie.db', sqlite.OPEN_READWRITE | sqlite.OPEN_CREATE);
   return db;
-}
+};
 /**
  * In charge of correctly displaying current battle royale pubs rotation in nessie's activity status
  * As the maps have varying durations, needed to figure out a way to dynamically change the timeout after each call
@@ -156,28 +186,28 @@ const createNessieDatabase = () => {
 const setCurrentMapStatus = (data, channel) => {
   const fiveSecondsBuffer = 5000;
   let currentBrPubsData = data;
-  let currentTimer = data.current.remainingSecs*1000 + fiveSecondsBuffer;
+  let currentTimer = data.current.remainingSecs * 1000 + fiveSecondsBuffer;
   const intervalRequest = async () => {
     try {
       const updatedBrPubsData = await getBattleRoyalePubs();
-       /**
-     * Checks to see if the data taken from API is accurate
-     * Was brought to my attention that the status was displaying the wrong map at one point
-     * Not sure why this is happening so just adding a notification when this happens again
-     * Don't really want to add extra code for now, if it happens again then i'll fix it
-     */
-    const isAccurate = currentBrPubsData.next.code === updatedBrPubsData.current.code; 
-    currentBrPubsData = updatedBrPubsData;
-    currentTimer = updatedBrPubsData.current.remainingSecs*1000 + fiveSecondsBuffer;
-    nessie.user.setActivity(updatedBrPubsData.current.map);
-    sendHealthLog(updatedBrPubsData, channel, isAccurate);
-    setTimeout(intervalRequest, currentTimer);
-    } catch (e){
+      /**
+       * Checks to see if the data taken from API is accurate
+       * Was brought to my attention that the status was displaying the wrong map at one point
+       * Not sure why this is happening so just adding a notification when this happens again
+       * Don't really want to add extra code for now, if it happens again then i'll fix it
+       */
+      const isAccurate = currentBrPubsData.next.code === updatedBrPubsData.current.code;
+      currentBrPubsData = updatedBrPubsData;
+      currentTimer = updatedBrPubsData.current.remainingSecs * 1000 + fiveSecondsBuffer;
+      nessie.user.setActivity(updatedBrPubsData.current.map);
+      sendHealthLog(updatedBrPubsData, channel, isAccurate);
+      setTimeout(intervalRequest, currentTimer);
+    } catch (e) {
       channel.send('<@183444648360935424> WHOOPS SOMETHING WENT WRONG');
     }
-  }
+  };
   setTimeout(intervalRequest, currentTimer); //Start initial timer
-}
+};
 /**
  * Function to delete all the relevant data in our database when yagi is removed from a server
  * Removes:
@@ -186,19 +216,28 @@ const setCurrentMapStatus = (data, channel) => {
  * @param guild - guild in which nessie was kicked in
  */
 const removeServerDataFromNessie = (guild) => {
-  let database = new sqlite.Database('./database/nessie.db', sqlite.OPEN_READWRITE | sqlite.OPEN_CREATE);
+  let database = new sqlite.Database(
+    './database/nessie.db',
+    sqlite.OPEN_READWRITE | sqlite.OPEN_CREATE
+  );
   database.serialize(() => {
     database.run(`DELETE FROM Guild WHERE uuid = "${guild.id}"`);
     sendGuildUpdateNotification(nessie, guild, 'leave');
-  })
-}
+  });
+};
 const registerApplicationCommands = async () => {
-  const commandList = Object.keys(commands).map((key) => commands[key].data).filter(command => command).map(command => command.toJSON());
-  const rest = new REST({version: '9'}).setToken(token);
+  const appCommandList = Object.keys(appCommands)
+    .map((key) => appCommands[key].data)
+    .filter((command) => command)
+    .map((command) => command.toJSON());
+
+  const rest = new REST({ version: '9' }).setToken(token);
   try {
-    await rest.put(Routes.applicationGuildCommands("929421200797626388", guildIDs), { body: commandList });
+    await rest.put(Routes.applicationGuildCommands('929421200797626388', guildIDs), {
+      body: appCommandList,
+    });
     console.log('Successfully registered application commands');
-  } catch(e){
+  } catch (e) {
     console.log(e);
   }
-}
+};

--- a/nessie.js
+++ b/nessie.js
@@ -130,7 +130,16 @@ nessie.on('messageCreate', async (message) => {
       console.log(e);
     }
   })
-})
+});
+
+nessie.on('interactionCreate', async (interaction) => {
+  if (!interaction.isCommand()) return;
+  const { commandName } = interaction
+  await commands[commandName].execute({interaction, nessie});
+});
+
+
+
 //TODO: Maybe move these functions in their separate files at some point
 
 //Creates Nessie Database under database folder

--- a/package.json
+++ b/package.json
@@ -7,9 +7,12 @@
   },
   "main": "index.js",
   "dependencies": {
+    "@discordjs/builders": "^0.11.0",
+    "@discordjs/rest": "^0.2.0-canary.0",
     "@top-gg/sdk": "^3.1.2",
     "axios": "^0.22.0",
     "date-fns": "^2.24.0",
+    "discord-api-types": "^0.26.1",
     "discord.js": "^13.1.0",
     "mixpanel": "^0.13.0",
     "mocha": "^9.1.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -113,6 +113,17 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
+"@discordjs/builders@^0.11.0":
+  version "0.11.0"
+  resolved "https://registry.yarnpkg.com/@discordjs/builders/-/builders-0.11.0.tgz#4102abe3e0cd093501f3f71931df43eb92f5b0cc"
+  integrity sha512-ZTB8yJdJKrKlq44dpWkNUrAtEJEq0gqpb7ASdv4vmq6/mZal5kOv312hQ56I/vxwMre+VIkoHquNUAfnTbiYtg==
+  dependencies:
+    "@sindresorhus/is" "^4.2.0"
+    discord-api-types "^0.26.0"
+    ts-mixer "^6.0.0"
+    tslib "^2.3.1"
+    zod "^3.11.6"
+
 "@discordjs/builders@^0.5.0":
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/@discordjs/builders/-/builders-0.5.0.tgz#646cbea9cc67f68639e6fb70ed1278b26dacdb14"
@@ -129,6 +140,11 @@
   resolved "https://registry.yarnpkg.com/@discordjs/collection/-/collection-0.2.1.tgz#ea4bc7b41b7b7b6daa82e439141222ec95c469b2"
   integrity sha512-vhxqzzM8gkomw0TYRF3tgx7SwElzUlXT/Aa41O7mOcyN6wIJfj5JmDWaO5XGKsGSsNx7F3i5oIlrucCCWV1Nog==
 
+"@discordjs/collection@^0.3.2":
+  version "0.3.2"
+  resolved "https://registry.yarnpkg.com/@discordjs/collection/-/collection-0.3.2.tgz#3c271dd8a93dad89b186d330e24dbceaab58424a"
+  integrity sha512-dMjLl60b2DMqObbH1MQZKePgWhsNe49XkKBZ0W5Acl5uVV43SN414i2QfZwRI7dXAqIn8pEWD2+XXQFn9KWxqg==
+
 "@discordjs/form-data@^3.0.1":
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/@discordjs/form-data/-/form-data-3.0.1.tgz#5c9e6be992e2e57d0dfa0e39979a850225fb4697"
@@ -137,6 +153,19 @@
     asynckit "^0.4.0"
     combined-stream "^1.0.8"
     mime-types "^2.1.12"
+
+"@discordjs/rest@^0.2.0-canary.0":
+  version "0.2.0-canary.0"
+  resolved "https://registry.yarnpkg.com/@discordjs/rest/-/rest-0.2.0-canary.0.tgz#5ac955614453d02808c4df35a5cfb28d146566b2"
+  integrity sha512-jOxz1aqTEzn9N0qaJcZbHz6FbA0oq+vjpXUKkQzgfMihO6gC+kLlpRnFqG25T/aPYbjaR1UM/lGhrGBB1dutqg==
+  dependencies:
+    "@discordjs/collection" "^0.3.2"
+    "@sapphire/async-queue" "^1.1.9"
+    "@sapphire/snowflake" "^3.0.0"
+    discord-api-types "^0.25.2"
+    form-data "^4.0.0"
+    node-fetch "^2.6.5"
+    tslib "^2.3.1"
 
 "@endemolshinegroup/cosmiconfig-typescript-loader@^3.0.2":
   version "3.0.2"
@@ -304,6 +333,16 @@
   resolved "https://registry.yarnpkg.com/@sapphire/async-queue/-/async-queue-1.1.4.tgz#ae431310917a8880961cebe8e59df6ffa40f2957"
   integrity sha512-fFrlF/uWpGOX5djw5Mu2Hnnrunao75WGey0sP0J3jnhmrJ5TAPzHYOmytD5iN/+pMxS+f+u/gezqHa9tPhRHEA==
 
+"@sapphire/async-queue@^1.1.9":
+  version "1.1.9"
+  resolved "https://registry.yarnpkg.com/@sapphire/async-queue/-/async-queue-1.1.9.tgz#ce69611c8753c4affd905a7ef43061c7eb95c01b"
+  integrity sha512-CbXaGwwlEMq+l1TRu01FJCvySJ1CEFKFclHT48nIfNeZXaAAmmwwy7scUKmYHPUa3GhoMp6Qr1B3eAJux6XgOQ==
+
+"@sapphire/snowflake@^3.0.0":
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/@sapphire/snowflake/-/snowflake-3.0.1.tgz#400602940d1c5dc12f71e104972a1ace7c6c6b74"
+  integrity sha512-v+wCC2q9DK3OhG7Vcdt/8A/INAYiyhlMD5snakmXGBN1usLBwSGJVJBjDHv4VGI5C9YYl4UdW5Ovr3arvYsJXQ==
+
 "@sindresorhus/is@^0.14.0":
   version "0.14.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-0.14.0.tgz#9fb3a3cf3132328151f353de4632e01e52102bea"
@@ -313,6 +352,11 @@
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.2.0.tgz#667bfc6186ae7c9e0b45a08960c551437176e1ca"
   integrity sha512-VkE3KLBmJwcCaVARtQpfuKcKv8gcBmUubrfHGF84dXuuW6jgsRYxPtzcIhPyK9WAPpRt2/xY6zkD9MnRaJzSyw==
+
+"@sindresorhus/is@^4.2.0":
+  version "4.3.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.3.0.tgz#344fd9bf808a84567ba563d00cc54b2f428dbab1"
+  integrity sha512-wwOvh0eO3PiTEivGJWiZ+b946SlMSb4pe+y+Ur/4S87cwo09pYi+FWHHnbrM3W9W7cBYKDqQXcrFYjYUCOJUEQ==
 
 "@szmarczak/http-timer@^1.1.2":
   version "1.1.2"
@@ -983,6 +1027,16 @@ discord-api-types@^0.22.0:
   resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.22.0.tgz#34dc57fe8e016e5eaac5e393646cd42a7e1ccc2a"
   integrity sha512-l8yD/2zRbZItUQpy7ZxBJwaLX/Bs2TGaCthRppk8Sw24LOIWg12t9JEreezPoYD0SQcC2htNNo27kYEpYW/Srg==
 
+discord-api-types@^0.25.2:
+  version "0.25.2"
+  resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.25.2.tgz#e50ed152e6d48fe7963f5de1002ca6f2df57c61b"
+  integrity sha512-O243LXxb5gLLxubu5zgoppYQuolapGVWPw3ll0acN0+O8TnPUE2kFp9Bt3sTRYodw8xFIknOVxjSeyWYBpVcEQ==
+
+discord-api-types@^0.26.0, discord-api-types@^0.26.1:
+  version "0.26.1"
+  resolved "https://registry.yarnpkg.com/discord-api-types/-/discord-api-types-0.26.1.tgz#726f766ddc37d60da95740991d22cb6ef2ed787b"
+  integrity sha512-T5PdMQ+Y1MEECYMV5wmyi9VEYPagEDEi4S0amgsszpWY0VB9JJ/hEvM6BgLhbdnKky4gfmZEXtEEtojN8ZKJQQ==
+
 discord.js@^13.1.0:
   version "13.1.0"
   resolved "https://registry.yarnpkg.com/discord.js/-/discord.js-13.1.0.tgz#99f6a2a8be88d31906ff0148e9b1cb603ebb2e2e"
@@ -1210,6 +1264,15 @@ forever-agent@~0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
   integrity sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
+form-data@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/form-data/-/form-data-4.0.0.tgz#93919daeaf361ee529584b9b31664dc12c9fa452"
+  integrity sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==
+  dependencies:
+    asynckit "^0.4.0"
+    combined-stream "^1.0.8"
+    mime-types "^2.1.12"
 
 form-data@~2.3.2:
   version "2.3.3"
@@ -2016,6 +2079,13 @@ node-fetch@^2.6.1:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.2.tgz#986996818b73785e47b1965cc34eb093a1d464d0"
   integrity sha512-aLoxToI6RfZ+0NOjmWAgn9+LEd30YCkJKFSyWacNZdEKTit/ZMcKjGkTRo8uWEsnIb/hfKecNPEbln02PdWbcA==
+
+node-fetch@^2.6.5:
+  version "2.6.7"
+  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-2.6.7.tgz#24de9fba827e3b4ae44dc8b20256a379160052ad"
+  integrity sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==
+  dependencies:
+    whatwg-url "^5.0.0"
 
 node-gyp@3.x:
   version "3.8.0"
@@ -2938,6 +3008,11 @@ tough-cookie@~2.5.0:
     psl "^1.1.28"
     punycode "^2.1.1"
 
+tr46@~0.0.3:
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
+  integrity sha1-gYT9NH2snNwYWZLzpmIuFLnZq2o=
+
 ts-mixer@^6.0.0:
   version "6.0.0"
   resolved "https://registry.yarnpkg.com/ts-mixer/-/ts-mixer-6.0.0.tgz#4e631d3a36e3fa9521b973b132e8353bc7267f9f"
@@ -2970,7 +3045,7 @@ tslib@^1.14.1:
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
 
-tslib@^2, tslib@^2.3.0:
+tslib@^2, tslib@^2.3.0, tslib@^2.3.1:
   version "2.3.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.3.1.tgz#e8a335add5ceae51aa261d32a490158ef042ef01"
   integrity sha512-77EbyPPpMz+FRFRuAFlWMtmgUWGe9UOG2Z25NqCwiIjRhOf5iKGuzSe5P2w1laq+FkRy4p+PCuVkJSGkzTEKVw==
@@ -3122,6 +3197,19 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
+webidl-conversions@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/webidl-conversions/-/webidl-conversions-3.0.1.tgz#24534275e2a7bc6be7bc86611cc16ae0a5654871"
+  integrity sha1-JFNCdeKnvGvnvIZhHMFq4KVlSHE=
+
+whatwg-url@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/whatwg-url/-/whatwg-url-5.0.0.tgz#966454e8765462e37644d3626f6742ce8b70965d"
+  integrity sha1-lmRU6HZUYuN2RNNib2dCzotwll0=
+  dependencies:
+    tr46 "~0.0.3"
+    webidl-conversions "^3.0.0"
+
 which@1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/which/-/which-1.3.1.tgz#a45043d54f5805316da8d62f9f50918d3da70b0a"
@@ -3266,3 +3354,8 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
+
+zod@^3.11.6:
+  version "3.11.6"
+  resolved "https://registry.yarnpkg.com/zod/-/zod-3.11.6.tgz#e43a5e0c213ae2e02aefe7cb2b1a6fa3d7f1f483"
+  integrity sha512-daZ80A81I3/9lIydI44motWe6n59kRBfNzTuS2bfzVh1nAXi667TOTWWtatxyG+fwgNUiagSj/CWZwRRbevJIg==


### PR DESCRIPTION
#### Context
With nessie in the process of getting verified and the deadline for priviliged message intent is looming, I've decided to prioritise migrating nessie and yagi to application commands in the next 2 weeks. Nessie should be straightforward enough, Yagi on the other hand I'm a bit concerned. Granted looking at this codebase hurts me and I should really put aside time in cleaning this mess up, Nessie is still far better than the clownfest I made in Yagi.

In terms of implementing application commands, it doesn't look too hard. Going with the approach of duplicating commands and supporting both for now. I'll slowly deprecate prefix commands a week before the deadline comes

oh and I changed info to about since I'm adopting that methodology from here on out as well as switching to use Shizuka Test for all development needs. Bisolen served me well but I realised scalability-wise it's better to have one main testing bot for all my projects
![image](https://user-images.githubusercontent.com/42207245/151190163-87d7eacd-3c85-4204-a3ae-6291f52a8fcc.png)
![image](https://user-images.githubusercontent.com/42207245/151190193-3b20ace1-3782-40a9-aba5-815afe49a38b.png)

#### Change
- Install application commands dependencies
- Change development bot to use shizuka instead of bisolen
- Create app_commands 
- Add registration and initialisation of app commands
- Change info command to about

#### Release Notes
Investigate application commands