### PR TITLE
Add mixpanel support for application commands

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -40,7 +40,7 @@ const sendMixpanelEvent = (
       guild_id: guild.id,
       command: command,
       arguments: arguments ? arguments : 'none',
-      isApplicationCommand: isApplicationCommand,
+      isApplicationCommand: isApplicationCommand, //undefined if command is a prefix command
     });
     /**
      * Sets a user profile properties only once
@@ -53,6 +53,7 @@ const sendMixpanelEvent = (
       first_used_in_guild: guild.name,
       first_used_in_channel: channel.name,
     });
+    // Only set the user profilce once for when they first used an application command
     isApplicationCommand &&
       client.people.set_once(user.id, {
         first_used_application_command: new Date().toISOString(),

--- a/analytics.js
+++ b/analytics.js
@@ -3,20 +3,28 @@
  * Learning from past mistakes so adding this pre-launch
  * For reference: https://developer.mixpanel.com/docs/nodejs
  */
- const sendMixpanelEvent = (user, channel, guild, command, client, arguments) => {
+const sendMixpanelEvent = (
+  user,
+  channel,
+  guild,
+  command,
+  client,
+  arguments,
+  isApplicationCommand
+) => {
   const eventToSend = `Use ${command} command`; //Name of event; string interpolated with command as best to write an event as an action a user is doing
   /**
    * Creates and updates a user profile
    * Sets properties everytime event is called and overrides if they're different
    */
-   client.people.set(user.id, {
+  client.people.set(user.id, {
     $name: user.username,
     $created: user.createdAt.toISOString(),
     tag: user.tag,
     guild: guild.name,
-    guild_id: guild.id
-  })
-  if(channel.type !== 'dm'){
+    guild_id: guild.id,
+  });
+  if (channel.type !== 'dm') {
     /**
      * Event to send to mixpanel
      * Added relevant properties along with event such as user, channel and guild
@@ -31,24 +39,29 @@
       guild: guild.name,
       guild_id: guild.id,
       command: command,
-      arguments: arguments ? arguments : 'none'
-    })
+      arguments: arguments ? arguments : 'none',
+      isApplicationCommand: isApplicationCommand,
+    });
     /**
      * Sets a user profile properties only once
      * Gets called on every event but doesn't override property if it already exists
      * Useful for first time stuff
      */
     client.people.set_once(user.id, {
-      first_used: (new Date()).toISOString(),
+      first_used: new Date().toISOString(),
       first_command: command,
       first_used_in_guild: guild.name,
-      first_used_in_channel: channel.name
-    })
+      first_used_in_channel: channel.name,
+    });
+    isApplicationCommand &&
+      client.people.set_once(user.id, {
+        first_used_application_command: new Date().toISOString(),
+      });
   } else {
-   //Maybe look into dms someday; dropping this for now from Yagi
+    //Maybe look into dms someday; dropping this for now from Yagi
   }
-}
+};
 
 module.exports = {
-  sendMixpanelEvent
-}
+  sendMixpanelEvent,
+};

--- a/commands/maps/_arenas.js
+++ b/commands/maps/_arenas.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder } = require('@discordjs/builders');
 const { getArenasPubs, getArenasRanked } = require('../../adapters');
 const { sendErrorLog, generateErrorEmbed } = require('../../helpers');
 const { v4: uuidv4 } = require('uuid');
+const { sendMixpanelEvent } = require('../../analytics');
 
 /**
  * Display the time left in a more aethestically manner
@@ -96,7 +97,7 @@ module.exports = {
    * This is pretty cool as discord will treat it as a normal response and we can do whatever we want with it within 15 minutes
    * which is editing the reply with the relevant information after the promise resolves
    **/
