### PR TITLE
Add control map command

### DIFF
--- a/adapters.js
+++ b/adapters.js
@@ -2,7 +2,7 @@ const axios = require('axios');
 const { apiKey } = require('./config/nessie.json');
 
 //Documentation on API: https://apexlegendsapi.com/documentation.php
-const url = `https://api.mozambiquehe.re/maprotation?version=2&auth=${apiKey}`
+const url = `https://api.mozambiquehe.re/maprotation?version=2&auth=${apiKey}`;
 /**
  * Full example response 
  * {
@@ -10,6 +10,7 @@ const url = `https://api.mozambiquehe.re/maprotation?version=2&auth=${apiKey}`
  *  arenas: {rotation},
  *  ranked: {brRanked},
  *  arenasRanked: {rotation}
+ *  control: {rotation}
  * } 
  * where
  * rotation = {
@@ -48,30 +49,37 @@ const url = `https://api.mozambiquehe.re/maprotation?version=2&auth=${apiKey}`
  */
 
 exports.getBattleRoyalePubs = async () => {
-  const data = await axios.get(url).then(response => {
+  const data = await axios.get(url).then((response) => {
     return response.data.battle_royale;
-  })
+  });
   console.log(data);
   return data;
-}
+};
 exports.getBattleRoyaleRanked = async () => {
-  const data = await axios.get(url).then(response => {
+  const data = await axios.get(url).then((response) => {
     return response.data.ranked;
-  })
+  });
   console.log(data);
   return data;
-}
+};
 exports.getArenasPubs = async () => {
-  const data = await axios.get(url).then(response => {
+  const data = await axios.get(url).then((response) => {
     return response.data.arenas;
-  })
+  });
   console.log(data);
   return data;
-}
+};
 exports.getArenasRanked = async () => {
-  const data = await axios.get(url).then(response => {
+  const data = await axios.get(url).then((response) => {
     return response.data.arenasRanked;
-  })
+  });
   console.log(data);
   return data;
-}
+};
+exports.getControlPubs = async () => {
+  const data = await axios.get(url).then((response) => {
+    return response.data.control;
+  });
+  console.log(data);
+  return data;
+};

--- a/commands.js
+++ b/commands.js
@@ -11,6 +11,7 @@ exports.getPrefixCommands = () => {
     //Maps
     br: require('./commands/maps/battle-royale'),
     arenas: require('./commands/maps/arenas'),
+    control: require('./commands/maps/control'),
     //Hub
     about: require('./commands/hub/about'),
     help: require('./commands/hub/help'),

--- a/commands.js
+++ b/commands.js
@@ -30,5 +30,6 @@ exports.getApplicationCommands = () => {
     // Maps
     br: require('./commands/maps/_battle-royale'),
     arenas: require('./commands/maps/_arenas'),
+    control: require('./commands/maps/_control'),
   };
 };

