### PR TITLE
Set PSA for application commands

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -17,6 +17,7 @@ exports.getPrefixCommands = () => {
     prefix: require('./commands/hub/prefix'),
     setprefix: require('./commands/hub/setPrefix'),
     invite: require('./commands/hub/invite'),
+    announcement: require('./commands/hub/announcement'),
   };
 };
 exports.getApplicationCommands = () => {

--- a/commands/hub/about.js
+++ b/commands/hub/about.js
@@ -1,11 +1,14 @@
 const { format } = require('date-fns');
 const { version } = require('../../package.json');
+const { generateAnnouncementMessage } = require('../../helpers');
 const grvAcnt = '`';
 
 const sendAboutEmbed = ({ message, nessie, prefix }) => {
   const embed = {
     title: 'About',
-    description: `Hi there! I'm Nessie and I provide information about map rotations in Apex Legends! In my final form, I want to be able to automatically notify you which maps you want to play are currently active!\n\nCurrent version: No notifications yet but you can manually check the current map rotation with my commands! I also display the current br pubs map as my activity status. And custom prefixes!\n\nMy current prefix  is ${grvAcnt}${prefix}${grvAcnt} | For a detailed list of my commands, type ${grvAcnt}${prefix}help${grvAcnt}`, //Removed users for now
+    description:
+      generateAnnouncementMessage(prefix) +
+      `Hi there! I'm Nessie and I provide information about map rotations in Apex Legends! In my final form, I want to be able to automatically notify you which maps you want to play are currently active!\n\nCurrent version: No notifications yet but you can manually check the current map rotation with my commands! I also display the current br pubs map as my activity status. And custom prefixes!\n\nMy current prefix  is ${grvAcnt}${prefix}${grvAcnt} | For a detailed list of my commands, type ${grvAcnt}${prefix}help${grvAcnt}`, //Removed users for now
     color: 3447003,
     thumbnail: {
       url: 'https://cdn.discordapp.com/attachments/889134541615292459/896698383593517066/sir_nessie.png',

--- a/commands/hub/announcement.js
+++ b/commands/hub/announcement.js
@@ -1,7 +1,20 @@
+const generateAnnouncementEmbed = () => {
+  const embed = {
+    title: 'Announcement',
+    color: 16776960,
+    description: 'Announcement here',
+    thumbnail: {
+      url: 'https://cdn.discordapp.com/attachments/889134541615292459/896698383593517066/sir_nessie.png',
+    },
+  };
+  return [embed];
+};
+
 module.exports = {
   name: 'announcement',
   description: 'Displays current important news about Nessie',
-  execute({ message }) {
-    message.channel.send('announcement prefix command');
+  async execute({ message }) {
+    const embed = generateAnnouncementEmbed();
+    await message.channel.send({ embeds: embed });
   },
 };

--- a/commands/hub/announcement.js
+++ b/commands/hub/announcement.js
@@ -1,0 +1,7 @@
+module.exports = {
+  name: 'announcement',
+  description: 'Displays current important news about Nessie',
+  execute({ message }) {
+    message.channel.send('announcement prefix command');
+  },
+};

--- a/commands/hub/help.js
+++ b/commands/hub/help.js
@@ -1,3 +1,5 @@
+const { generateAnnouncementMessage } = require('../../helpers');
+
 module.exports = {
   name: 'help',
   description: 'directory of commands',
@@ -6,6 +8,7 @@ module.exports = {
     const embed = {
       color: 3447003,
       description:
+        generateAnnouncementMessage(nessiePrefix) +
         'Below you can see all the commands that I know!\n\nMy current prefix is `' +
         nessiePrefix +
         '`',
@@ -16,7 +19,7 @@ module.exports = {
         },
         {
           name: 'Information',
-          value: '`about`, `help`, `prefix`, `setprefix`, `invite`',
+          value: '`announcement`, `about`, `help`, `prefix`, `setprefix`, `invite`',
         },
       ],
     };

--- a/commands/hub/invite.js
+++ b/commands/hub/invite.js
@@ -1,13 +1,15 @@
+const { generateAnnouncementMessage } = require('../../helpers');
+
 module.exports = {
   name: 'invite',
   description: 'Generates an invite link for Nessie',
-  execute({message}) {
+  execute({ message, nessiePrefix }) {
     const embed = {
-      description: `${
-        message.author
-      } | [Add me to your servers! (◕ᴗ◕✿)](https://tinyurl.com/nessie-invite-v021)`,
-      color: 3447003
-    }
+      description:
+        generateAnnouncementMessage(nessiePrefix) +
+        `${message.author} | [Add me to your servers! (◕ᴗ◕✿)](https://tinyurl.com/nessie-invite-v021)`,
+      color: 3447003,
+    };
     message.channel.send({ embeds: [embed] });
-  }
+  },
 };

--- a/commands/hub/prefix.js
+++ b/commands/hub/prefix.js
@@ -1,18 +1,21 @@
+const { generateAnnouncementMessage } = require('../../helpers');
+
 const generateEmbed = (prefix) => {
   const embed = {
     color: 3447003,
+    description: generateAnnouncementMessage(prefix),
     fields: [
       {
         name: 'Current Prefix',
         value: prefix,
-        inline: true
+        inline: true,
       },
       {
         name: 'Usage Example',
         value: `${prefix}help`,
-        inline: true
-      }
-    ]
+        inline: true,
+      },
+    ],
   };
   return [embed];
 };
@@ -21,9 +24,9 @@ module.exports = {
   name: 'prefix',
   description: 'Shows current prefix',
   hasArguments: false,
-  execute({message, nessiePrefix}) {
+  execute({ message, nessiePrefix }) {
     const currentPrefix = nessiePrefix;
     const embed = generateEmbed(currentPrefix);
     message.channel.send({ embeds: embed });
-  }
+  },
 };

--- a/commands/hub/setPrefix.js
+++ b/commands/hub/setPrefix.js
@@ -1,4 +1,4 @@
-const { codeBlock } = require('../../helpers');
+const { codeBlock, generateAnnouncementMessage } = require('../../helpers');
 const { Permissions } = require('discord.js');
 const sqlite = require('sqlite3').verbose();
 
@@ -7,11 +7,15 @@ const generateInfoEmbed = (prefix) => {
   const embed = {
     color: 3447003,
     title: 'Custom Prefix',
-    description: 'To set a new prefix, add your new prefix between ``\n\nNote:\n1. Only users with Admin privileges can set a new custom prefix.\n2. Custom prefix cannot be empty.',
-    fields: [{
-      name: 'Example',
-      value: '```fix\n\n' + `${prefix}setprefix` +' `newPrefixHere`\n' + '```'
-    }],
+    description:
+      generateAnnouncementMessage(prefix) +
+      'To set a new prefix, add your new prefix between ``\n\nNote:\n1. Only users with Admin privileges can set a new custom prefix.\n2. Custom prefix cannot be empty.',
+    fields: [
+      {
+        name: 'Example',
+        value: '```fix\n\n' + `${prefix}setprefix` + ' `newPrefixHere`\n' + '```',
+      },
+    ],
   };
   return [embed];
 };
@@ -21,18 +25,19 @@ const generateSuccessEmbed = (newPrefix) => {
     color: 3066993,
     title: 'Yay!',
     description: 'New prefix successfully set!',
-    fields: [{
-      name: 'Current Prefix',
-      value: codeBlock(newPrefix)
-    },
-    {
-      name: 'Example Usage',
-      value: codeBlock(`${newPrefix}br`)
-    }
-  ]
-  }
+    fields: [
+      {
+        name: 'Current Prefix',
+        value: codeBlock(newPrefix),
+      },
+      {
+        name: 'Example Usage',
+        value: codeBlock(`${newPrefix}br`),
+      },
+    ],
+  };
   return [embed];
-}
+};
 /**
  * Embeds to show when user wrongly uses the command
  * 'empty': when setting a new prefix is empty ``
@@ -47,36 +52,36 @@ const generateErrorEmbed = (type, prefix) => {
     fields: [
       {
         name: 'Example',
-        value: '```fix\n\n' + `${prefix}setprefix` +' `newPrefixHere`\n' + '```'
-      }
-    ]
-  }
-  switch(type){
+        value: '```fix\n\n' + `${prefix}setprefix` + ' `newPrefixHere`\n' + '```',
+      },
+    ],
+  };
+  switch (type) {
     case 'empty':
-     embed.description = 'New prefix cannot be empty!';
-    break;
+      embed.description = 'New prefix cannot be empty!';
+      break;
     case 'incorrect':
       embed.description = 'To set a new prefix, make sure to add your new prefix between ``';
-    break;
-    case 'admin': 
+      break;
+    case 'admin':
       embed.description = 'Only users with Admin privileges can set a new custom prefix';
       embed.fields = undefined;
-    break;
+      break;
   }
   return [embed];
-}
+};
 module.exports = {
   name: 'setprefix',
   description: "Sets nessie's prefix to a custom one",
   hasArguments: true,
-  execute({message, arguments, nessiePrefix}) {
+  execute({ message, arguments, nessiePrefix }) {
     //When user only types setprefix; shows information about command
-    if(!arguments){
-      return message.channel.send({embeds: generateInfoEmbed(nessiePrefix)});
+    if (!arguments) {
+      return message.channel.send({ embeds: generateInfoEmbed(nessiePrefix) });
     }
     //When user is not an admin; shows admin error message
-    if(!message.member.permissions.has(Permissions.FLAGS.ADMINISTRATOR)){
-      return message.channel.send({ embeds: generateErrorEmbed('admin', nessiePrefix)})
+    if (!message.member.permissions.has(Permissions.FLAGS.ADMINISTRATOR)) {
+      return message.channel.send({ embeds: generateErrorEmbed('admin', nessiePrefix) });
     }
     /**
      * If user sets the new prefix correctly with ``
@@ -84,24 +89,27 @@ module.exports = {
      * - if the number of arguments are more than 2, parse out grave accents and update guild prefix with new prefix in our database
      * Else send incorrect error message
      */
