### PR TITLE
Register global application commands

### DIFF
--- a/events.js
+++ b/events.js
@@ -238,7 +238,6 @@ const removeServerDataFromNessie = (nessie, guild) => {
  * Basicailly guild commands can only be used in that server it was registered in
  * While global commands can be used to every server that bot is in
  * Main difference between the two apart from server constraints are that app commands are instantly registered in guilds while global would take up to an hour for changes to appear
- * TODO: Add handler for global register, below only handles guilds
  */
 const registerApplicationCommands = async (nessie) => {
   const isInDevelopment = checkIfInDevelopment(nessie);
@@ -249,6 +248,7 @@ const registerApplicationCommands = async (nessie) => {
   const rest = new REST({ version: '9' }).setToken(token);
 
   if (isInDevelopment) {
+    //Guild register
     try {
       await rest.put(Routes.applicationGuildCommands('929421200797626388', guildIDs), {
         body: appCommandList,
@@ -258,6 +258,8 @@ const registerApplicationCommands = async (nessie) => {
       console.log(e);
     }
   } else {
+    //Global Register
+    //TODO: Maybe create a script one day to delete global commands for test bot
     try {
       await rest.put(Routes.applicationCommands('929421200797626388'), { body: appCommandList });
       console.log('Successfully registered global application commands');


### PR DESCRIPTION
#### Context
Add handler for registering global application commands. Pretty straightforward; we register it globally if client is actually nessie and not the test bot

![image](https://user-images.githubusercontent.com/42207245/152367186-7cde0167-54b0-49df-9807-c615f63a482b.png)
![image](https://user-images.githubusercontent.com/42207245/152367369-5a16e981-6270-4298-860a-894f41018b4f.png)

#### Change
- Register global commands

#### Considerations
Since we're registering global commands in the test bot, it's probably a good idea to create a script that deletes global application commands for a bot. Good standalone project in the future

#### Release Notes
Register application commands