--- a/commands/hub/_help.js
+++ b/commands/hub/_help.js
@@ -9,7 +9,7 @@ module.exports = {
       fields: [
         {
           name: 'Maps',
-          value: '`br`, `arenas`',
+          value: '`br`, `arenas`, `control`',
         },
         {
           name: 'Information',

--- a/commands/hub/help.js
+++ b/commands/hub/help.js
@@ -15,7 +15,7 @@ module.exports = {
       fields: [
         {
           name: 'Maps',
-          value: '`br`, `br ranked`, `arenas`, `arenas ranked`',
+          value: '`br`, `br ranked`, `arenas`, `arenas ranked`, `control`',
         },
         {
           name: 'Information',

--- a/commands/maps/_control.js
+++ b/commands/maps/_control.js
@@ -4,6 +4,13 @@ const { sendErrorLog, generateErrorEmbed } = require('../../helpers');
 const { v4: uuidv4 } = require('uuid');
 const { sendMixpanelEvent } = require('../../analytics');
 
+/**
+ * TODO: Figure out a system to show custom map images for map commands
+ * Aside from br, the rest of the modes rely on the assets return by the API
+ * These assets don't look good however I've decided to use them for now as it's direct
+ * Manually wiring them up to our images isn't scalable either
+ * I'll just leave this comment so I get reminded about it in the future
+ */
 const getCountdown = (timer) => {
   const countdown = timer.split(':');
   const isOverAnHour = countdown[0] && countdown[0] !== '00';

--- a/commands/maps/_control.js
+++ b/commands/maps/_control.js
@@ -1,0 +1,83 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const { getControlPubs } = require('../../adapters');
+const { sendErrorLog, generateErrorEmbed } = require('../../helpers');
+const { v4: uuidv4 } = require('uuid');
+const { sendMixpanelEvent } = require('../../analytics');
+
+const getCountdown = (timer) => {
+  const countdown = timer.split(':');
+  const isOverAnHour = countdown[0] && countdown[0] !== '00';
+  return `${isOverAnHour ? `${countdown[0]} hr ` : ''}${countdown[1]} mins ${countdown[2]} secs`;
+};
+
+const generatePubsEmbed = (data) => {
+  const embedData = {
+    title: 'Control | Pubs',
+    color: 3066993,
+    image: {
+      url: data.current.asset, //Using the scuffed saturated images as it'll be a chore adding custom images for each control map(some use areas of br maps)
+    },
+    timestamp: Date.now() + data.current.remainingSecs * 1000,
+    footer: {
+      text: `Next Map: ${data.next.map}`,
+    },
+    fields: [
+      {
+        name: 'Current map',
+        value: '```fix\n\n' + data.current.map + '```',
+        inline: true,
+      },
+      {
+        name: 'Time left',
+        value: '```xl\n\n' + getCountdown(data.current.remainingTimer) + '```',
+        inline: true,
+      },
+    ],
+  };
+  return [embedData];
+};
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('control')
+    .setDescription('Shows current map rotation for control')
+    .addStringOption((option) =>
+      option
+        .setName('mode')
+        .setDescription('Game Mode')
+        .setRequired(true)
+        .addChoice('pubs', 'control_pubs')
+    ),
+  async execute({ nessie, interaction, mixpanel }) {
+    let data;
+    let embed;
+    try {
+      await interaction.deferReply();
+      const optionMode = interaction.options.getString('mode');
+      switch (optionMode) {
+        case 'control_pubs':
+          data = await getControlPubs();
+          embed = generatePubsEmbed(data);
+          break;
+      }
+      await interaction.editReply({ embeds: embed });
+      sendMixpanelEvent(
+        interaction.user,
+        interaction.channel,
+        interaction.guild,
+        'control',
+        mixpanel,
+        optionMode,
+        true
+      );
+    } catch (error) {
+      const uuid = uuidv4();
+      const type = 'Battle Royale';
+      const errorEmbed = generateErrorEmbed(
+        'Oops something went wrong! D: Try again in a bit!',
+        uuid
+      );
+      await interaction.editReply({ embeds: errorEmbed });
+      await sendErrorLog({ nessie, error, interaction, type, uuid });
+    }
+  },
+};

--- a/commands/maps/control.js
+++ b/commands/maps/control.js
@@ -1,5 +1,40 @@
 const { getControlPubs } = require('../../adapters');
+const { sendErrorLog, generateErrorEmbed, generateAnnouncementMessage } = require('../../helpers');
+const { v4: uuidv4 } = require('uuid');
 
+const getCountdown = (timer) => {
+  const countdown = timer.split(':');
+  const isOverAnHour = countdown[0] && countdown[0] !== '00';
+  return `${isOverAnHour ? `${countdown[0]} hr ` : ''}${countdown[1]} mins ${countdown[2]} secs`;
+};
+
+const generatePubsEmbed = (data, prefix) => {
+  const embedData = {
+    title: 'Control | Pubs',
+    color: 3066993,
+    description: generateAnnouncementMessage(prefix),
+    image: {
+      url: data.current.asset, //Using the scuffed saturated images as it'll be a chore adding custom images for each control map(some use areas of br maps)
+    },
+    timestamp: Date.now() + data.current.remainingSecs * 1000,
+    footer: {
+      text: `Next Map: ${data.next.map}`,
+    },
+    fields: [
+      {
+        name: 'Current map',
+        value: '```fix\n\n' + data.current.map + '```',
+        inline: true,
+      },
+      {
+        name: 'Time left',
+        value: '```xl\n\n' + getCountdown(data.current.remainingTimer) + '```',
+        inline: true,
+      },
+    ],
+  };
+  return [embedData];
+};
 module.exports = {
   name: 'control',
   description: 'Shows current map rotation for control mode',
@@ -7,7 +42,17 @@ module.exports = {
     message.channel.sendTyping();
     try {
       const data = await getControlPubs();
-      console.log(data);
-    } catch (error) {}
+      const embedToSend = generatePubsEmbed(data, nessiePrefix);
+      return await message.channel.send({ embeds: embedToSend });
+    } catch (error) {
+      const uuid = uuidv4();
+      const type = 'Control';
+      const errorEmbed = generateErrorEmbed(
+        'Oops something went wrong! D: Try again in a bit!',
+        uuid
+      );
+      await message.channel.send({ embeds: errorEmbed });
+      await sendErrorLog({ nessie, error, type, message, uuid });
+    }
   },
 };

--- a/commands/maps/control.js
+++ b/commands/maps/control.js
@@ -1,0 +1,13 @@
+const { getControlPubs } = require('../../adapters');
+
+module.exports = {
+  name: 'control',
+  description: 'Shows current map rotation for control mode',
+  async execute({ nessie, message, nessiePrefix }) {
+    message.channel.sendTyping();
+    try {
+      const data = await getControlPubs();
+      console.log(data);
+    } catch (error) {}
+  },
+};

--- a/helpers.js
+++ b/helpers.js
@@ -202,11 +202,12 @@ const sendErrorLog = async ({ nessie, error, message, interaction, type, uuid })
   return await errorChannel.send({ embeds: [embed] });
 };
 const generateAnnouncementMessage = (prefix) => {
-  return (
-    '```diff\n' +
-    `- Prefix commands will no longer be supported\n- Full information: ${prefix}announcement` +
-    '```\n'
-  );
+  return '';
+  // return (
+  //   '```diff\n' +
+  //   `- Prefix commands will no longer be supported\n- Full information: ${prefix}announcement` +
+  //   '```\n'
+  // );
 };
 //---------
 module.exports = {

--- a/helpers.js
+++ b/helpers.js
@@ -202,12 +202,11 @@ const sendErrorLog = async ({ nessie, error, message, interaction, type, uuid })
   return await errorChannel.send({ embeds: [embed] });
 };
 const generateAnnouncementMessage = (prefix) => {
-  return '';
-  // return (
-  //   '```diff\n' +
-  //   `- Prefix commands will no longer be supported\n- Full information: ${prefix}announcement` +
-  //   '```\n'
-  // );
+  return (
+    '```diff\n' +
+    `- Prefix commands will no longer be supported\n- Full information: ${prefix}announcement` +
+    '```\n'
+  );
 };
 //---------
 module.exports = {


### PR DESCRIPTION
#### Context
With Season 12 being released last night comes with it, a new game mode. Don't really know much about it apart from it being 9v9 which is cool I guess. API got updated pretty fast after the release and since I'm already planning a release tonight for the verification, it's the cherry on top to add this

![image](https://user-images.githubusercontent.com/42207245/153216712-1ed8c8ec-dfd7-43a0-b898-193a4274c3da.png)
![image](https://user-images.githubusercontent.com/42207245/153217658-69d2e6d8-be49-4769-8009-b58e17cee086.png)


#### Change
- Wire up control adapter
- Create control prefix command
- Create control application command

#### Considerations
I followed the same pattern as the existing map commands. Don't think this will get a ranked mode but it's safe to assume it and still make users put in a mode option

#### Release Notes
Add control map command
