### PR TITLE
Add error handling

### DIFF
--- a/commands/maps/_arenas.js
+++ b/commands/maps/_arenas.js
@@ -1,5 +1,7 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const { getArenasPubs, getArenasRanked } = require('../../adapters');
+const { sendErrorLog, generateErrorEmbed } = require('../../helpers');
+const { v4: uuidv4 } = require('uuid');
 
 /**
  * Display the time left in a more aethestically manner
@@ -94,7 +96,7 @@ module.exports = {
    * This is pretty cool as discord will treat it as a normal response and we can do whatever we want with it within 15 minutes
    * which is editing the reply with the relevant information after the promise resolves
    **/
-  async execute({ interaction }) {
+  async execute({ nessie, interaction }) {
     let data;
     let embed;
     try {
@@ -111,8 +113,15 @@ module.exports = {
           break;
       }
       return await interaction.editReply({ embeds: embed });
-    } catch (e) {
-      console.log(e);
+    } catch (error) {
+      const uuid = uuidv4();
+      const type = 'Battle Royale';
+      const errorEmbed = generateErrorEmbed(
+        'Oops something went wrong! D: Try again in a bit!',
+        uuid
+      );
+      await interaction.editReply({ embeds: errorEmbed });
+      await sendErrorLog({ nessie, error, type, interaction, uuid });
     }
   },
 };

--- a/commands/maps/_battle-royale.js
+++ b/commands/maps/_battle-royale.js
@@ -142,7 +142,7 @@ module.exports = {
         'Oops something went wrong! D: Try again in a bit!',
         uuid
       );
-      await interaction.editReply({ embeds: [errorEmbed] });
+      await interaction.editReply({ embeds: errorEmbed });
       await sendErrorLog({ nessie, error, interaction, type, uuid });
     }
   },

--- a/commands/maps/_battle-royale.js
+++ b/commands/maps/_battle-royale.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const { getBattleRoyalePubs, getBattleRoyaleRanked } = require('../../adapters');
-const { sendErrorLog } = require('../../helpers');
+const { sendErrorLog, generateErrorEmbed } = require('../../helpers');
+const { v4: uuidv4 } = require('uuid');
 
 /**
  * Gets url link image for each br map
@@ -121,7 +122,6 @@ module.exports = {
     let data;
     let embed;
     try {
-      throw new Error('Test Error');
       await interaction.deferReply();
       const optionMode = interaction.options.getString('mode');
       switch (optionMode) {
@@ -136,9 +136,14 @@ module.exports = {
       }
       return await interaction.editReply({ embeds: embed });
     } catch (error) {
+      const uuid = uuidv4();
       const type = 'Battle Royale';
-      console.log(error); //Add proper error handling someday
-      sendErrorLog({ nessie, error, interaction, type });
+      const errorEmbed = generateErrorEmbed(
+        'Oops something went wrong! D: Try again in a bit!',
+        uuid
+      );
+      await interaction.editReply({ embeds: [errorEmbed] });
+      await sendErrorLog({ nessie, error, interaction, type, uuid });
     }
   },
 };

--- a/commands/maps/_battle-royale.js
+++ b/commands/maps/_battle-royale.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const { getBattleRoyalePubs, getBattleRoyaleRanked } = require('../../adapters');
+const { sendErrorLog } = require('../../helpers');
 
 /**
  * Gets url link image for each br map
@@ -116,10 +117,11 @@ module.exports = {
    * This is pretty cool as discord will treat it as a normal response and we can do whatever we want with it within 15 minutes
    * which is editing the reply with the relevant information after the promise resolves
    **/
