### PR TITLE
Create Status Command UI

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -14,5 +14,6 @@ exports.getApplicationCommands = () => {
     br: require('./commands/maps/battle-royale'),
     arenas: require('./commands/maps/arenas'),
     control: require('./commands/maps/control'),
+    status: require('./commands/maps/status'),
   };
 };

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -1,7 +1,6 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const { MessageActionRow, MessageButton } = require('discord.js');
 
-const generateHelpEmbed = () => {};
 const sendHelpInteraction = async (interaction) => {
   const embedData = {
     title: 'Status | Help',
@@ -34,6 +33,29 @@ const sendStartInteraction = async (interaction) => {
 
   return await interaction.editReply({ components: [row], embeds: [embedData] });
 };
+const sendStopInteraction = async (interaction) => {
+  const embedData = {
+    title: 'Status | Stop',
+    color: 3447003,
+    description:
+      'By confirming below, Nessie will stop the existing map status and delete these channels:\n• Apex Map Status\n• #apex-pubs\n• #apex-ranked\n\nTo re-enable the automated map status after, simply use `/status start` again',
+  };
+  const row = new MessageActionRow()
+    .addComponents(
+      new MessageButton()
+        .setCustomId('statusStop__cancelButton')
+        .setLabel('Cancel')
+        .setStyle('SECONDARY')
+    )
+    .addComponents(
+      new MessageButton()
+        .setCustomId('statusStop__stopButton')
+        .setLabel(`Stop it!`)
+        .setStyle('DANGER')
+    );
+
+  return await interaction.editReply({ components: [row], embeds: [embedData] });
+};
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('status')
@@ -59,7 +81,7 @@ module.exports = {
         case 'start':
           return await sendStartInteraction(interaction);
         case 'stop':
-          return await interaction.editReply('Status Stop Command');
+          return await sendStopInteraction(interaction);
       }
     } catch (error) {
       console.log(error);

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -58,24 +58,45 @@ const generatePubsEmbed = (data) => {
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('status')
-    .setDescription('Creates an automated channel to show map status'),
+    .setDescription('Creates an automated channel to show map status')
+    .addSubcommand((subCommand) =>
+      subCommand.setName('help').setDescription('Displays information about automatic map status')
+    )
+    .addSubcommand((subCommand) =>
+      subCommand.setName('start').setDescription('Starts the automated map status')
+    )
+    .addSubcommand((subCommand) =>
+      subCommand.setName('stop').setDescription('Stops an existing automated status')
+    ),
 
   async execute({ nessie, interaction, mixpanel }) {
+    const statusOption = interaction.options.getSubcommand();
+    console.log(statusOption);
     try {
       await interaction.deferReply();
-      const data = await getBattleRoyalePubs();
-      const embedToSend = generatePubsEmbed(data);
-      console.log(interaction);
-      // //Creates a category channel for better readability
-      const statusCategory = await interaction.guild.channels.create('Apex Legends Map Status', {
-        type: 'GUILD_CATEGORY',
-      });
-      // //Creates the status channnel for br
-      const statusChannel = await interaction.guild.channels.create('apex-pubs', {
-        parent: statusCategory,
-      });
-      const statusMessage = await statusChannel.send({ embeds: embedToSend }); //Sends initial br embed in status channel
-      await interaction.editReply(`Created map status at ${statusChannel}`); //Sends success message in channel where command got instantiated
+      switch (statusOption) {
+        case 'help':
+          await interaction.editReply('Status Help Command');
+          break;
+        case 'start':
+          await interaction.editReply('Status Start Command');
+          // const data = await getBattleRoyalePubs();
+          // const embedToSend = generatePubsEmbed(data);
+          // // //Creates a category channel for better readability
+          // const statusCategory = await interaction.guild.channels.create('Apex Legends Map Status', {
+          //   type: 'GUILD_CATEGORY',
+          // });
+          // //Creates the status channnel for br
+          // const statusChannel = await interaction.guild.channels.create('apex-pubs', {
+          //   parent: statusCategory,
+          // });
+          // const statusMessage = await statusChannel.send({ embeds: embedToSend }); //Sends initial br embed in status channel
+          // await interaction.editReply(`Created map status at ${statusChannel}`); //Sends success message in channel where command got instantiated
+          break;
+        case 'stop':
+          await interaction.editReply('Status Stop Command');
+          break;
+      }
     } catch (error) {
       console.log(error);
     }

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -56,7 +56,16 @@ const sendStopInteraction = async (interaction) => {
 
   return await interaction.editReply({ components: [row], embeds: [embedData] });
 };
+
 module.exports = {
+  /**
+   * Creates Status application command with relevant subcommands
+   * Apparently when you create a subcommand under a base command, the base command will no longer be called
+   * I.e /status becomes void and only '/status xyz' can be used as commands
+   * I'm not sure why Discord did it this way but their explanation is the base command now becomes a folder of sorts
+   * Was initially planning to have /status, /status start and /status stop with the former showing the command information
+   * Not really a problem anyway since now it's /status help
+   */
   data: new SlashCommandBuilder()
     .setName('status')
     .setDescription('Creates an automated channel to show map status')
@@ -69,7 +78,13 @@ module.exports = {
     .addSubcommand((subCommand) =>
       subCommand.setName('stop').setDescription('Stops an existing automated status')
     ),
-
+  /**
+   * Send correct reply based on the user's subcommand input
+   * Since we're opting to use button components, the actual status implementation can't be placed here when an application command is called
+   * This is because buttons are also interactions similar to app commands (component interactions)
+   * Upon clicking a button, a new interaction is retrieved by the interactionCreate listener and would have to be treated there
+   * It's honestly going to be a maze trying to link things together here but it's the price of being trailblazers I guess
+   */
   async execute({ nessie, interaction, mixpanel }) {
     const statusOption = interaction.options.getSubcommand();
     try {

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const { getBattleRoyalePubs } = require('../../adapters');
+const { nessieLogo } = require('../../constants');
 const Scheduler = require('../../scheduler');
 
 const getMapUrl = (map) => {
@@ -28,6 +29,15 @@ const getCountdown = (timer) => {
   const countdown = timer.split(':');
   const isOverAnHour = countdown[0] && countdown[0] !== '00';
   return `${isOverAnHour ? `${countdown[0]} hr ` : ''}${countdown[1]} mins ${countdown[2]} secs`;
+};
+const generateHelpEmbed = () => {
+  const embedData = {
+    title: 'Status | Help',
+    description:
+      'This command will send automatic updates about Apex Legends Map Status in 2 new channels: *apex-pubs* and *apex-ranked*\n\nUpdates occur **every 15 minutes**\n\nRequires:\n• Manage Channel Permissions\n• Send Message Permissions\n• Only Admins can enable automatic status',
+    color: 3447003,
+  };
+  return [embedData];
 };
 const generatePubsEmbed = (data) => {
   const embedData = {
@@ -71,12 +81,12 @@ module.exports = {
 
   async execute({ nessie, interaction, mixpanel }) {
     const statusOption = interaction.options.getSubcommand();
-    console.log(statusOption);
     try {
       await interaction.deferReply();
       switch (statusOption) {
         case 'help':
-          await interaction.editReply('Status Help Command');
+          const embedToSend = generateHelpEmbed();
+          await interaction.editReply({ embeds: embedToSend });
           break;
         case 'start':
           await interaction.editReply('Status Start Command');

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -1,4 +1,5 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
+const { MessageActionRow, MessageButton } = require('discord.js');
 const { getBattleRoyalePubs, getBattleRoyaleRanked } = require('../../adapters');
 const { nessieLogo } = require('../../constants');
 const Scheduler = require('../../scheduler');
@@ -38,6 +39,29 @@ const generateHelpEmbed = () => {
     color: 3447003,
   };
   return [embedData];
+};
+const sendStartInteraction = async (interaction) => {
+  const embedData = {
+    title: 'Status | Start',
+    color: 3447003,
+    description:
+      'By confirming below, Nessie will create a new category channel and 2 new text channels for the automated map status:\n• `Apex Map Status`\n• `#apex-pubs`\n• `#apex-ranked`\n\nNessie will use these channels to send automatic updates every 15 minutes',
+  };
+  const row = new MessageActionRow()
+    .addComponents(
+      new MessageButton()
+        .setCustomId('statusStart__cancelButton')
+        .setLabel('Cancel')
+        .setStyle('SECONDARY')
+    )
+    .addComponents(
+      new MessageButton()
+        .setCustomId('statusStart__startButton')
+        .setLabel(`Let's go!`)
+        .setStyle('SUCCESS')
+    );
+
+  await interaction.editReply({ components: [row], embeds: [embedData] });
 };
 const generatePubsEmbed = (data) => {
   const embedData = {
@@ -111,29 +135,30 @@ module.exports = {
           await interaction.editReply({ embeds: embedToSend });
           break;
         case 'start':
-          const pubsData = await getBattleRoyalePubs();
-          const rankedData = await getBattleRoyaleRanked();
-          const pubsEmbed = generatePubsEmbed(pubsData);
-          const rankedEmbed = generateRankedEmbed(rankedData);
-          // //Creates a category channel for better readability
-          const statusCategory = await interaction.guild.channels.create(
-            'Apex Legends Map Status',
-            {
-              type: 'GUILD_CATEGORY',
-            }
-          );
-          //Creates the status channnel for br
-          const statusPubsChannel = await interaction.guild.channels.create('apex-pubs', {
-            parent: statusCategory,
-          });
-          const statusRankedChannel = await interaction.guild.channels.create('apex-ranked', {
-            parent: statusCategory,
-          });
-          const statusPubsMessage = await statusPubsChannel.send({ embeds: pubsEmbed }); //Sends initial br embed in status channel
-          const statusRankedMessage = await statusRankedChannel.send({ embeds: rankedEmbed });
-          await interaction.editReply(
-            `Created map status at ${statusPubsChannel} and ${statusRankedChannel}`
-          ); //Sends success message in channel where command got instantiated
+          await sendStartInteraction(interaction);
+          // const pubsData = await getBattleRoyalePubs();
+          // const rankedData = await getBattleRoyaleRanked();
+          // const pubsEmbed = generatePubsEmbed(pubsData);
+          // const rankedEmbed = generateRankedEmbed(rankedData);
+          // // //Creates a category channel for better readability
+          // const statusCategory = await interaction.guild.channels.create(
+          //   'Apex Legends Map Status',
+          //   {
+          //     type: 'GUILD_CATEGORY',
+          //   }
+          // );
+          // //Creates the status channnel for br
+          // const statusPubsChannel = await interaction.guild.channels.create('apex-pubs', {
+          //   parent: statusCategory,
+          // });
+          // const statusRankedChannel = await interaction.guild.channels.create('apex-ranked', {
+          //   parent: statusCategory,
+          // });
+          // const statusPubsMessage = await statusPubsChannel.send({ embeds: pubsEmbed }); //Sends initial br embed in status channel
+          // const statusRankedMessage = await statusRankedChannel.send({ embeds: rankedEmbed });
+          // await interaction.editReply(
+          //   `Created map status at ${statusPubsChannel} and ${statusRankedChannel}`
+          // ); //Sends success message in channel where command got instantiated
           break;
         case 'stop':
           await interaction.editReply('Status Stop Command');

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -1,44 +1,15 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const { MessageActionRow, MessageButton } = require('discord.js');
-const { getBattleRoyalePubs, getBattleRoyaleRanked } = require('../../adapters');
-const { nessieLogo } = require('../../constants');
-const Scheduler = require('../../scheduler');
 
-const getMapUrl = (map) => {
-  switch (map) {
-    case 'kings_canyon_rotation':
-      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544176815099954/kings_canyon.jpg';
-    case 'Kings Canyon':
-      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544176815099954/kings_canyon.jpg';
-    case 'worlds_edge_rotation':
-      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544195488129034/worlds_edge.jpg';
-    case `World's Edge`:
-      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544195488129034/worlds_edge.jpg';
-    case 'olympus_rotation':
-      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544165163323402/olympus_nessie.jpg';
-    case 'Olympus':
-      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544165163323402/olympus_nessie.jpg';
-    case 'Storm Point':
-      return 'https://cdn.discordapp.com/attachments/896544134813319168/911631835300237332/storm_point_nessie.jpg';
-    case 'storm_point_rotation':
-      return 'https://cdn.discordapp.com/attachments/896544134813319168/911631835300237332/storm_point_nessie.jpg';
-    default:
-      return '';
-  }
-};
-const getCountdown = (timer) => {
-  const countdown = timer.split(':');
-  const isOverAnHour = countdown[0] && countdown[0] !== '00';
-  return `${isOverAnHour ? `${countdown[0]} hr ` : ''}${countdown[1]} mins ${countdown[2]} secs`;
-};
-const generateHelpEmbed = () => {
+const generateHelpEmbed = () => {};
+const sendHelpInteraction = async (interaction) => {
   const embedData = {
     title: 'Status | Help',
     description:
       'This command will send automatic updates of Apex Legends Maps in 2 new channels: *apex-pubs* and *apex-ranked*\n\nUpdates occur **every 15 minutes**\n\nRequires:\n• Manage Channel Permissions\n• Send Message Permissions\n• Only Admins can enable automatic status',
     color: 3447003,
   };
-  return [embedData];
+  return await interaction.editReply({ embeds: [embedData] });
 };
 const sendStartInteraction = async (interaction) => {
   const embedData = {
@@ -61,55 +32,7 @@ const sendStartInteraction = async (interaction) => {
         .setStyle('SUCCESS')
     );
 
-  await interaction.editReply({ components: [row], embeds: [embedData] });
-};
-const generatePubsEmbed = (data) => {
-  const embedData = {
-    title: 'Battle Royale | Pubs',
-    color: 3066993,
-    image: {
-      url: getMapUrl(data.current.code),
-    },
-    timestamp: Date.now() + data.current.remainingSecs * 1000,
-    footer: {
-      text: `Next Map: ${data.next.map}`,
-    },
-    fields: [
-      {
-        name: 'Current map',
-        value: '```fix\n\n' + data.current.map + '```',
-        inline: true,
-      },
-      {
-        name: 'Time left',
-        value: '```xl\n\n' + getCountdown(data.current.remainingTimer) + '```',
-        inline: true,
-      },
-    ],
-  };
-  return [embedData];
-};
-const generateRankedEmbed = (data) => {
-  const embedData = {
-    title: 'Battle Royale | Ranked',
-    color: 7419530,
-    image: {
-      url: getMapUrl(data.current.map),
-    },
-    fields: [
-      {
-        name: 'Current map',
-        value: '```fix\n\n' + data.current.map + '```',
-        inline: true,
-      },
-      {
-        name: 'Time left',
-        value: '```xl\n\n' + getCountdown(data.current.remainingTimer) + '```',
-        inline: true,
-      },
-    ],
-  };
-  return [embedData];
+  return await interaction.editReply({ components: [row], embeds: [embedData] });
 };
 module.exports = {
   data: new SlashCommandBuilder()
@@ -131,38 +54,12 @@ module.exports = {
       await interaction.deferReply();
       switch (statusOption) {
         case 'help':
-          const embedToSend = generateHelpEmbed();
-          await interaction.editReply({ embeds: embedToSend });
+          return await sendHelpInteraction(interaction);
           break;
         case 'start':
-          await sendStartInteraction(interaction);
-          // const pubsData = await getBattleRoyalePubs();
-          // const rankedData = await getBattleRoyaleRanked();
-          // const pubsEmbed = generatePubsEmbed(pubsData);
-          // const rankedEmbed = generateRankedEmbed(rankedData);
-          // // //Creates a category channel for better readability
-          // const statusCategory = await interaction.guild.channels.create(
-          //   'Apex Legends Map Status',
-          //   {
-          //     type: 'GUILD_CATEGORY',
-          //   }
-          // );
-          // //Creates the status channnel for br
-          // const statusPubsChannel = await interaction.guild.channels.create('apex-pubs', {
-          //   parent: statusCategory,
-          // });
-          // const statusRankedChannel = await interaction.guild.channels.create('apex-ranked', {
-          //   parent: statusCategory,
-          // });
-          // const statusPubsMessage = await statusPubsChannel.send({ embeds: pubsEmbed }); //Sends initial br embed in status channel
-          // const statusRankedMessage = await statusRankedChannel.send({ embeds: rankedEmbed });
-          // await interaction.editReply(
-          //   `Created map status at ${statusPubsChannel} and ${statusRankedChannel}`
-          // ); //Sends success message in channel where command got instantiated
-          break;
+          return await sendStartInteraction(interaction);
         case 'stop':
-          await interaction.editReply('Status Stop Command');
-          break;
+          return await interaction.editReply('Status Stop Command');
       }
     } catch (error) {
       console.log(error);

--- a/events.js
+++ b/events.js
@@ -89,26 +89,29 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
   nessie.on('messageCreate', async (message) => {});
 
   nessie.on('interactionCreate', async (interaction) => {
-    if (!interaction.isCommand() || !interaction.inGuild()) return; //Only respond in server channels or if it's an actual command
-    const { commandName } = interaction;
-    await appCommands[commandName].execute({ interaction, nessie, mixpanel });
-    /**
-     * Send event information to mixpanel for application commands
-     * This is for general commands that do not require arguments
-     * We can't do this here as we can only get the options within the command execution itself
-     * Hence, we have a separate handler for these commands in their own files instead of here
-     * TODO: Refactor conditional in the future, probably a better way to check since this isn't scalable
-     */
-    if (commandName !== 'br' && commandName !== 'arenas') {
-      sendMixpanelEvent(
-        interaction.user,
-        interaction.channel,
-        interaction.guild,
-        commandName,
-        mixpanel,
-        null,
-        true
-      );
+    if (!interaction.inGuild()) return; //Only respond in server channels or if it's an actual command
+
+    if (interaction.isCommand()) {
+      const { commandName } = interaction;
+      await appCommands[commandName].execute({ interaction, nessie, mixpanel });
+      /**
+       * Send event information to mixpanel for application commands
+       * This is for general commands that do not require arguments
+       * We can't do this here as we can only get the options within the command execution itself
+       * Hence, we have a separate handler for these commands in their own files instead of here
+       * TODO: Refactor conditional in the future, probably a better way to check since this isn't scalable
+       */
+      if (commandName !== 'br' && commandName !== 'arenas') {
+        sendMixpanelEvent(
+          interaction.user,
+          interaction.channel,
+          interaction.guild,
+          commandName,
+          mixpanel,
+          null,
+          true
+        );
+      }
     }
   });
 };


### PR DESCRIPTION
#### Context
Create Status application commands and its relevant subcommands. Also added the UI elements for each status command. Apparently Discord doesn't allow the base command to be called when subcommands are involved; it becomes a sort of folder instead of an actual command. I.e. `/status` can't be called and only allow `status xyz`. A lil bit weird but I ain't complaining.

Structure of the status command:
- /status help
- /status start
- /status stop

<img width="509" alt="image" src="https://user-images.githubusercontent.com/42207245/167462637-50b01b6d-f4b5-4435-8aeb-214362047d04.png">
<img width="539" alt="image" src="https://user-images.githubusercontent.com/42207245/167462529-c2b0e9ee-da9c-4137-a3e1-bc12952e50ce.png">
<img width="552" alt="image" src="https://user-images.githubusercontent.com/42207245/167462566-ef248733-0f8b-4a52-8a8a-6cd2f8dd2d22.png">
<img width="544" alt="image" src="https://user-images.githubusercontent.com/42207245/167462602-d4711b86-1187-4546-9f8a-7a9ab4b6a681.png">

#### Change
- Create status application command
- Create subcommands for help, start and stop
- Create interaction replies for each subcommand
- Remove status channel implementation

#### Considerations
This was initially going to be all the UI elements of every interaction but when I started to wire up the buttons I realised that was going to a big boi change. Gonna continue the status interactions in another pr