### PR TITLE
Migrate to application commands

### DIFF
--- a/app_commands.js
+++ b/app_commands.js
@@ -8,4 +8,5 @@
 module.exports = {
   //Hub
   about: require('./app_commands/hub/about'),
+  help: require('./app_commands/hub/help'),
 };

--- a/app_commands.js
+++ b/app_commands.js
@@ -9,4 +9,5 @@ module.exports = {
   //Hub
   about: require('./app_commands/hub/about'),
   help: require('./app_commands/hub/help'),
+  invite: require('./app_commands/hub/invite'),
 };

--- a/app_commands.js
+++ b/app_commands.js
@@ -10,4 +10,6 @@ module.exports = {
   about: require('./app_commands/hub/about'),
   help: require('./app_commands/hub/help'),
   invite: require('./app_commands/hub/invite'),
+  // Maps
+  br: require('./app_commands/maps/battle-royale'),
 };

--- a/app_commands.js
+++ b/app_commands.js
@@ -12,4 +12,5 @@ module.exports = {
   invite: require('./app_commands/hub/invite'),
   // Maps
   br: require('./app_commands/maps/battle-royale'),
+  arenas: require('./app_commands/maps/arenas'),
 };

--- a/app_commands/hub/about.js
+++ b/app_commands/hub/about.js
@@ -49,7 +49,7 @@ const sendAboutEmbed = ({ nessie, interaction }) => {
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('about')
-    .setDescription('The story and information hub of nessie'),
+    .setDescription('Displays information about Nessie'),
   execute({ nessie, interaction }) {
     sendAboutEmbed({ nessie, interaction });
   },

--- a/app_commands/hub/about.js
+++ b/app_commands/hub/about.js
@@ -2,7 +2,7 @@ const { SlashCommandBuilder } = require('@discordjs/builders');
 const { format } = require('date-fns');
 const { version } = require('../../package.json');
 
-const sendAboutEmbed = ({ nessie, interaction }) => {
+const sendAboutEmbed = async ({ nessie, interaction }) => {
   const embed = {
     title: 'About',
     description: `Hi there! I'm Nessie and I provide information about map rotations in Apex Legends! In my final form, I want to be able to automatically notify you which maps you want to play are currently active!\n\nCurrent version: No notifications yet but you can manually check the current map rotation with my commands! I also display the current br pubs map as my activity status\n\nFor a detailed list of my commands, use the help command!`,
@@ -43,14 +43,14 @@ const sendAboutEmbed = ({ nessie, interaction }) => {
       },
     ],
   };
-  return interaction.reply({ embeds: [embed] });
+  return await interaction.reply({ embeds: [embed] });
 };
 
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('about')
     .setDescription('Displays information about Nessie'),
-  execute({ nessie, interaction }) {
-    sendAboutEmbed({ nessie, interaction });
+  async execute({ nessie, interaction }) {
+    return await sendAboutEmbed({ nessie, interaction });
   },
 };

--- a/app_commands/hub/help.js
+++ b/app_commands/hub/help.js
@@ -1,0 +1,22 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+
+module.exports = {
+  data: new SlashCommandBuilder().setName('help').setDescription('Directory hub of commands'),
+  execute({ interaction }) {
+    const embed = {
+      color: 3447003,
+      description: 'Below you can see all the commands that I know!',
+      fields: [
+        {
+          name: 'Maps',
+          value: '`br`, `arenas`',
+        },
+        {
+          name: 'Information',
+          value: '`about`, `help`, `invite`',
+        },
+      ],
+    };
+    return interaction.reply({ embeds: [embed] });
+  },
+};

--- a/app_commands/hub/help.js
+++ b/app_commands/hub/help.js
@@ -2,7 +2,7 @@ const { SlashCommandBuilder } = require('@discordjs/builders');
 
 module.exports = {
   data: new SlashCommandBuilder().setName('help').setDescription('Directory hub of commands'),
-  execute({ interaction }) {
+  async execute({ interaction }) {
     const embed = {
       color: 3447003,
       description: 'Below you can see all the commands that I know!',
@@ -17,6 +17,6 @@ module.exports = {
         },
       ],
     };
-    return interaction.reply({ embeds: [embed] });
+    return await interaction.reply({ embeds: [embed] });
   },
 };

--- a/app_commands/hub/invite.js
+++ b/app_commands/hub/invite.js
@@ -4,11 +4,11 @@ module.exports = {
   data: new SlashCommandBuilder()
     .setName('invite')
     .setDescription('Generates an invite link for Nessie'),
-  execute({ interaction }) {
+  async execute({ interaction }) {
     const embed = {
       description: `<@${interaction.user.id}> | [Add me to your servers! (◕ᴗ◕✿)](https://tinyurl.com/nessie-invite-v021)`,
       color: 3447003,
     };
-    interaction.reply({ embeds: [embed] });
+    return await interaction.reply({ embeds: [embed] });
   },
 };

--- a/app_commands/hub/invite.js
+++ b/app_commands/hub/invite.js
@@ -1,0 +1,14 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('invite')
+    .setDescription('Generates an invite link for Nessie'),
+  execute({ interaction }) {
+    const embed = {
+      description: `<@${interaction.user.id}> | [Add me to your servers! (◕ᴗ◕✿)](https://tinyurl.com/nessie-invite-v021)`,
+      color: 3447003,
+    };
+    interaction.reply({ embeds: [embed] });
+  },
+};

--- a/app_commands/maps/arenas.js
+++ b/app_commands/maps/arenas.js
@@ -1,0 +1,118 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const { getArenasPubs, getArenasRanked } = require('../../adapters');
+
+/**
+ * Display the time left in a more aethestically manner
+ * API returns in the form hr:min:sec (01:02:03)
+ * Function returns hr hrs min mins sec secs (01 hrs 02 mins 03 secs);
+ * Might want to think of using the number of remaining seconds instead of splitting the timer string in the future
+ */
+const getCountdown = (timer) => {
+  const countdown = timer.split(':');
+  const isOverAnHour = countdown[0] && countdown[0] !== '00';
+  return `${isOverAnHour ? `${countdown[0]} hr ` : ''}${countdown[1]} mins ${countdown[2]} secs`;
+};
+/**
+ * Embed design for Arenas Pubs
+ * Added a hack to display the time for next map regardless of timezone
+ * As discord embed has a timestamp property, I added the remianing milliseconds to the current date
+ * Make reusable?
+ */
+const generatePubsEmbed = (data) => {
+  const embedData = {
+    title: 'Arenas | Pubs',
+    color: 3066993,
+    image: {
+      url: data.current.asset, //Using the scuffed saturated images as it'll be a chore adding custom images for each arenas map(some use areas of br maps)
+    },
+    timestamp: Date.now() + data.current.remainingSecs * 1000,
+    footer: {
+      text: `Next Map: ${data.next.map}`,
+    },
+    fields: [
+      {
+        name: 'Current map',
+        value: '```fix\n\n' + data.current.map + '```',
+        inline: true,
+      },
+      {
+        name: 'Time left',
+        value: '```xl\n\n' + getCountdown(data.current.remainingTimer) + '```',
+        inline: true,
+      },
+    ],
+  };
+  return [embedData];
+};
+/**
+ * Embed design for Arenas Ranked
+ * Slighly different from BR ranked and similar to its Pubs counterpart
+ * Might want to make all of these reusable, a lot of repeats
+ */
+const generateRankedEmbed = (data) => {
+  const embedData = {
+    title: 'Arenas | Ranked',
+    color: 7419530,
+    image: {
+      url: data.current.asset, //Using the scuffed saturated images as it'll be a chore adding custom images for each arenas map(some use areas of br maps)
+    },
+    timestamp: Date.now() + data.current.remainingSecs * 1000,
+    footer: {
+      text: `Next Map: ${data.next.map}`,
+    },
+    fields: [
+      {
+        name: 'Current map',
+        value: '```fix\n\n' + data.current.map + '```',
+        inline: true,
+      },
+      {
+        name: 'Time left',
+        value: '```xl\n\n' + getCountdown(data.current.remainingTimer) + '```',
+        inline: true,
+      },
+    ],
+  };
+  return [embedData];
+};
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('arenas')
+    .setDescription('Shows current map rotation for arenas')
+    .addStringOption((option) =>
+      option
+        .setName('mode')
+        .setDescription('Game Mode')
+        .setRequired(true)
+        .addChoice('pubs', 'arenas_pubs')
+        .addChoice('ranked', 'arenas_ranked')
+    ),
+  /**
+   * Send correct game mode map information based on user option
+   * We want to defer interaction as discord invalidates token after 3 seconds and we're retrieving our data through the api
+   * This is pretty cool as discord will treat it as a normal response and we can do whatever we want with it within 15 minutes
+   * which is editing the reply with the relevant information after the promise resolves
+   **/
+  async execute({ interaction }) {
+    let data;
+    let embed;
+    try {
+      await interaction.deferReply();
+      const optionMode = interaction.options.getString('mode');
+      switch (optionMode) {
+        case 'arenas_pubs':
+          data = await getArenasPubs();
+          embed = generatePubsEmbed(data);
+          break;
+        case 'arenas_ranked':
+          data = await getArenasRanked();
+          embed = generateRankedEmbed(data);
+          break;
+      }
+      return await interaction.editReply({ embeds: embed });
+    } catch (e) {
+      console.log(e);
+    }
+  },
+};