-    if(arguments.startsWith("`") && arguments.endsWith("`") && arguments.length >= 2){
-      if(arguments.length === 2){
-        return message.channel.send({embeds: generateErrorEmbed('empty', nessiePrefix)});
+    if (arguments.startsWith('`') && arguments.endsWith('`') && arguments.length >= 2) {
+      if (arguments.length === 2) {
+        return message.channel.send({ embeds: generateErrorEmbed('empty', nessiePrefix) });
       }
-      if(arguments.length > 2){
+      if (arguments.length > 2) {
         const newPrefix = arguments.replace(/\`/g, '');
         let database = new sqlite.Database('./database/nessie.db', sqlite.OPEN_READWRITE);
 
-        database.run(`UPDATE Guild SET prefix = "${newPrefix}" WHERE uuid = ${message.guildId}`, err => {
-          if(err){
-            console.log(err);
-            return message.channel.send('Oops something went wrong! Try again!'); //Maybe add link to support server here?
+        database.run(
+          `UPDATE Guild SET prefix = "${newPrefix}" WHERE uuid = ${message.guildId}`,
+          (err) => {
+            if (err) {
+              console.log(err);
+              return message.channel.send('Oops something went wrong! Try again!'); //Maybe add link to support server here?
+            }
+            return message.channel.send({ embeds: generateSuccessEmbed(newPrefix) });
           }
-          return message.channel.send({embeds: generateSuccessEmbed(newPrefix)});
-        });
+        );
       }
     } else {
-      return message.channel.send({embeds: generateErrorEmbed('incorrect', nessiePrefix)})
+      return message.channel.send({ embeds: generateErrorEmbed('incorrect', nessiePrefix) });
     }
-  }
+  },
 };

--- a/commands/maps/arenas.js
+++ b/commands/maps/arenas.js
@@ -1,5 +1,5 @@
 const { getArenasPubs, getArenasRanked } = require('../../adapters');
-const { sendErrorLog, generateErrorEmbed } = require('../../helpers');
+const { sendErrorLog, generateErrorEmbed, generateAnnouncementMessage } = require('../../helpers');
 const { v4: uuidv4 } = require('uuid');
 
 /**
@@ -19,10 +19,11 @@ const getCountdown = (timer) => {
  * As discord embed has a timestamp property, I added the remianing milliseconds to the current date
  * Make reusable?
  */
-const generatePubsEmbed = (data) => {
+const generatePubsEmbed = (data, prefix) => {
   const embedData = {
     title: 'Arenas | Pubs',
     color: 3066993,
+    description: generateAnnouncementMessage(prefix),
     image: {
       url: data.current.asset, //Using the scuffed saturated images as it'll be a chore adding custom images for each arenas map(some use areas of br maps)
     },
@@ -50,10 +51,11 @@ const generatePubsEmbed = (data) => {
  * Slighly different from BR ranked and similar to its Pubs counterpart
  * Might want to make all of these reusable, a lot of repeats
  */
-const generateRankedEmbed = (data) => {
+const generateRankedEmbed = (data, prefix) => {
   const embedData = {
     title: 'Arenas | Ranked',
     color: 7419530,
+    description: generateAnnouncementMessage(prefix),
     image: {
       url: data.current.asset, //Using the scuffed saturated images as it'll be a chore adding custom images for each arenas map(some use areas of br maps)
     },
@@ -81,17 +83,17 @@ module.exports = {
   name: 'arenas',
   description: 'Shows currrent map rotation for arenas mode',
   hasArguments: true,
-  async execute({ nessie, message, arguments }) {
+  async execute({ nessie, message, arguments, nessiePrefix }) {
     message.channel.sendTyping();
     try {
       if (!arguments) {
         const data = await getArenasPubs();
-        const embedToSend = generatePubsEmbed(data);
+        const embedToSend = generatePubsEmbed(data, nessiePrefix);
         return message.channel.send({ embeds: embedToSend });
       } else {
         if (arguments === 'ranked') {
           const data = await getArenasRanked();
-          const embedToSend = generateRankedEmbed(data);
+          const embedToSend = generateRankedEmbed(data, nessiePrefix);
           return message.channel.send({ embeds: embedToSend });
         }
         return message.channel.send("I don't understand that argument （・□・；）");

--- a/commands/maps/battle-royale.js
+++ b/commands/maps/battle-royale.js
@@ -1,5 +1,5 @@
 const { getBattleRoyalePubs, getBattleRoyaleRanked } = require('../../adapters');
-const { sendErrorLog, generateErrorEmbed } = require('../../helpers');
+const { sendErrorLog, generateErrorEmbed, generateAnnouncementMessage } = require('../../helpers');
 const { v4: uuidv4 } = require('uuid');
 
 /**
@@ -46,10 +46,11 @@ const getCountdown = (timer) => {
  * As discord embed has a timestamp propery, I added the remianing milliseconds to the current date
  * Make reusable?
  */
-const generatePubsEmbed = (data) => {
+const generatePubsEmbed = (data, prefix) => {
   const embedData = {
     title: 'Battle Royale | Pubs',
     color: 3066993,
+    description: generateAnnouncementMessage(prefix),
     image: {
       url: getMapUrl(data.current.code),
     },
@@ -76,10 +77,11 @@ const generatePubsEmbed = (data) => {
  * Embed design for BR Ranked
  * Fairly simple, don't need any fancy timers and footers
  */
-const generateRankedEmbed = (data) => {
+const generateRankedEmbed = (data, prefix) => {
   const embedData = {
     title: 'Battle Royale | Ranked',
     color: 7419530,
+    description: generateAnnouncementMessage(prefix),
     image: {
       url: getMapUrl(data.current.map),
     },
@@ -103,17 +105,17 @@ module.exports = {
   name: 'br',
   description: 'Shows currrent map rotation for battle royale mode',
   hasArguments: true,
-  async execute({ nessie, message, arguments }) {
+  async execute({ nessie, message, arguments, nessiePrefix }) {
     message.channel.sendTyping();
     try {
       if (!arguments) {
         const data = await getBattleRoyalePubs();
-        const embedToSend = generatePubsEmbed(data);
+        const embedToSend = generatePubsEmbed(data, nessiePrefix);
         return message.channel.send({ embeds: embedToSend });
       } else {
         if (arguments === 'ranked') {
           const data = await getBattleRoyaleRanked();
-          const embedToSend = generateRankedEmbed(data);
+          const embedToSend = generateRankedEmbed(data, nessiePrefix);
           return message.channel.send({ embeds: embedToSend });
         }
         return message.channel.send("I don't understand that argument （・□・；）");

--- a/helpers.js
+++ b/helpers.js
@@ -201,6 +201,13 @@ const sendErrorLog = async ({ nessie, error, message, interaction, type, uuid })
   };
   return await errorChannel.send({ embeds: [embed] });
 };
+const generateAnnouncementMessage = (prefix) => {
+  return (
+    '```diff\n' +
+    `- Prefix commands will no longer be supported\n- Full information: ${prefix}announcement` +
+    '```\n'
+  );
+};
 //---------
 module.exports = {
   checkIfInDevelopment,
@@ -210,4 +217,5 @@ module.exports = {
   sendHealthLog,
   sendErrorLog,
   generateErrorEmbed,
+  generateAnnouncementMessage,
 };


### PR DESCRIPTION
#### Context
Set a public service announcement for each prefix command. Was initially gonna only put it only for hub commands as I didn't want to ruin user experience with the main map commands but after creating the design for the announcement, I think it looks fine so did it for every command. Placeholder content for the announcement command for now, will add them in a later pr
![image](https://user-images.githubusercontent.com/42207245/152446697-d450a4a2-6bb0-4040-bd1b-0788b178c818.png)
![image](https://user-images.githubusercontent.com/42207245/152446771-355111df-4262-49b3-9b55-15bd1d2e02c6.png)

#### Change
- Create prefix application command
- Create announcement message helper
- Add announcement message to every prefix command

#### Release Notes
Set PSA for application commands