-  async execute({ nessie, interaction }) {
+  async execute({ nessie, interaction, mixpanel }) {
     let data;
     let embed;
     try {
@@ -112,7 +113,16 @@ module.exports = {
           embed = generateRankedEmbed(data);
           break;
       }
-      return await interaction.editReply({ embeds: embed });
+      await interaction.editReply({ embeds: embed });
+      sendMixpanelEvent(
+        interaction.user,
+        interaction.channel,
+        interaction.guild,
+        'arenas',
+        mixpanel,
+        optionMode,
+        true
+      );
     } catch (error) {
       const uuid = uuidv4();
       const type = 'Battle Royale';

--- a/commands/maps/_battle-royale.js
+++ b/commands/maps/_battle-royale.js
@@ -2,6 +2,7 @@ const { SlashCommandBuilder } = require('@discordjs/builders');
 const { getBattleRoyalePubs, getBattleRoyaleRanked } = require('../../adapters');
 const { sendErrorLog, generateErrorEmbed } = require('../../helpers');
 const { v4: uuidv4 } = require('uuid');
+const { sendMixpanelEvent } = require('../../analytics');
 
 /**
  * Gets url link image for each br map
@@ -118,7 +119,7 @@ module.exports = {
    * This is pretty cool as discord will treat it as a normal response and we can do whatever we want with it within 15 minutes
    * which is editing the reply with the relevant information after the promise resolves
    **/
-  async execute({ nessie, interaction }) {
+  async execute({ nessie, interaction, mixpanel }) {
     let data;
     let embed;
     try {
@@ -134,7 +135,16 @@ module.exports = {
           embed = generateRankedEmbed(data);
           break;
       }
-      return await interaction.editReply({ embeds: embed });
+      await interaction.editReply({ embeds: embed });
+      sendMixpanelEvent(
+        interaction.user,
+        interaction.channel,
+        interaction.guild,
+        'br',
+        mixpanel,
+        optionMode,
+        true
+      );
     } catch (error) {
       const uuid = uuidv4();
       const type = 'Battle Royale';

--- a/events.js
+++ b/events.js
@@ -145,16 +145,18 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
   nessie.on('interactionCreate', async (interaction) => {
     if (!interaction.isCommand()) return;
     const { commandName } = interaction;
-    await appCommands[commandName].execute({ interaction, nessie });
-    sendMixpanelEvent(
-      interaction.user,
-      interaction.channel,
-      interaction.guild,
-      commandName,
-      mixpanel,
-      null,
-      true
-    );
+    await appCommands[commandName].execute({ interaction, nessie, mixpanel });
+    if (commandName !== 'br' && commandName !== 'arenas') {
+      sendMixpanelEvent(
+        interaction.user,
+        interaction.channel,
+        interaction.guild,
+        commandName,
+        mixpanel,
+        null,
+        true
+      );
+    }
   });
 };
 

--- a/events.js
+++ b/events.js
@@ -146,6 +146,13 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
     if (!interaction.isCommand()) return;
     const { commandName } = interaction;
     await appCommands[commandName].execute({ interaction, nessie, mixpanel });
+    /**
+     * Send event information to mixpanel for application commands
+     * This is for general commands that do not require arguments
+     * We can't do this here as we can only get the options within the command execution itself
+     * Hence, we have a separate handler for these commands in their own files instead of here
+     * TODO: Refactor conditional in the future, probably a better way to check since this isn't scalable
+     */
     if (commandName !== 'br' && commandName !== 'arenas') {
       sendMixpanelEvent(
         interaction.user,

--- a/events.js
+++ b/events.js
@@ -71,7 +71,7 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
   });
   nessie.on('guildDelete', (guild) => {
     try {
-      removeServerDataFromNessie(guild);
+      removeServerDataFromNessie(nessie, guild);
     } catch (e) {
       console.log(e); // Add proper handling
     }
@@ -195,7 +195,7 @@ const setCurrentMapStatus = (data, channel, nessie) => {
  * More stuff here when auto notifications gets developed
  * @param guild - guild in which nessie was kicked in
  */
-const removeServerDataFromNessie = (guild) => {
+const removeServerDataFromNessie = (nessie, guild) => {
   let database = new sqlite.Database(
     './database/nessie.db',
     sqlite.OPEN_READWRITE | sqlite.OPEN_CREATE

--- a/events.js
+++ b/events.js
@@ -145,7 +145,16 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
   nessie.on('interactionCreate', async (interaction) => {
     if (!interaction.isCommand()) return;
     const { commandName } = interaction;
-    return await appCommands[commandName].execute({ interaction, nessie });
+    await appCommands[commandName].execute({ interaction, nessie });
+    sendMixpanelEvent(
+      interaction.user,
+      interaction.channel,
+      interaction.guild,
+      commandName,
+      mixpanel,
+      null,
+      true
+    );
   });
 };
 


### PR DESCRIPTION
#### Context
As there are now application commands along with prefix commands, we want to continue to track user events while not messing up the data. Instead of creating new separate events for each command, I've decided to add a property, `isApplicationCommand`, on the event itself as we'll be able to filter these in our reports easily anyway. A caveat is that commands that require options, we have to manually create a separate mixpanel handler for them just so we properly key in arguments. Just a thought as this might not be scalable

![image](https://user-images.githubusercontent.com/42207245/152210990-59541123-5112-481c-ada7-6c82478009b3.png)

#### Change
- Fix missing argument for onGuildDelete event
- Send application command properties to mixpanel
- Create separate handler for br and arenas

#### Release Notes
Add mixpanel support for application commands