### PR TITLE
Commands Usage Migration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@ node_modules
 #database
 /database/nessie.db
 /database/nessie.db-journal
+/database/nessie_backup.db
 
 # system files
 .DS_Store

--- a/database/guild-db.js
+++ b/database/guild-db.js
@@ -53,13 +53,14 @@ exports.createGuildTable = (database, guilds, client) => {
 exports.insertNewGuild = (guild) => {
   let database = new sqlite.Database('./database/nessie.db', sqlite.OPEN_READWRITE);
   database.run(
-    'INSERT INTO Guild (uuid, name, member_count, owner_id, prefix) VALUES ($uuid, $name, $member_count, $owner_id, $prefix)',
+    'INSERT INTO Guild (uuid, name, member_count, owner_id, prefix, use_prefix) VALUES ($uuid, $name, $member_count, $owner_id, $prefix, $use_prefix)',
     {
       $uuid: guild.id,
       $name: guild.name,
       $member_count: guild.memberCount,
       $owner_id: guild.ownerId,
       $prefix: defaultPrefix,
+      $use_prefix: false,
     },
     (err) => {
       if (err) {

--- a/database/guild-db.js
+++ b/database/guild-db.js
@@ -9,52 +9,81 @@ const { defaultPrefix } = require('../config/nessie.json');
  * @param guilds - guilds that yagi is in
  * @param client - yagi client
  */
- exports.createGuildTable = (database, guilds, client) => {
+exports.createGuildTable = (database, guilds, client) => {
   //Wrapped in a serialize to ensure that each method is called in order which its initialised
-  database.serialize(() => { 
+  database.serialize(() => {
     //Creates Guild Table with the relevant columns if it does not exist
-    database.run('CREATE TABLE IF NOT EXISTS Guild(uuid TEXT NOT NULL PRIMARY KEY, name TEXT NOT NULL, member_count INTEGER NOT NULL, owner_id TEXT NOT NULL, prefix TEXT NOT NULL)');
-    
+    database.run(
+      'CREATE TABLE IF NOT EXISTS Guild(uuid TEXT NOT NULL PRIMARY KEY, name TEXT NOT NULL, member_count INTEGER NOT NULL, owner_id TEXT NOT NULL, prefix TEXT NOT NULL)'
+    );
+
     //Populate Guild Table with existing guilds
-    guilds.forEach(guild => {
+    guilds.forEach((guild) => {
       database.get(`SELECT * FROM Guild WHERE uuid = ${guild.id}`, (error, row) => {
-        if(error){
+        if (error) {
           console.log(error);
         }
         //Only runs statement and insert into guild table if the guild hasn't been created yet
-        if(!row){
-          database.run('INSERT INTO Guild (uuid, name, member_count, owner_id, prefix) VALUES ($uuid, $name, $member_count, $owner_id, $prefix)', {
-            $uuid: guild.id,
-            $name: guild.name,
-            $member_count: guild.memberCount,
-            $owner_id: guild.ownerId,
-            $prefix: defaultPrefix
-          }, err => {
-            if(err){
-              console.log(err);
+        if (!row) {
+          database.run(
+            'INSERT INTO Guild (uuid, name, member_count, owner_id, prefix) VALUES ($uuid, $name, $member_count, $owner_id, $prefix)',
+            {
+              $uuid: guild.id,
+              $name: guild.name,
+              $member_count: guild.memberCount,
+              $owner_id: guild.ownerId,
+              $prefix: defaultPrefix,
+            },
+            (err) => {
+              if (err) {
+                console.log(err);
+              }
+              sendGuildUpdateNotification(client, guild, 'join');
             }
-            sendGuildUpdateNotification(client, guild, 'join');
-          })
+          );
         }
-      })
-    })
-  })
-}
+      });
+    });
+  });
+};
 /**
  * Adds new guild to Guild table
  * @param guild - guild that yagi is newly invited in
  */
- exports.insertNewGuild = (guild) => {
+exports.insertNewGuild = (guild) => {
   let database = new sqlite.Database('./database/nessie.db', sqlite.OPEN_READWRITE);
-  database.run('INSERT INTO Guild (uuid, name, member_count, owner_id, prefix) VALUES ($uuid, $name, $member_count, $owner_id, $prefix)', {
-    $uuid: guild.id,
-    $name: guild.name,
-    $member_count: guild.memberCount,
-    $owner_id: guild.ownerId,
-    $prefix: defaultPrefix
-  }, err => {
-    if(err){
-      console.log(err);
+  database.run(
+    'INSERT INTO Guild (uuid, name, member_count, owner_id, prefix) VALUES ($uuid, $name, $member_count, $owner_id, $prefix)',
+    {
+      $uuid: guild.id,
+      $name: guild.name,
+      $member_count: guild.memberCount,
+      $owner_id: guild.ownerId,
+      $prefix: defaultPrefix,
+    },
+    (err) => {
+      if (err) {
+        console.log(err);
+      }
     }
-  })
-}
+  );
+};
+
+exports.migrateToUseApplicationCommands = (database) => {
+  database.get(
+    'SELECT name FROM sqlite_master WHERE type="table" AND name="OldGuild"',
+    (error, row) => {
+      if (!row) {
+        database.serialize(() => {
+          database.run('ALTER TABLE Guild RENAME TO OldGuild');
+          database.run(
+            'CREATE TABLE Guild(uuid TEXT NOT NULL PRIMARY KEY, name TEXT NOT NULL, member_count INTEGER NOT NULL, owner_id TEXT NOT NULL, prefix TEXT NOT NULL, use_prefix BOOLEAN NOT NULL DEFAULT TRUE)'
+          );
+          database.run(
+            'INSERT INTO Guild (uuid, name, member_count, owner_id, prefix) SELECT uuid, name, member_count, owner_id, prefix FROM OldGuild'
+          );
+        });
+      }
+    }
+  );
+};

--- a/database/guild-db.js
+++ b/database/guild-db.js
@@ -3,11 +3,11 @@ const { sendGuildUpdateNotification } = require('../helpers');
 const { defaultPrefix } = require('../config/nessie.json');
 
 /**
- * Creates Guild table inside the Yagi Database
+ * Creates Guild table inside the Nessie Database
  * Gets called in the client.once("ready") hook
- * @param database - yagi database
- * @param guilds - guilds that yagi is in
- * @param client - yagi client
+ * @param database - nessie database
+ * @param guilds - guilds that nessie is in
+ * @param client - nessie client
  */
 exports.createGuildTable = (database, guilds, client) => {
   //Wrapped in a serialize to ensure that each method is called in order which its initialised
@@ -48,7 +48,7 @@ exports.createGuildTable = (database, guilds, client) => {
 };
 /**
  * Adds new guild to Guild table
- * @param guild - guild that yagi is newly invited in
+ * @param guild - guild that nessie is newly invited in
  */
 exports.insertNewGuild = (guild) => {
   let database = new sqlite.Database('./database/nessie.db', sqlite.OPEN_READWRITE);
@@ -69,7 +69,16 @@ exports.insertNewGuild = (guild) => {
     }
   );
 };
-
+/**
+ * Script to migrate existing database table to have a new use_prefix column
+ * This is so the transition of using application commands for users is easier
+ * Guilds that joined after v1.0.0 will only be able to use application commands
+ * While existing guilds prior to that will be able to use prefix commands and app commands; until april 29 that is
+ * To be able to distinguish between the two, this script will create a new table with a new use_prefix column based on the data from existing guilds
+ * Then by using the use_prefix value, we'll be able to constrain guilds
+ * TODO: Since this is a one-time use, probably best to remove this after v1.0.0 is deployed
+ * @param database - nessie database
+ */
 exports.migrateToUseApplicationCommands = (database) => {
   database.get(
     'SELECT name FROM sqlite_master WHERE type="table" AND name="OldGuild"',

--- a/events.js
+++ b/events.js
@@ -188,7 +188,7 @@ const setCurrentMapStatus = (data, channel) => {
   setTimeout(intervalRequest, currentTimer); //Start initial timer
 };
 /**
- * Function to delete all the relevant data in our database when yagi is removed from a server
+ * Function to delete all the relevant data in our database when nessie is removed from a server
  * Removes:
  * Guild
  * More stuff here when auto notifications gets developed

--- a/events.js
+++ b/events.js
@@ -91,6 +91,7 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
       if (error) {
         console.log(error);
       }
+      if (row.use_prefix === 0) return;
       const nessiePrefix = row.prefix;
 
       //Refactor this into its own function and pass as a callback for better readability in the future

--- a/events.js
+++ b/events.js
@@ -10,7 +10,11 @@ const { guildIDs, token } = require('./config/nessie.json');
 const { getBattleRoyalePubs } = require('./adapters');
 const { sendMixpanelEvent } = require('./analytics');
 const { sendHealthLog, sendGuildUpdateNotification, codeBlock } = require('./helpers');
-const { createGuildTable, insertNewGuild } = require('./database/guild-db');
+const {
+  createGuildTable,
+  insertNewGuild,
+  migrateToUseApplicationCommands,
+} = require('./database/guild-db');
 const { REST } = require('@discordjs/rest');
 const { Routes } = require('discord-api-types/v9');
 const { getPrefixCommands, getApplicationCommands } = require('./commands');
@@ -36,6 +40,7 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
        */
       const nessieDatabase = createNessieDatabase();
       createGuildTable(nessieDatabase, nessie.guilds.cache, nessie);
+      migrateToUseApplicationCommands(nessieDatabase);
       /**
        * Changes Nessie's activity when the current map has switched over to the next
        * Refer to the setCurrentMapStatus function for more information


### PR DESCRIPTION
#### Context
When I was initially creating application commands, my train of thought is that every guild will able to use it. This sentiment is shared with prefix commands, both old and new guilds will be able to use it upon launch. But I've come to realise last night that this might prove to be inefficient performance wise and probably setting myself up for more tech debt down the road when I eventually have to deprecate this feature

In the end, I've decided to only support usage of prefix commands for existing guilds (joined before v1.0.0) and new guilds that joined after launch will only be able to use application commands. In order to accomplish this, a migration is inevitable on the current database. I've created a script that runs on ready which creates a new table with a new column `use_prefix` based on the existing database data. 

This new column will then be used to return early in the messageCreate event handler when new users try to use a prefix command

![image](https://user-images.githubusercontent.com/42207245/152002765-efb5b641-9571-47d6-b9cf-3fe47f19949a.png)
![image](https://user-images.githubusercontent.com/42207245/152002799-4e4a408d-ce59-4109-8a32-ebda51712ef1.png)
![image](https://user-images.githubusercontent.com/42207245/152002869-f3da8c53-8254-42b3-b4c7-4169e7b9d8a2.png)

#### Change
- Create migration script for existing guild prefix users
- Only reply to prefix commands for old guilds

#### Release Notes
Commands Usage Migration