-  async execute({ interaction }) {
+  async execute({ nessie, interaction }) {
     let data;
     let embed;
     try {
+      throw new Error('Test Error');
       await interaction.deferReply();
       const optionMode = interaction.options.getString('mode');
       switch (optionMode) {
@@ -133,8 +135,10 @@ module.exports = {
           break;
       }
       return await interaction.editReply({ embeds: embed });
-    } catch (e) {
-      console.log(e); //Add proper error handling someday
+    } catch (error) {
+      const type = 'Battle Royale';
+      console.log(error); //Add proper error handling someday
+      sendErrorLog({ nessie, error, interaction, type });
     }
   },
 };

--- a/commands/maps/arenas.js
+++ b/commands/maps/arenas.js
@@ -1,4 +1,6 @@
 const { getArenasPubs, getArenasRanked } = require('../../adapters');
+const { sendErrorLog, generateErrorEmbed } = require('../../helpers');
+const { v4: uuidv4 } = require('uuid');
 
 /**
  * Display the time left in a more aethestically manner
@@ -6,11 +8,11 @@ const { getArenasPubs, getArenasRanked } = require('../../adapters');
  * Function returns hr hrs min mins sec secs (01 hrs 02 mins 03 secs);
  * Might want to think of using the number of remaining seconds instead of splitting the timer string in the future
  */
- const getCountdown = (timer) => {
+const getCountdown = (timer) => {
   const countdown = timer.split(':');
   const isOverAnHour = countdown[0] && countdown[0] !== '00';
   return `${isOverAnHour ? `${countdown[0]} hr ` : ''}${countdown[1]} mins ${countdown[2]} secs`;
-}
+};
 /**
  * Embed design for Arenas Pubs
  * Added a hack to display the time for next map regardless of timezone
@@ -19,83 +21,90 @@ const { getArenasPubs, getArenasRanked } = require('../../adapters');
  */
 const generatePubsEmbed = (data) => {
   const embedData = {
-    title : "Arenas | Pubs",
-    color : 3066993,
+    title: 'Arenas | Pubs',
+    color: 3066993,
     image: {
-      url: data.current.asset //Using the scuffed saturated images as it'll be a chore adding custom images for each arenas map(some use areas of br maps)
+      url: data.current.asset, //Using the scuffed saturated images as it'll be a chore adding custom images for each arenas map(some use areas of br maps)
     },
-    timestamp: Date.now() + data.current.remainingSecs*1000,
+    timestamp: Date.now() + data.current.remainingSecs * 1000,
     footer: {
-      text: `Next Map: ${data.next.map}`
+      text: `Next Map: ${data.next.map}`,
     },
     fields: [
       {
-        name: "Current map",
-        value: "```fix\n\n" + data.current.map + "```",
-        inline: true
+        name: 'Current map',
+        value: '```fix\n\n' + data.current.map + '```',
+        inline: true,
       },
       {
-        name: "Time left",
-        value: "```xl\n\n" + getCountdown(data.current.remainingTimer) + "```",
-        inline: true
+        name: 'Time left',
+        value: '```xl\n\n' + getCountdown(data.current.remainingTimer) + '```',
+        inline: true,
       },
-    ]
+    ],
   };
   return [embedData];
-}
+};
 /**
  * Embed design for Arenas Ranked
  * Slighly different from BR ranked and similar to its Pubs counterpart
  * Might want to make all of these reusable, a lot of repeats
  */
- const generateRankedEmbed = (data) => {
+const generateRankedEmbed = (data) => {
   const embedData = {
-    title : "Arenas | Ranked",
-    color : 7419530,
+    title: 'Arenas | Ranked',
+    color: 7419530,
     image: {
-      url: data.current.asset //Using the scuffed saturated images as it'll be a chore adding custom images for each arenas map(some use areas of br maps)
+      url: data.current.asset, //Using the scuffed saturated images as it'll be a chore adding custom images for each arenas map(some use areas of br maps)
     },
-    timestamp: Date.now() + data.current.remainingSecs*1000,
+    timestamp: Date.now() + data.current.remainingSecs * 1000,
     footer: {
-      text: `Next Map: ${data.next.map}`
+      text: `Next Map: ${data.next.map}`,
     },
     fields: [
       {
-        name: "Current map",
-        value: "```fix\n\n" + data.current.map + "```",
-        inline: true
+        name: 'Current map',
+        value: '```fix\n\n' + data.current.map + '```',
+        inline: true,
       },
       {
-        name: "Time left",
-        value: "```xl\n\n" + getCountdown(data.current.remainingTimer) + "```",
-        inline: true
-      }
-    ]
+        name: 'Time left',
+        value: '```xl\n\n' + getCountdown(data.current.remainingTimer) + '```',
+        inline: true,
+      },
+    ],
   };
   return [embedData];
