### PR TITLE
Add current timer to br ranked

### DIFF
--- a/adapters.js
+++ b/adapters.js
@@ -40,12 +40,22 @@ const url = `https://api.mozambiquehe.re/maprotation?version=2&auth=${apiKey}`;
  *  }
  * }
  * And brRanked = {
- *  current: {
+    current: {
+      start: 1649178000,
+      end: 1652202000,
+      readableDate_start: '2022-04-05 17:00:00',
+      readableDate_end: '2022-05-10 17:00:00',
       map: 'Kings Canyon',
-      asset: 'https://apexlegendsstatus.com/assets/maps/Kings_Canyon.png'
+      code: 'kings_canyon_rotation',
+      DurationInSecs: 3024000,
+      DurationInMinutes: 50400,
+      asset: 'https://apexlegendsstatus.com/assets/maps/Kings_Canyon.png',
+      remainingSecs: 2197532,
+      remainingMins: 36626,
+      remainingTimer: '610:25:32'
     },
-    next: { map: 'Olympus' }
- * }
+    next: { map: 'Unknown' }
+}
  */
 
 exports.getBattleRoyalePubs = async () => {

--- a/commands/maps/_battle-royale.js
+++ b/commands/maps/_battle-royale.js
@@ -93,7 +93,7 @@ const generateRankedEmbed = (data) => {
       },
       {
         name: 'Time left',
-        value: '```xl\n\nRunning till end of split```',
+        value: '```xl\n\n' + getCountdown(data.current.remainingTimer) + '```',
         inline: true,
       },
     ],

--- a/commands/maps/battle-royale.js
+++ b/commands/maps/battle-royale.js
@@ -93,7 +93,7 @@ const generateRankedEmbed = (data, prefix) => {
       },
       {
         name: 'Time left',
-        value: '```xl\n\nRunning till end of split```',
+        value: '```xl\n\n' + getCountdown(data.current.remainingTimer) + '```',
         inline: true,
       },
     ],


### PR DESCRIPTION
#### Context
With the new update of apexlegendsapi, the maps endpoint now supports battle royale ranked current time. Essentially it returns the same payload as the battle royale pubs object so we can now show the exact time left

<img width="466" alt="image" src="https://user-images.githubusercontent.com/42207245/163537541-0d1ce590-e742-4f1a-9c68-0fa09a22bac1.png">
<img width="479" alt="image" src="https://user-images.githubusercontent.com/42207245/163537571-b7e9056d-51db-4395-97d3-f4fa6940825f.png">

#### Change
- Add current timer to br ranked