--- a/app_commands/maps/battle-royale.js
+++ b/app_commands/maps/battle-royale.js
@@ -110,16 +110,16 @@ module.exports = {
         .addChoice('pubs', 'br_pubs')
         .addChoice('ranked', 'br_ranked')
     ),
+  /**
+   * Send correct game mode map information based on user option
+   * We want to defer interaction as discord invalidates token after 3 seconds and we're retrieving our data through the api
+   * This is pretty cool as discord will treat it as a normal response and we can do whatever we want with it within 15 minutes
+   * which is editing the reply with the relevant information after the promise resolves
+   **/
   async execute({ interaction }) {
     let data;
     let embed;
     try {
-      /**
-       * Send correct game mode map information based on user option
-       * We want to defer interaction as discord invalidates token after 3 seconds and we're retrieving our data through the api
-       * This is pretty cool as discord will treat it as a normal response and we can do whatever we want with it within 15 minutes
-       * which is editing the reply with the relevant information after the promise resolves
-       **/
       await interaction.deferReply();
       const optionMode = interaction.options.getString('mode');
       switch (optionMode) {
@@ -133,6 +133,8 @@ module.exports = {
           break;
       }
       return await interaction.editReply({ embeds: embed });
-    } catch (e) {}
+    } catch (e) {
+      console.log(e); //Add proper error handling someday
+    }
   },
 };