-}
+};
 
 module.exports = {
   name: 'arenas',
   description: 'Shows currrent map rotation for arenas mode',
   hasArguments: true,
-  async execute({message, arguments}){
+  async execute({ nessie, message, arguments }) {
     message.channel.sendTyping();
     try {
-      if(!arguments){
+      if (!arguments) {
         const data = await getArenasPubs();
         const embedToSend = generatePubsEmbed(data);
         return message.channel.send({ embeds: embedToSend });
-      } else{
-        if(arguments === 'ranked'){
+      } else {
+        if (arguments === 'ranked') {
           const data = await getArenasRanked();
           const embedToSend = generateRankedEmbed(data);
           return message.channel.send({ embeds: embedToSend });
         }
         return message.channel.send("I don't understand that argument （・□・；）");
       }
-    } catch(e){
-      console.log(e); //Add proper error handling someday
+    } catch (error) {
+      const uuid = uuidv4();
+      const type = 'Arenas';
+      const errorEmbed = generateErrorEmbed(
+        'Oops something went wrong! D: Try again in a bit!',
+        uuid
+      );
+      await message.channel.send({ embeds: errorEmbed });
+      await sendErrorLog({ nessie, error, type, message, uuid });
     }
-  }
-}
+  },
+};

--- a/commands/maps/battle-royale.js
+++ b/commands/maps/battle-royale.js
@@ -1,4 +1,5 @@
 const { getBattleRoyalePubs, getBattleRoyaleRanked } = require('../../adapters');
+const { sendErrorLog } = require('../../helpers');
 
 /**
  * Gets url link image for each br map
@@ -6,7 +7,7 @@ const { getBattleRoyalePubs, getBattleRoyaleRanked } = require('../../adapters')
  * Currently hosted scuffly in discord itself; might want to think of hosting it in cloudfront in the future
  */
 const getMapUrl = (map) => {
-  switch(map){
+  switch (map) {
     case 'kings_canyon_rotation':
       return 'https://cdn.discordapp.com/attachments/896544134813319168/896544176815099954/kings_canyon.jpg';
     case 'Kings Canyon':
@@ -22,11 +23,11 @@ const getMapUrl = (map) => {
     case 'Storm Point':
       return 'https://cdn.discordapp.com/attachments/896544134813319168/911631835300237332/storm_point_nessie.jpg';
     case 'storm_point_rotation':
-      return 'https://cdn.discordapp.com/attachments/896544134813319168/911631835300237332/storm_point_nessie.jpg';  
+      return 'https://cdn.discordapp.com/attachments/896544134813319168/911631835300237332/storm_point_nessie.jpg';
     default:
       return '';
   }
-}
+};
 /**
  * Display the time left in a more aethestically manner
  * API returns in the form hr:min:sec (01:02:03)
@@ -37,7 +38,7 @@ const getCountdown = (timer) => {
   const countdown = timer.split(':');
   const isOverAnHour = countdown[0] && countdown[0] !== '00';
   return `${isOverAnHour ? `${countdown[0]} hr ` : ''}${countdown[1]} mins ${countdown[2]} secs`;
-}
+};
 /**
  * Embed design for BR Pubs
  * Added a hack to display the time for next map regardless of timezone
@@ -46,78 +47,81 @@ const getCountdown = (timer) => {
  */
 const generatePubsEmbed = (data) => {
   const embedData = {
-    title : "Battle Royale | Pubs",
-    color : 3066993,
+    title: 'Battle Royale | Pubs',
+    color: 3066993,
     image: {
-      url: getMapUrl(data.current.code)
+      url: getMapUrl(data.current.code),
     },
-    timestamp: Date.now() + data.current.remainingSecs*1000,
+    timestamp: Date.now() + data.current.remainingSecs * 1000,
     footer: {
-      text: `Next Map: ${data.next.map}`
+      text: `Next Map: ${data.next.map}`,
     },
     fields: [
       {
-        name: "Current map",
-        value: "```fix\n\n" + data.current.map + "```",
-        inline: true
+        name: 'Current map',
+        value: '```fix\n\n' + data.current.map + '```',
+        inline: true,
       },
       {
-        name: "Time left",
-        value: "```xl\n\n" + getCountdown(data.current.remainingTimer) + "```",
-        inline: true
+        name: 'Time left',
+        value: '```xl\n\n' + getCountdown(data.current.remainingTimer) + '```',
+        inline: true,
       },
-    ]
+    ],
   };
   return [embedData];
-}
+};
 /**
  * Embed design for BR Ranked
  * Fairly simple, don't need any fancy timers and footers
  */
