### PR TITLE
Add days to br ranked timer

### DIFF
--- a/commands/maps/battle-royale.js
+++ b/commands/maps/battle-royale.js
@@ -40,6 +40,14 @@ const getMapUrl = (map) => {
 const getCountdown = (timer) => {
   const countdown = timer.split(':');
   const isOverAnHour = countdown[0] && countdown[0] !== '00';
+  const isOverADay = countdown[0] && parseInt(countdown[0]) >= 24;
+
+  //Since ranked br is usually one map for the whole split, good to show days as well rather than just the usual hours
+  if (isOverADay) {
+    const countdownDays = parseInt(countdown[0]) / 24;
+    const countdownHours = parseInt(countdown[0]) % 24;
+    return `${Math.floor(countdownDays)} days ${countdownHours} hrs ${countdown[1]} mins`;
+  }
   return `${isOverAnHour ? `${countdown[0]} hr ` : ''}${countdown[1]} mins ${countdown[2]} secs`;
 };
 /**

--- a/commands/maps/control.js
+++ b/commands/maps/control.js
@@ -78,7 +78,7 @@ module.exports = {
       );
     } catch (error) {
       const uuid = uuidv4();
-      const type = 'Battle Royale';
+      const type = 'Control';
       const errorEmbed = generateErrorEmbed(
         'Oops something went wrong! D: Try again in a bit!',
         uuid


### PR DESCRIPTION
#### Context
Recently I've added timers to the ranked br command and follows the default `hr mins secs` format. However ranked br normally lasts the whole split which is way more than a couple of hours. This pr is purely a qol change to show days + hrs instead of purely hours

From:
<img width="462" alt="image" src="https://user-images.githubusercontent.com/42207245/166436618-946eab9f-4ad5-4275-8930-495c8b2f3a85.png">
To:
<img width="501" alt="image" src="https://user-images.githubusercontent.com/42207245/166436581-422b84c8-3b3a-4f63-97c9-0e5172605f07.png">

#### Change
- Add days to br ranked timer