--- a/app_commands/maps/battle-royale.js
+++ b/app_commands/maps/battle-royale.js
@@ -1,4 +1,102 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
+const { getBattleRoyalePubs, getBattleRoyaleRanked } = require('../../adapters');
+
+/**
+ * Gets url link image for each br map
+ * Using custom images as the image links sent by API are desaturated for some reason
+ * Currently hosted scuffly in discord itself; might want to think of hosting it in cloudfront in the future
+ */
+const getMapUrl = (map) => {
+  switch (map) {
+    case 'kings_canyon_rotation':
+      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544176815099954/kings_canyon.jpg';
+    case 'Kings Canyon':
+      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544176815099954/kings_canyon.jpg';
+    case 'worlds_edge_rotation':
+      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544195488129034/worlds_edge.jpg';
+    case `World's Edge`:
+      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544195488129034/worlds_edge.jpg';
+    case 'olympus_rotation':
+      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544165163323402/olympus_nessie.jpg';
+    case 'Olympus':
+      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544165163323402/olympus_nessie.jpg';
+    case 'Storm Point':
+      return 'https://cdn.discordapp.com/attachments/896544134813319168/911631835300237332/storm_point_nessie.jpg';
+    case 'storm_point_rotation':
+      return 'https://cdn.discordapp.com/attachments/896544134813319168/911631835300237332/storm_point_nessie.jpg';
+    default:
+      return '';
+  }
+};
+/**
+ * Display the time left in a more aethestically manner
+ * API returns in the form hr:min:sec (01:02:03)
+ * Function returns hr hrs min mins sec secs (01 hrs 02 mins 03 secs);
+ * Might want to think of using the number of remaining seconds instead of splitting the timer string in the future
+ */
+const getCountdown = (timer) => {
+  const countdown = timer.split(':');
+  const isOverAnHour = countdown[0] && countdown[0] !== '00';
+  return `${isOverAnHour ? `${countdown[0]} hr ` : ''}${countdown[1]} mins ${countdown[2]} secs`;
+};
+/**
+ * Embed design for BR Pubs
+ * Added a hack to display the time for next map regardless of timezone
+ * As discord embed has a timestamp propery, I added the remianing milliseconds to the current date
+ * Make reusable?
+ */
+const generatePubsEmbed = (data) => {
+  const embedData = {
+    title: 'Battle Royale | Pubs',
+    color: 3066993,
+    image: {
+      url: getMapUrl(data.current.code),
+    },
+    timestamp: Date.now() + data.current.remainingSecs * 1000,
+    footer: {
+      text: `Next Map: ${data.next.map}`,
+    },
+    fields: [
+      {
+        name: 'Current map',
+        value: '```fix\n\n' + data.current.map + '```',
+        inline: true,
+      },
+      {
+        name: 'Time left',
+        value: '```xl\n\n' + getCountdown(data.current.remainingTimer) + '```',
+        inline: true,
+      },
+    ],
+  };
+  return [embedData];
+};
+/**
+ * Embed design for BR Ranked
+ * Fairly simple, don't need any fancy timers and footers
+ */
+const generateRankedEmbed = (data) => {
+  const embedData = {
+    title: 'Battle Royale | Ranked',
+    color: 7419530,
+    image: {
+      url: getMapUrl(data.current.map),
+    },
+    fields: [
+      {
+        name: 'Current map',
+        value: '```fix\n\n' + data.current.map + '```',
+        inline: true,
+      },
+      {
+        name: 'Time left',
+        value: '```xl\n\nRunning till end of split```',
+        inline: true,
+      },
+    ],
+  };
+  return [embedData];
+};
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -13,14 +111,28 @@ module.exports = {
         .addChoice('ranked', 'br_ranked')
     ),
   async execute({ interaction }) {
+    let data;
+    let embed;
     try {
+      /**
+       * Send correct game mode map information based on user option
+       * We want to defer interaction as discord invalidates token after 3 seconds and we're retrieving our data through the api
+       * This is pretty cool as discord will treat it as a normal response and we can do whatever we want with it within 15 minutes
+       * which is editing the reply with the relevant information after the promise resolves
+       **/
+      await interaction.deferReply();
       const optionMode = interaction.options.getString('mode');
       switch (optionMode) {
         case 'br_pubs':
-          return await interaction.reply('br pubs command');
+          data = await getBattleRoyalePubs();
+          embed = generatePubsEmbed(data);
+          break;
         case 'br_ranked':
-          return await interaction.reply('br ranked command');
+          data = await getBattleRoyaleRanked();
+          embed = generateRankedEmbed(data);
+          break;
       }
+      return await interaction.editReply({ embeds: embed });
     } catch (e) {}
   },
 };