- const generateRankedEmbed = (data) => {
+const generateRankedEmbed = (data) => {
   const embedData = {
-    title : "Battle Royale | Ranked",
-    color : 7419530,
+    title: 'Battle Royale | Ranked',
+    color: 7419530,
     image: {
-      url: getMapUrl(data.current.map)
+      url: getMapUrl(data.current.map),
     },
     fields: [
       {
-        name: "Current map",
-        value: "```fix\n\n" + data.current.map + "```",
-        inline: true
+        name: 'Current map',
+        value: '```fix\n\n' + data.current.map + '```',
+        inline: true,
       },
       {
-        name: "Time left",
-        value: "```xl\n\nRunning till end of split```",
-        inline: true
-      }
-    ]
+        name: 'Time left',
+        value: '```xl\n\nRunning till end of split```',
+        inline: true,
+      },
+    ],
   };
   return [embedData];
-}
+};
 
 module.exports = {
   name: 'br',
   description: 'Shows currrent map rotation for battle royale mode',
   hasArguments: true,
-  async execute({message, arguments}){
+  async execute({ nessie, message, arguments }) {
     message.channel.sendTyping();
     try {
-      if(!arguments){
+      throw new Error('Test Error');
+      if (!arguments) {
         const data = await getBattleRoyalePubs();
         const embedToSend = generatePubsEmbed(data);
         return message.channel.send({ embeds: embedToSend });
-      } else{
-        if(arguments === 'ranked'){
+      } else {
+        if (arguments === 'ranked') {
           const data = await getBattleRoyaleRanked();
           const embedToSend = generateRankedEmbed(data);
           return message.channel.send({ embeds: embedToSend });
         }
         return message.channel.send("I don't understand that argument （・□・；）");
       }
-    } catch(e){
-      console.log(e); //Add proper error handling someday
+    } catch (error) {
+      console.log(error); //Add proper error handling someday
+      const type = 'Battle Royale';
+      await sendErrorLog({ nessie, error, type, message });
     }
-  }
-}
+  },
+};

--- a/commands/maps/battle-royale.js
+++ b/commands/maps/battle-royale.js
@@ -125,7 +125,7 @@ module.exports = {
         'Oops something went wrong! D: Try again in a bit!',
         uuid
       );
-      await message.channel.send({ embeds: [errorEmbed] });
+      await message.channel.send({ embeds: errorEmbed });
       await sendErrorLog({ nessie, error, type, message, uuid });
     }
   },

--- a/commands/maps/battle-royale.js
+++ b/commands/maps/battle-royale.js
@@ -1,5 +1,6 @@
 const { getBattleRoyalePubs, getBattleRoyaleRanked } = require('../../adapters');
-const { sendErrorLog } = require('../../helpers');
+const { sendErrorLog, generateErrorEmbed } = require('../../helpers');
+const { v4: uuidv4 } = require('uuid');
 
 /**
  * Gets url link image for each br map
@@ -105,7 +106,6 @@ module.exports = {
   async execute({ nessie, message, arguments }) {
     message.channel.sendTyping();
     try {
-      throw new Error('Test Error');
       if (!arguments) {
         const data = await getBattleRoyalePubs();
         const embedToSend = generatePubsEmbed(data);
@@ -119,9 +119,14 @@ module.exports = {
         return message.channel.send("I don't understand that argument （・□・；）");
       }
     } catch (error) {
-      console.log(error); //Add proper error handling someday
+      const uuid = uuidv4();
       const type = 'Battle Royale';
-      await sendErrorLog({ nessie, error, type, message });
+      const errorEmbed = generateErrorEmbed(
+        'Oops something went wrong! D: Try again in a bit!',
+        uuid
+      );
+      await message.channel.send({ embeds: [errorEmbed] });
+      await sendErrorLog({ nessie, error, type, message, uuid });
     }
   },
 };

--- a/events.js
+++ b/events.js
@@ -48,7 +48,7 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
       const brPubsData = await getBattleRoyalePubs(); //Get data of br map rotation
       nessie.user.setActivity(brPubsData.current.map); //Set current br map as activity status
       sendHealthLog(brPubsData, logChannel, true); //For logging purpose
-      setCurrentMapStatus(brPubsData, logChannel); //Calls status display function
+      setCurrentMapStatus(brPubsData, logChannel, nessie); //Calls status display function
     } catch (e) {
       console.log(e); //Add proper error handling
     }
@@ -162,7 +162,7 @@ const createNessieDatabase = () => {
  * Accomplished this by creating a intervalRequest function that has a setTimeout that calls itself as its callback
  * Inside the interval function we can then properly get the current timer and update accordingly
  */
-const setCurrentMapStatus = (data, channel) => {
+const setCurrentMapStatus = (data, channel, nessie) => {
   const fiveSecondsBuffer = 5000;
   let currentBrPubsData = data;
   let currentTimer = data.current.remainingSecs * 1000 + fiveSecondsBuffer;
@@ -182,6 +182,7 @@ const setCurrentMapStatus = (data, channel) => {
       sendHealthLog(updatedBrPubsData, channel, isAccurate);
       setTimeout(intervalRequest, currentTimer);
     } catch (e) {
+      console.log(e);
       channel.send('<@183444648360935424> WHOOPS SOMETHING WENT WRONG');
     }
   };

--- a/helpers.js
+++ b/helpers.js
@@ -135,10 +135,53 @@ const checkIfInDevelopment = (client) => {
   return client.user.id === '929421200797626388'; //Lochnesss' id (Development Bot)
 };
 //----------
+const sendErrorLog = async ({ nessie, error, message, interaction, type }) => {
+  console.log(error);
+  const errorChannel = nessie.channels.cache.get('938441853542465548');
+  const embed = {
+    title: message ? `Error | ${type} Prefix Command` : `Error | ${type} Application Command`,
+    color: 16711680,
+    description: `${error.message ? error.message : 'Unexpected Error'}`,
+    fields: [
+      {
+        name: 'User',
+        value: message ? message.author.username : interaction.user.username,
+        inline: true,
+      },
+      {
+        name: 'User ID',
+        value: message ? message.author.id : interaction.user.id,
+        inline: true,
+      },
+      {
+        name: 'Channel',
+        value: message ? message.channel.name : interaction.channel.name,
+        inline: true,
+      },
+      {
+        name: 'Channel ID',
+        value: message ? message.channel.id : interaction.channelId,
+        inline: true,
+      },
+      {
+        name: 'Guild',
+        value: message ? message.guild.name : interaction.guild.name,
+        inline: true,
+      },
+      {
+        name: 'Guild ID',
+        value: message ? message.guild.id : interaction.guildId,
+        inline: true,
+      },
+    ],
+  };
+  return await errorChannel.send({ embeds: [embed] });
+};
 module.exports = {
   checkIfInDevelopment,
   sendGuildUpdateNotification,
   serverEmbed,
   codeBlock,
   sendHealthLog,
+  sendErrorLog,
 };

--- a/helpers.js
+++ b/helpers.js
@@ -1,5 +1,4 @@
 const { format } = require('date-fns');
-const { v4: uuidv4 } = require('uuid');
 
 //----------
 /**
@@ -135,13 +134,20 @@ const sendGuildUpdateNotification = async (client, guild, type) => {
 const checkIfInDevelopment = (client) => {
   return client.user.id === '929421200797626388'; //Lochnesss' id (Development Bot)
 };
+const generateErrorEmbed = (message, uuid) => {
+  const embed = {
+    description: `${message}\n\nError ID: ${uuid}\nAlternatively, you can also report issue through the [support server](https://discord.com/invite/47Ccgz9jA4)`,
+    color: 16711680,
+  };
+  return embed;
+};
 //----------
-const sendErrorLog = async ({ nessie, error, message, interaction, type }) => {
+const sendErrorLog = async ({ nessie, error, message, interaction, type, uuid }) => {
   const errorChannel = nessie.channels.cache.get('938441853542465548');
   const embed = {
     title: message ? `Error | ${type} Prefix Command` : `Error | ${type} Application Command`,
     color: 16711680,
-    description: `uuid: ${uuidv4()}\nError: ${error.message ? error.message : 'Unexpected Error'}`,
+    description: `uuid: ${uuid}\nError: ${error.message ? error.message : 'Unexpected Error'}`,
     fields: [
       {
         name: 'User',
@@ -184,4 +190,5 @@ module.exports = {
   codeBlock,
   sendHealthLog,
   sendErrorLog,
+  generateErrorEmbed,
 };

--- a/helpers.js
+++ b/helpers.js
@@ -1,4 +1,5 @@
 const { format } = require('date-fns');
+const { v4: uuidv4 } = require('uuid');
 
 //----------
 /**
@@ -136,12 +137,11 @@ const checkIfInDevelopment = (client) => {
 };
 //----------
 const sendErrorLog = async ({ nessie, error, message, interaction, type }) => {
-  console.log(error);
   const errorChannel = nessie.channels.cache.get('938441853542465548');
   const embed = {
     title: message ? `Error | ${type} Prefix Command` : `Error | ${type} Application Command`,
     color: 16711680,
-    description: `${error.message ? error.message : 'Unexpected Error'}`,
+    description: `uuid: ${uuidv4()}\nError: ${error.message ? error.message : 'Unexpected Error'}`,
     fields: [
       {
         name: 'User',

--- a/helpers.js
+++ b/helpers.js
@@ -139,7 +139,7 @@ const generateErrorEmbed = (message, uuid) => {
     description: `${message}\n\nError ID: ${uuid}\nAlternatively, you can also report issue through the [support server](https://discord.com/invite/47Ccgz9jA4)`,
     color: 16711680,
   };
-  return embed;
+  return [embed];
 };
 //----------
 const sendErrorLog = async ({ nessie, error, message, interaction, type, uuid }) => {

--- a/helpers.js
+++ b/helpers.js
@@ -134,6 +134,13 @@ const sendGuildUpdateNotification = async (client, guild, type) => {
 const checkIfInDevelopment = (client) => {
   return client.user.id === '929421200797626388'; //Lochnesss' id (Development Bot)
 };
+//---------
+/**
+ * Generates an error embed to be replied to the user when an error occurs with a command
+ * Mainly used for failed promises
+ * @param message - error description/message
+ * @param uuid - error uuid
+ */
 const generateErrorEmbed = (message, uuid) => {
   const embed = {
     description: `${message}\n\nError ID: ${uuid}\nAlternatively, you can also report issue through the [support server](https://discord.com/invite/47Ccgz9jA4)`,
@@ -142,6 +149,17 @@ const generateErrorEmbed = (message, uuid) => {
   return [embed];
 };
 //----------
+/**
+ * Send error log with relevant information to the error-logs channel in the support server
+ * Mainly used for failed promises
+ * Probably think of a more efficient way of handling these errors; right now it does the job but looks to be cluttered
+ * @param nessie - client
+ * @param error - error object
+ * @param message - discord message object
+ * @param interaction - discord interaction object
+ * @param type - which command the error originated from
+ * @param uuid - error uuid
+ */
 const sendErrorLog = async ({ nessie, error, message, interaction, type, uuid }) => {
   const errorChannel = nessie.channels.cache.get('938441853542465548');
   const embed = {
@@ -183,6 +201,7 @@ const sendErrorLog = async ({ nessie, error, message, interaction, type, uuid })
   };
   return await errorChannel.send({ embeds: [embed] });
 };
+//---------
 module.exports = {
   checkIfInDevelopment,
   sendGuildUpdateNotification,

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "mocha": "^9.1.1",
     "nodemon": "^2.0.12",
     "sqlite3": "^5.0.2",
-    "topgg-autoposter": "^2.0.0"
+    "topgg-autoposter": "^2.0.0",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "auto": "^10.32.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -3183,6 +3183,11 @@ uuid@^3.3.2:
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
   integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
 
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
 vali-date@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/vali-date/-/vali-date-1.0.0.tgz#1b904a59609fb328ef078138420934f6b86709a6"


### PR DESCRIPTION
#### Context
In preparation of nessie getting verified, it's probably a good idea to have some sort of error handling for commands. Or at least commands that are dependent on external requests specifically the maps. Had this issue once when the API was experiencing an outage which resulted in nessie silently failing. Wasn't big of an issue back then but with nessie now supporting 100 servers and beyond, the good user experience is to reply with an error

Installed uuid so we can have an identifier for each error. We don't store these but at least it'll be easier to find the error in the log channel when a user reports the issue

![image](https://user-images.githubusercontent.com/42207245/152192059-ed90485b-1c7b-48d4-b508-87a9f11fb434.png)
![image](https://user-images.githubusercontent.com/42207245/152192106-7ffd545e-e83b-4db1-80c7-9919c868cd09.png)

#### Change
- Fix map rotation status by passing missing argument
- Create error log for both prefix and app commands
- Install uuid
- Reply with error message to user
- Add error handling for every promise

#### Release Notes
Add error handling