--- a/app_commands/maps/battle-royale.js
+++ b/app_commands/maps/battle-royale.js
@@ -1,0 +1,26 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('br')
+    .setDescription('Shows current map rotation for battle royale')
+    .addStringOption((option) =>
+      option
+        .setName('mode')
+        .setDescription('Game Mode')
+        .setRequired(true)
+        .addChoice('pubs', 'br_pubs')
+        .addChoice('ranked', 'br_ranked')
+    ),
+  async execute({ interaction }) {
+    try {
+      const optionMode = interaction.options.getString('mode');
+      switch (optionMode) {
+        case 'br_pubs':
+          return await interaction.reply('br pubs command');
+        case 'br_ranked':
+          return await interaction.reply('br ranked command');
+      }
+    } catch (e) {}
+  },
+};

--- a/commands/hub/help.js
+++ b/commands/hub/help.js
@@ -1,6 +1,6 @@
 module.exports = {
   name: 'help',
-  description: 'directory hub of commands',
+  description: 'directory of commands',
   hasArguments: false,
   execute({ message, nessiePrefix }) {
     const embed = {

--- a/nessie.js
+++ b/nessie.js
@@ -167,7 +167,7 @@ nessie.on('messageCreate', async (message) => {
 nessie.on('interactionCreate', async (interaction) => {
   if (!interaction.isCommand()) return;
   const { commandName } = interaction;
-  await appCommands[commandName].execute({ interaction, nessie });
+  return await appCommands[commandName].execute({ interaction, nessie });
 });
 
 //TODO: Maybe move these functions in their separate files at some point


### PR DESCRIPTION
#### Context
Migrate app to use application commands. Well semi-migrate since I'm going to support prefix commands until april. Actually very straightforward to do this. Thought it'd be as frustrating as it was with Pycord but discord.js's great guides/documentation helped a ton. Maybe I'm just biased cuz I'm more familiar with js

Didn't bother to create application commands for prefix and setprefix as they'll be deprecated in the future anyway
![image](https://user-images.githubusercontent.com/42207245/151400765-68b52814-7372-4d61-bcfc-f8e350919540.png)
![image](https://user-images.githubusercontent.com/42207245/151400676-2e138269-5de3-4ede-afdc-d297fbc26b95.png)
![image](https://user-images.githubusercontent.com/42207245/151400811-259e0c75-bbf1-47a3-a488-b8f56a19334b.png)
![image](https://user-images.githubusercontent.com/42207245/151400884-5eab203b-0c18-4cb1-a2fe-a87affa2259f.png)

#### Change
- Create application commands for each prefix command

#### Release Notes
Migrate to use application commands