### PR TITLE
Wire up status start

### DIFF
--- a/adapters.js
+++ b/adapters.js
@@ -93,3 +93,10 @@ exports.getControlPubs = async () => {
   console.log(data);
   return data;
 };
+exports.getRotationData = async () => {
+  const data = await axios.get(url).then((response) => {
+    return response.data;
+  });
+  console.log(data);
+  return data;
+};

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -64,6 +64,20 @@ const sendStopInteraction = async (interaction) => {
 
   return await interaction.editReply({ components: [row], embeds: [embedData] });
 };
+const generatePubsStatusEmbeds = (data) => {
+  const battleRoyaleEmbed = generatePubsEmbed(data.battle_royale);
+  const arenasEmbed = generatePubsEmbed(data.arenas, 'Arenas');
+  const informationEmbed = {
+    description:
+      '**Updates occur every 15 minutes**. This feature is currently in beta! For feedback and bug reports, feel free to drop them in the [support server](https://discord.com/invite/47Ccgz9jA4)!',
+    color: 3066993,
+    timestamp: Date.now(),
+    footer: {
+      text: 'Last Update',
+    },
+  };
+  return [informationEmbed, battleRoyaleEmbed, arenasEmbed];
+};
 const createStatusChannel = async ({ nessie, interaction }) => {
   interaction.deferUpdate();
   try {
@@ -73,7 +87,7 @@ const createStatusChannel = async ({ nessie, interaction }) => {
     };
     await interaction.message.edit({ embeds: [embedLoading], components: [] });
     const rotationData = await getRotationData();
-    const pubsEmbed = generatePubsEmbed(rotationData.battle_royale);
+    const statusPubsEmbed = generatePubsStatusEmbeds(rotationData);
     const rankedEmbed = generateRankedEmbed(rotationData.ranked);
     // //Creates a category channel for better readability
     const statusCategory = await interaction.guild.channels.create('Apex Legends Map Status', {
@@ -86,7 +100,7 @@ const createStatusChannel = async ({ nessie, interaction }) => {
     const statusRankedChannel = await interaction.guild.channels.create('apex-ranked', {
       parent: statusCategory,
     });
-    const statusPubsMessage = await statusPubsChannel.send({ embeds: pubsEmbed }); //Sends initial br embed in status channel
+    const statusPubsMessage = await statusPubsChannel.send({ embeds: statusPubsEmbed }); //Sends initial br embed in status channel
     const statusRankedMessage = await statusRankedChannel.send({ embeds: rankedEmbed });
     const embedSuccess = {
       description: `Created map status at ${statusPubsChannel} and ${statusRankedChannel}`,

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -1,5 +1,6 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const { MessageActionRow, MessageButton } = require('discord.js');
+const { getBattleRoyalePubs, getBattleRoyaleRanked } = require('../../adapters');
 
 const sendHelpInteraction = async (interaction) => {
   const embedData = {
@@ -56,7 +57,130 @@ const sendStopInteraction = async (interaction) => {
 
   return await interaction.editReply({ components: [row], embeds: [embedData] });
 };
+/**
+ * Gets url link image for each br map
+ * Using custom images as the image links sent by API are desaturated for some reason
+ * Currently hosted scuffly in discord itself; might want to think of hosting it in cloudfront in the future
+ */
+const getMapUrl = (map) => {
+  switch (map) {
+    case 'kings_canyon_rotation':
+      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544176815099954/kings_canyon.jpg';
+    case 'Kings Canyon':
+      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544176815099954/kings_canyon.jpg';
+    case 'worlds_edge_rotation':
+      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544195488129034/worlds_edge.jpg';
+    case `World's Edge`:
+      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544195488129034/worlds_edge.jpg';
+    case 'olympus_rotation':
+      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544165163323402/olympus_nessie.jpg';
+    case 'Olympus':
+      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544165163323402/olympus_nessie.jpg';
+    case 'Storm Point':
+      return 'https://cdn.discordapp.com/attachments/896544134813319168/911631835300237332/storm_point_nessie.jpg';
+    case 'storm_point_rotation':
+      return 'https://cdn.discordapp.com/attachments/896544134813319168/911631835300237332/storm_point_nessie.jpg';
+    default:
+      return '';
+  }
+};
+/**
+ * Display the time left in a more aethestically manner
+ * API returns in the form hr:min:sec (01:02:03)
+ * Function returns hr hrs min mins sec secs (01 hrs 02 mins 03 secs);
+ * Might want to think of using the number of remaining seconds instead of splitting the timer string in the future
+ */
+const getCountdown = (timer) => {
+  const countdown = timer.split(':');
+  const isOverAnHour = countdown[0] && countdown[0] !== '00';
+  const isOverADay = countdown[0] && parseInt(countdown[0]) >= 24;
 
+  //Since ranked br is usually one map for the whole split, good to show days as well rather than just the usual hours
+  if (isOverADay) {
+    const countdownDays = parseInt(countdown[0]) / 24;
+    const countdownHours = parseInt(countdown[0]) % 24;
+    return `${Math.floor(countdownDays)} days ${countdownHours} hrs ${countdown[1]} mins`;
+  }
+  return `${isOverAnHour ? `${countdown[0]} hr ` : ''}${countdown[1]} mins ${countdown[2]} secs`;
+};
+const generatePubsEmbed = (data) => {
+  const embedData = {
+    title: 'Battle Royale | Pubs',
+    color: 3066993,
+    image: {
+      url: getMapUrl(data.current.code),
+    },
+    timestamp: Date.now() + data.current.remainingSecs * 1000,
+    footer: {
+      text: `Next Map: ${data.next.map}`,
+    },
+    fields: [
+      {
+        name: 'Current map',
+        value: '```fix\n\n' + data.current.map + '```',
+        inline: true,
+      },
+      {
+        name: 'Time left',
+        value: '```xl\n\n' + getCountdown(data.current.remainingTimer) + '```',
+        inline: true,
+      },
+    ],
+  };
+  return [embedData];
+};
+const generateRankedEmbed = (data) => {
+  const embedData = {
+    title: 'Battle Royale | Ranked',
+    color: 7419530,
+    image: {
+      url: getMapUrl(data.current.map),
+    },
+    fields: [
+      {
+        name: 'Current map',
+        value: '```fix\n\n' + data.current.map + '```',
+        inline: true,
+      },
+      {
+        name: 'Time left',
+        value: '```xl\n\n' + getCountdown(data.current.remainingTimer) + '```',
+        inline: true,
+      },
+    ],
+  };
+  return [embedData];
+};
+const createStatusChannel = async (interaction) => {
+  interaction.deferUpdate();
+  const embedLoading = {
+    description: `Loading status channels...`,
+    color: 16776960,
+  };
+  await interaction.message.edit({ embeds: [embedLoading], components: [] }); //Sends success message in channel where command got instantiated
+  const pubsData = await getBattleRoyalePubs();
+  const rankedData = await getBattleRoyaleRanked();
+  const pubsEmbed = generatePubsEmbed(pubsData);
+  const rankedEmbed = generateRankedEmbed(rankedData);
+  // //Creates a category channel for better readability
+  const statusCategory = await interaction.guild.channels.create('Apex Legends Map Status', {
+    type: 'GUILD_CATEGORY',
+  });
+  //Creates the status channnel for br
+  const statusPubsChannel = await interaction.guild.channels.create('apex-pubs', {
+    parent: statusCategory,
+  });
+  const statusRankedChannel = await interaction.guild.channels.create('apex-ranked', {
+    parent: statusCategory,
+  });
+  const statusPubsMessage = await statusPubsChannel.send({ embeds: pubsEmbed }); //Sends initial br embed in status channel
+  const statusRankedMessage = await statusRankedChannel.send({ embeds: rankedEmbed });
+  const embedSuccess = {
+    description: `Created map status at ${statusPubsChannel} and ${statusRankedChannel}`,
+    color: 3066993,
+  };
+  await interaction.message.edit({ embeds: [embedSuccess], components: [] }); //Sends success message in channel where command got instantiated
+};
 module.exports = {
   /**
    * Creates Status application command with relevant subcommands
@@ -102,4 +226,5 @@ module.exports = {
       console.log(error);
     }
   },
+  createStatusChannel,
 };

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const { MessageActionRow, MessageButton } = require('discord.js');
-const { getBattleRoyalePubs, getBattleRoyaleRanked } = require('../../adapters');
+const { getBattleRoyalePubs, getBattleRoyaleRanked, getRotationData } = require('../../adapters');
 const {
   generatePubsEmbed,
   generateRankedEmbed,
@@ -72,10 +72,9 @@ const createStatusChannel = async ({ nessie, interaction }) => {
       color: 16776960,
     };
     await interaction.message.edit({ embeds: [embedLoading], components: [] });
-    const pubsData = await getBattleRoyalePubs();
-    const rankedData = await getBattleRoyaleRanked();
-    const pubsEmbed = generatePubsEmbed(pubsData);
-    const rankedEmbed = generateRankedEmbed(rankedData);
+    const rotationData = await getRotationData();
+    const pubsEmbed = generatePubsEmbed(rotationData.battle_royale);
+    const rankedEmbed = generateRankedEmbed(rotationData.ranked);
     // //Creates a category channel for better readability
     const statusCategory = await interaction.guild.channels.create('Apex Legends Map Status', {
       type: 'GUILD_CATEGORY',

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -70,7 +70,7 @@ const generatePubsStatusEmbeds = (data) => {
   const informationEmbed = {
     description:
       '**Updates occur every 15 minutes**. This feature is currently in beta! For feedback and bug reports, feel free to drop them in the [support server](https://discord.com/invite/47Ccgz9jA4)!',
-    color: 16776960,
+    color: 3447003,
     timestamp: Date.now(),
     footer: {
       text: 'Last Update',
@@ -84,7 +84,7 @@ const generateRankedStatusEmbeds = (data) => {
   const informationEmbed = {
     description:
       '**Updates occur every 15 minutes**. This feature is currently in beta! For feedback and bug reports, feel free to drop them in the [support server](https://discord.com/invite/47Ccgz9jA4)!',
-    color: 16776960,
+    color: 3447003,
     timestamp: Date.now(),
     footer: {
       text: 'Last Update',

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -71,7 +71,7 @@ const createStatusChannel = async ({ nessie, interaction }) => {
       description: `Loading status channels...`,
       color: 16776960,
     };
-    await interaction.message.edit({ embeds: [embedLoading], components: [] }); //Sends success message in channel where command got instantiated
+    await interaction.message.edit({ embeds: [embedLoading], components: [] });
     const pubsData = await getBattleRoyalePubs();
     const rankedData = await getBattleRoyaleRanked();
     const pubsEmbed = generatePubsEmbed(pubsData);
@@ -97,6 +97,25 @@ const createStatusChannel = async ({ nessie, interaction }) => {
   } catch (error) {
     const uuid = uuidv4();
     const type = 'Status Start Button';
+    const errorEmbed = generateErrorEmbed(
+      'Oops something went wrong! D: Try again in a bit!',
+      uuid
+    );
+    await interaction.message.edit({ embeds: errorEmbed, components: [] });
+    await sendErrorLog({ nessie, error, interaction, type, uuid });
+  }
+};
+const cancelStatusStart = async ({ nessie, interaction }) => {
+  interaction.deferUpdate();
+  try {
+    const embedSuccess = {
+      description: 'Cancelled automated map status setup',
+      color: 16711680,
+    };
+    await interaction.message.edit({ embeds: [embedSuccess], components: [] });
+  } catch (error) {
+    const uuid = uuidv4();
+    const type = 'Status Cancel Button';
     const errorEmbed = generateErrorEmbed(
       'Oops something went wrong! D: Try again in a bit!',
       uuid
@@ -150,4 +169,5 @@ module.exports = {
     }
   },
   createStatusChannel,
+  cancelStatusStart,
 };

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -1,6 +1,7 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const { MessageActionRow, MessageButton } = require('discord.js');
 const { getBattleRoyalePubs, getBattleRoyaleRanked } = require('../../adapters');
+const { generatePubsEmbed, generateRankedEmbed } = require('../../helpers');
 
 const sendHelpInteraction = async (interaction) => {
   const embedData = {
@@ -56,100 +57,6 @@ const sendStopInteraction = async (interaction) => {
     );
 
   return await interaction.editReply({ components: [row], embeds: [embedData] });
-};
-/**
- * Gets url link image for each br map
- * Using custom images as the image links sent by API are desaturated for some reason
- * Currently hosted scuffly in discord itself; might want to think of hosting it in cloudfront in the future
- */
-const getMapUrl = (map) => {
-  switch (map) {
-    case 'kings_canyon_rotation':
-      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544176815099954/kings_canyon.jpg';
-    case 'Kings Canyon':
-      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544176815099954/kings_canyon.jpg';
-    case 'worlds_edge_rotation':
-      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544195488129034/worlds_edge.jpg';
-    case `World's Edge`:
-      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544195488129034/worlds_edge.jpg';
-    case 'olympus_rotation':
-      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544165163323402/olympus_nessie.jpg';
-    case 'Olympus':
-      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544165163323402/olympus_nessie.jpg';
-    case 'Storm Point':
-      return 'https://cdn.discordapp.com/attachments/896544134813319168/911631835300237332/storm_point_nessie.jpg';
-    case 'storm_point_rotation':
-      return 'https://cdn.discordapp.com/attachments/896544134813319168/911631835300237332/storm_point_nessie.jpg';
-    default:
-      return '';
-  }
-};
-/**
- * Display the time left in a more aethestically manner
- * API returns in the form hr:min:sec (01:02:03)
- * Function returns hr hrs min mins sec secs (01 hrs 02 mins 03 secs);
- * Might want to think of using the number of remaining seconds instead of splitting the timer string in the future
- */
-const getCountdown = (timer) => {
-  const countdown = timer.split(':');
-  const isOverAnHour = countdown[0] && countdown[0] !== '00';
-  const isOverADay = countdown[0] && parseInt(countdown[0]) >= 24;
-
-  //Since ranked br is usually one map for the whole split, good to show days as well rather than just the usual hours
-  if (isOverADay) {
-    const countdownDays = parseInt(countdown[0]) / 24;
-    const countdownHours = parseInt(countdown[0]) % 24;
-    return `${Math.floor(countdownDays)} days ${countdownHours} hrs ${countdown[1]} mins`;
-  }
-  return `${isOverAnHour ? `${countdown[0]} hr ` : ''}${countdown[1]} mins ${countdown[2]} secs`;
-};
-const generatePubsEmbed = (data) => {
-  const embedData = {
-    title: 'Battle Royale | Pubs',
-    color: 3066993,
-    image: {
-      url: getMapUrl(data.current.code),
-    },
-    timestamp: Date.now() + data.current.remainingSecs * 1000,
-    footer: {
-      text: `Next Map: ${data.next.map}`,
-    },
-    fields: [
-      {
-        name: 'Current map',
-        value: '```fix\n\n' + data.current.map + '```',
-        inline: true,
-      },
-      {
-        name: 'Time left',
-        value: '```xl\n\n' + getCountdown(data.current.remainingTimer) + '```',
-        inline: true,
-      },
-    ],
-  };
-  return [embedData];
-};
-const generateRankedEmbed = (data) => {
-  const embedData = {
-    title: 'Battle Royale | Ranked',
-    color: 7419530,
-    image: {
-      url: getMapUrl(data.current.map),
-    },
-    fields: [
-      {
-        name: 'Current map',
-        value: '```fix\n\n' + data.current.map + '```',
-        inline: true,
-      },
-      {
-        name: 'Time left',
-        value: '```xl\n\n' + getCountdown(data.current.remainingTimer) + '```',
-        inline: true,
-      },
-    ],
-  };
-  return [embedData];
 };
 const createStatusChannel = async (interaction) => {
   interaction.deferUpdate();
@@ -216,7 +123,6 @@ module.exports = {
       switch (statusOption) {
         case 'help':
           return await sendHelpInteraction(interaction);
-          break;
         case 'start':
           return await sendStartInteraction(interaction);
         case 'stop':

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -70,7 +70,21 @@ const generatePubsStatusEmbeds = (data) => {
   const informationEmbed = {
     description:
       '**Updates occur every 15 minutes**. This feature is currently in beta! For feedback and bug reports, feel free to drop them in the [support server](https://discord.com/invite/47Ccgz9jA4)!',
-    color: 3066993,
+    color: 16776960,
+    timestamp: Date.now(),
+    footer: {
+      text: 'Last Update',
+    },
+  };
+  return [informationEmbed, battleRoyaleEmbed, arenasEmbed];
+};
+const generateRankedStatusEmbeds = (data) => {
+  const battleRoyaleEmbed = generateRankedEmbed(data.ranked);
+  const arenasEmbed = generateRankedEmbed(data.arenasRanked, 'Arenas');
+  const informationEmbed = {
+    description:
+      '**Updates occur every 15 minutes**. This feature is currently in beta! For feedback and bug reports, feel free to drop them in the [support server](https://discord.com/invite/47Ccgz9jA4)!',
+    color: 16776960,
     timestamp: Date.now(),
     footer: {
       text: 'Last Update',
@@ -88,20 +102,20 @@ const createStatusChannel = async ({ nessie, interaction }) => {
     await interaction.message.edit({ embeds: [embedLoading], components: [] });
     const rotationData = await getRotationData();
     const statusPubsEmbed = generatePubsStatusEmbeds(rotationData);
-    const rankedEmbed = generateRankedEmbed(rotationData.ranked);
+    const statusRankedEmbed = generateRankedStatusEmbeds(rotationData);
     // //Creates a category channel for better readability
     const statusCategory = await interaction.guild.channels.create('Apex Legends Map Status', {
       type: 'GUILD_CATEGORY',
     });
-    //Creates the status channnel for br
+    //Creates the status channnel for pubs and ranked
     const statusPubsChannel = await interaction.guild.channels.create('apex-pubs', {
       parent: statusCategory,
     });
     const statusRankedChannel = await interaction.guild.channels.create('apex-ranked', {
       parent: statusCategory,
     });
-    const statusPubsMessage = await statusPubsChannel.send({ embeds: statusPubsEmbed }); //Sends initial br embed in status channel
-    const statusRankedMessage = await statusRankedChannel.send({ embeds: rankedEmbed });
+    await statusPubsChannel.send({ embeds: statusPubsEmbed }); //Sends initial pubs embed in status channel
+    await statusRankedChannel.send({ embeds: statusRankedEmbed }); //Sends initial ranked embed in status channel
     const embedSuccess = {
       description: `Created map status at ${statusPubsChannel} and ${statusRankedChannel}`,
       color: 3066993,

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -92,6 +92,28 @@ const generateRankedStatusEmbeds = (data) => {
   };
   return [informationEmbed, battleRoyaleEmbed, arenasEmbed];
 };
+const generateStatusEmbeds = (data) => {
+  const battleRoyalePubsEmbed = generatePubsEmbed(data.battle_royale);
+  const arenasPubsEmbed = generatePubsEmbed(data.arenas, 'Arenas');
+  const battleRoyaleRankedEmbed = generateRankedEmbed(data.ranked);
+  const arenasRankedEmbed = generateRankedEmbed(data.arenasRanked, 'Arenas');
+  const informationEmbed = {
+    description:
+      '**Updates occur every 15 minutes**. This feature is currently in beta! For feedback and bug reports, feel free to drop them in the [support server](https://discord.com/invite/47Ccgz9jA4)!',
+    color: 3447003,
+    timestamp: Date.now(),
+    footer: {
+      text: 'Last Update',
+    },
+  };
+  return [
+    informationEmbed,
+    arenasRankedEmbed,
+    battleRoyaleRankedEmbed,
+    arenasPubsEmbed,
+    battleRoyalePubsEmbed,
+  ];
+};
 const createStatusChannel = async ({ nessie, interaction }) => {
   interaction.deferUpdate();
   try {
@@ -101,23 +123,33 @@ const createStatusChannel = async ({ nessie, interaction }) => {
     };
     await interaction.message.edit({ embeds: [embedLoading], components: [] });
     const rotationData = await getRotationData();
+
     const statusPubsEmbed = generatePubsStatusEmbeds(rotationData);
     const statusRankedEmbed = generateRankedStatusEmbeds(rotationData);
     // //Creates a category channel for better readability
     const statusCategory = await interaction.guild.channels.create('Apex Legends Map Status', {
       type: 'GUILD_CATEGORY',
     });
-    //Creates the status channnel for pubs and ranked
-    const statusPubsChannel = await interaction.guild.channels.create('apex-pubs', {
+    // //Creates the status channnel for pubs and ranked
+    // const statusPubsChannel = await interaction.guild.channels.create('apex-pubs', {
+    //   parent: statusCategory,
+    // });
+    // const statusRankedChannel = await interaction.guild.channels.create('apex-ranked', {
+    //   parent: statusCategory,
+    // });
+    // await statusPubsChannel.send({ embeds: statusPubsEmbed }); //Sends initial pubs embed in status channel
+    // await statusRankedChannel.send({ embeds: statusRankedEmbed }); //Sends initial ranked embed in status channel
+    // const embedSuccess = {
+    //   description: `Created map status at ${statusPubsChannel} and ${statusRankedChannel}`,
+    //   color: 3066993,
+    // };
+    const statusChannel = await interaction.guild.channels.create('apex-maps-status', {
       parent: statusCategory,
     });
-    const statusRankedChannel = await interaction.guild.channels.create('apex-ranked', {
-      parent: statusCategory,
-    });
-    await statusPubsChannel.send({ embeds: statusPubsEmbed }); //Sends initial pubs embed in status channel
-    await statusRankedChannel.send({ embeds: statusRankedEmbed }); //Sends initial ranked embed in status channel
+    const statusEmbed = generateStatusEmbeds(rotationData);
+    await statusChannel.send({ embeds: statusEmbed });
     const embedSuccess = {
-      description: `Created map status at ${statusPubsChannel} and ${statusRankedChannel}`,
+      description: `Created map status at ${statusChannel}`,
       color: 3066993,
     };
     await interaction.message.edit({ embeds: [embedSuccess], components: [] }); //Sends success message in channel where command got instantiated

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -9,6 +9,7 @@ const {
 } = require('../../helpers');
 const { v4: uuidv4 } = require('uuid');
 
+//----- Status Application Command Replies -----//
 const sendHelpInteraction = async (interaction) => {
   const embedData = {
     title: 'Status | Help',
@@ -64,6 +65,12 @@ const sendStopInteraction = async (interaction) => {
 
   return await interaction.editReply({ components: [row], embeds: [embedData] });
 };
+//----- Status Functions/Interactions -----//
+/**
+ * Generates relevant embeds for the status pubs channel
+ * Currently only showing battle royale and arenas
+ * Might put control in after double checking if it's still up in season 13
+ */
 const generatePubsStatusEmbeds = (data) => {
   const battleRoyaleEmbed = generatePubsEmbed(data.battle_royale);
   const arenasEmbed = generatePubsEmbed(data.arenas, 'Arenas');
@@ -78,6 +85,10 @@ const generatePubsStatusEmbeds = (data) => {
   };
   return [informationEmbed, battleRoyaleEmbed, arenasEmbed];
 };
+/**
+ * Generates relevant embeds for the status ranked channel
+ * Currently only showing battle royale and arenas
+ */
 const generateRankedStatusEmbeds = (data) => {
   const battleRoyaleEmbed = generateRankedEmbed(data.ranked);
   const arenasEmbed = generateRankedEmbed(data.arenasRanked, 'Arenas');
@@ -92,64 +103,52 @@ const generateRankedStatusEmbeds = (data) => {
   };
   return [informationEmbed, battleRoyaleEmbed, arenasEmbed];
 };
-const generateStatusEmbeds = (data) => {
-  const battleRoyalePubsEmbed = generatePubsEmbed(data.battle_royale);
-  const arenasPubsEmbed = generatePubsEmbed(data.arenas, 'Arenas');
-  const battleRoyaleRankedEmbed = generateRankedEmbed(data.ranked);
-  const arenasRankedEmbed = generateRankedEmbed(data.arenasRanked, 'Arenas');
-  const informationEmbed = {
-    description:
-      '**Updates occur every 15 minutes**. This feature is currently in beta! For feedback and bug reports, feel free to drop them in the [support server](https://discord.com/invite/47Ccgz9jA4)!',
-    color: 3447003,
-    timestamp: Date.now(),
-    footer: {
-      text: 'Last Update',
-    },
-  };
-  return [
-    informationEmbed,
-    arenasRankedEmbed,
-    battleRoyaleRankedEmbed,
-    arenasPubsEmbed,
-    battleRoyalePubsEmbed,
-  ];
-};
+/**
+ * Handler for initialising the process of map status
+ * Gets called when a user clicks the confirm button of the /status start reply
+ * Main steps upon button click:
+ * - Edits initial message with a loading state
+ * - Calls the API for the rotation data
+ * - Create embeds for each status channel
+ * - Creates a category channel and 2 new text channels under it
+ * - Sends embeds to respective channels and edits initial message with a success message
+ * -
+ * TODO: Start the auto-update scheduler
+ * TODO: Create tables in database to store status data
+ */
 const createStatusChannel = async ({ nessie, interaction }) => {
   interaction.deferUpdate();
   try {
+    /**
+     * Since we defer the update, discord's loading state isn't long enough to last until every promise is done
+     * To solve that, we'll edit the initial message with a loading embed
+     * This is so that we prevent any extra clicks from users on the buttons
+     **/
     const embedLoading = {
       description: `Loading status channels...`,
       color: 16776960,
     };
     await interaction.message.edit({ embeds: [embedLoading], components: [] });
-    const rotationData = await getRotationData();
 
+    const rotationData = await getRotationData();
     const statusPubsEmbed = generatePubsStatusEmbeds(rotationData);
     const statusRankedEmbed = generateRankedStatusEmbeds(rotationData);
+
     // //Creates a category channel for better readability
     const statusCategory = await interaction.guild.channels.create('Apex Legends Map Status', {
       type: 'GUILD_CATEGORY',
     });
-    // //Creates the status channnel for pubs and ranked
-    // const statusPubsChannel = await interaction.guild.channels.create('apex-pubs', {
-    //   parent: statusCategory,
-    // });
-    // const statusRankedChannel = await interaction.guild.channels.create('apex-ranked', {
-    //   parent: statusCategory,
-    // });
-    // await statusPubsChannel.send({ embeds: statusPubsEmbed }); //Sends initial pubs embed in status channel
-    // await statusRankedChannel.send({ embeds: statusRankedEmbed }); //Sends initial ranked embed in status channel
-    // const embedSuccess = {
-    //   description: `Created map status at ${statusPubsChannel} and ${statusRankedChannel}`,
-    //   color: 3066993,
-    // };
-    const statusChannel = await interaction.guild.channels.create('apex-maps-status', {
+    //Creates the status channnel for pubs and ranked
+    const statusPubsChannel = await interaction.guild.channels.create('apex-pubs', {
       parent: statusCategory,
     });
-    const statusEmbed = generateStatusEmbeds(rotationData);
-    await statusChannel.send({ embeds: statusEmbed });
+    const statusRankedChannel = await interaction.guild.channels.create('apex-ranked', {
+      parent: statusCategory,
+    });
+    await statusPubsChannel.send({ embeds: statusPubsEmbed }); //Sends initial pubs embed in status channel
+    await statusRankedChannel.send({ embeds: statusRankedEmbed }); //Sends initial ranked embed in status channel
     const embedSuccess = {
-      description: `Created map status at ${statusChannel}`,
+      description: `Created map status at ${statusPubsChannel} and ${statusRankedChannel}`,
       color: 3066993,
     };
     await interaction.message.edit({ embeds: [embedSuccess], components: [] }); //Sends success message in channel where command got instantiated
@@ -164,6 +163,11 @@ const createStatusChannel = async ({ nessie, interaction }) => {
     await sendErrorLog({ nessie, error, interaction, type, uuid });
   }
 };
+/**
+ * Handler for cancelling the setup of /status start
+ * Gets called when a user clicks the cancel button of the /status start reply
+ * Pretty straightforward; we just edit the initial message with a cancel message
+ */
 const cancelStatusStart = async ({ nessie, interaction }) => {
   interaction.deferUpdate();
   try {

--- a/events.js
+++ b/events.js
@@ -117,7 +117,7 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
     if (interaction.isButton()) {
       switch (interaction.customId) {
         case 'statusStart__startButton':
-          await createStatusChannel(interaction);
+          await createStatusChannel({ nessie, interaction });
           break;
       }
     }

--- a/events.js
+++ b/events.js
@@ -23,6 +23,7 @@ const {
   removeServerDataFromNessie,
   pool,
 } = require('./database/handler');
+const { createStatusChannel } = require('./commands/maps/status');
 
 const appCommands = getApplicationCommands(); //Get list of application commands
 
@@ -111,6 +112,13 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
           null,
           true
         );
+      }
+    }
+    if (interaction.isButton()) {
+      switch (interaction.customId) {
+        case 'statusStart__startButton':
+          await createStatusChannel(interaction);
+          break;
       }
     }
   });

--- a/events.js
+++ b/events.js
@@ -23,7 +23,7 @@ const {
   removeServerDataFromNessie,
   pool,
 } = require('./database/handler');
-const { createStatusChannel } = require('./commands/maps/status');
+const { createStatusChannel, cancelStatusStart } = require('./commands/maps/status');
 
 const appCommands = getApplicationCommands(); //Get list of application commands
 
@@ -117,8 +117,9 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
     if (interaction.isButton()) {
       switch (interaction.customId) {
         case 'statusStart__startButton':
-          await createStatusChannel({ nessie, interaction });
-          break;
+          return await createStatusChannel({ nessie, interaction });
+        case 'statusStart__cancelButton':
+          return await cancelStatusStart({ nessie, interaction });
       }
     }
   });

--- a/events.js
+++ b/events.js
@@ -114,6 +114,12 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
         );
       }
     }
+    /**
+     * Since components are also interactions, any user inputs from it go through this listener too
+     * This does prove to be a hassle code readability wise as the handlers for these interactions are now detached from their own files
+     * Tried to make it less ugly tho and house the implementations inside functions and call them here
+     * Will still have to check the customId for each of the buttons here though
+     */
     if (interaction.isButton()) {
       switch (interaction.customId) {
         case 'statusStart__startButton':

--- a/helpers.js
+++ b/helpers.js
@@ -209,6 +209,109 @@ const generateAnnouncementMessage = (prefix) => {
     '```\n'
   );
 };
+/**
+ * Gets url link image for each br map
+ * Using custom images as the image links sent by API are desaturated for some reason
+ * Currently hosted scuffly in discord itself; might want to think of hosting it in cloudfront in the future
+ */
+const getMapUrl = (map) => {
+  switch (map) {
+    case 'kings_canyon_rotation':
+      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544176815099954/kings_canyon.jpg';
+    case 'Kings Canyon':
+      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544176815099954/kings_canyon.jpg';
+    case 'worlds_edge_rotation':
+      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544195488129034/worlds_edge.jpg';
+    case `World's Edge`:
+      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544195488129034/worlds_edge.jpg';
+    case 'olympus_rotation':
+      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544165163323402/olympus_nessie.jpg';
+    case 'Olympus':
+      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544165163323402/olympus_nessie.jpg';
+    case 'Storm Point':
+      return 'https://cdn.discordapp.com/attachments/896544134813319168/911631835300237332/storm_point_nessie.jpg';
+    case 'storm_point_rotation':
+      return 'https://cdn.discordapp.com/attachments/896544134813319168/911631835300237332/storm_point_nessie.jpg';
+    default:
+      return '';
+  }
+};
+/**
+ * Display the time left in a more aethestically manner
+ * API returns in the form hr:min:sec (01:02:03)
+ * Function returns hr hrs min mins sec secs (01 hrs 02 mins 03 secs);
+ * Might want to think of using the number of remaining seconds instead of splitting the timer string in the future
+ */
+const getCountdown = (timer) => {
+  const countdown = timer.split(':');
+  const isOverAnHour = countdown[0] && countdown[0] !== '00';
+  const isOverADay = countdown[0] && parseInt(countdown[0]) >= 24;
+
+  //Since ranked br is usually one map for the whole split, good to show days as well rather than just the usual hours
+  if (isOverADay) {
+    const countdownDays = parseInt(countdown[0]) / 24;
+    const countdownHours = parseInt(countdown[0]) % 24;
+    return `${Math.floor(countdownDays)} days ${countdownHours} hrs ${countdown[1]} mins`;
+  }
+  return `${isOverAnHour ? `${countdown[0]} hr ` : ''}${countdown[1]} mins ${countdown[2]} secs`;
+};
+/**
+ * Embed design for BR Pubs
+ * Added a hack to display the time for next map regardless of timezone
+ * As discord embed has a timestamp propery, I added the remianing milliseconds to the current date
+ */
+const generatePubsEmbed = (data) => {
+  const embedData = {
+    title: 'Battle Royale | Pubs',
+    color: 3066993,
+    image: {
+      url: getMapUrl(data.current.code),
+    },
+    timestamp: Date.now() + data.current.remainingSecs * 1000,
+    footer: {
+      text: `Next Map: ${data.next.map}`,
+    },
+    fields: [
+      {
+        name: 'Current map',
+        value: '```fix\n\n' + data.current.map + '```',
+        inline: true,
+      },
+      {
+        name: 'Time left',
+        value: '```xl\n\n' + getCountdown(data.current.remainingTimer) + '```',
+        inline: true,
+      },
+    ],
+  };
+  return [embedData];
+};
+/**
+ * Embed design for BR Ranked
+ * Fairly simple, don't need any fancy timers and footers
+ */
+const generateRankedEmbed = (data) => {
+  const embedData = {
+    title: 'Battle Royale | Ranked',
+    color: 7419530,
+    image: {
+      url: getMapUrl(data.current.map),
+    },
+    fields: [
+      {
+        name: 'Current map',
+        value: '```fix\n\n' + data.current.map + '```',
+        inline: true,
+      },
+      {
+        name: 'Time left',
+        value: '```xl\n\n' + getCountdown(data.current.remainingTimer) + '```',
+        inline: true,
+      },
+    ],
+  };
+  return [embedData];
+};
 //---------
 module.exports = {
   checkIfInDevelopment,
@@ -219,4 +322,8 @@ module.exports = {
   sendErrorLog,
   generateErrorEmbed,
   generateAnnouncementMessage,
+  getMapUrl,
+  getCountdown,
+  generatePubsEmbed,
+  generateRankedEmbed,
 };

--- a/helpers.js
+++ b/helpers.js
@@ -260,12 +260,12 @@ const getCountdown = (timer) => {
  * Added a hack to display the time for next map regardless of timezone
  * As discord embed has a timestamp propery, I added the remianing milliseconds to the current date
  */
-const generatePubsEmbed = (data) => {
+const generatePubsEmbed = (data, type = 'Battle Royale') => {
   const embedData = {
-    title: 'Battle Royale | Pubs',
+    title: `${type} | Pubs`,
     color: 3066993,
     image: {
-      url: getMapUrl(data.current.code),
+      url: type === 'Battle Royale' ? getMapUrl(data.current.code) : data.current.asset,
     },
     timestamp: Date.now() + data.current.remainingSecs * 1000,
     footer: {
@@ -284,7 +284,7 @@ const generatePubsEmbed = (data) => {
       },
     ],
   };
-  return [embedData];
+  return embedData;
 };
 /**
  * Embed design for BR Ranked

--- a/helpers.js
+++ b/helpers.js
@@ -256,7 +256,7 @@ const getCountdown = (timer) => {
   return `${isOverAnHour ? `${countdown[0]} hr ` : ''}${countdown[1]} mins ${countdown[2]} secs`;
 };
 /**
- * Embed design for BR Pubs
+ * Embed design for any pubs map
  * Added a hack to display the time for next map regardless of timezone
  * As discord embed has a timestamp propery, I added the remianing milliseconds to the current date
  */
@@ -287,7 +287,7 @@ const generatePubsEmbed = (data, type = 'Battle Royale') => {
   return embedData;
 };
 /**
- * Embed design for BR Ranked
+ * Embed design for any ranked map
  * Fairly simple, don't need any fancy timers and footers
  */
 const generateRankedEmbed = (data, type = 'Battle Royale') => {

--- a/helpers.js
+++ b/helpers.js
@@ -290,12 +290,12 @@ const generatePubsEmbed = (data, type = 'Battle Royale') => {
  * Embed design for BR Ranked
  * Fairly simple, don't need any fancy timers and footers
  */
-const generateRankedEmbed = (data) => {
+const generateRankedEmbed = (data, type = 'Battle Royale') => {
   const embedData = {
-    title: 'Battle Royale | Ranked',
+    title: `${type} | Ranked`,
     color: 7419530,
     image: {
-      url: getMapUrl(data.current.map),
+      url: type === 'Battle Royale' ? getMapUrl(data.current.code) : data.current.asset,
     },
     fields: [
       {
@@ -310,7 +310,13 @@ const generateRankedEmbed = (data) => {
       },
     ],
   };
-  return [embedData];
+  if (type === 'Arenas') {
+    embedData.timestamp = Date.now() + data.current.remainingSecs * 1000;
+    embedData.footer = {
+      text: `Next Map: ${data.next.map}`,
+    };
+  }
+  return embedData;
 };
 //---------
 module.exports = {


### PR DESCRIPTION
#### Context
Wire up handlers for starting the automated map status. When a user clicks the confirm button of `/status start`, it'll:
1. Edit initial message with a loading state
2. Call the API for the rotation data
3. Create embeds for each status channel
4. Create a category channel and 2 new text channels under it
5.  Send embeds to respective channels and edits initial message with a success message

Gonna work on setting up the database tables for map status after this. Probably gonna focus on setting all the wiring up first before figuring out the rate limiting stuff
![wire up status start](https://user-images.githubusercontent.com/42207245/167883395-c45b498f-95fb-4f1f-b1cb-217ddb1ddead.gif)
![image](https://user-images.githubusercontent.com/42207245/167880286-7b701a0e-3902-4223-8f76-d7ac2001f995.png)
![image](https://user-images.githubusercontent.com/42207245/167880389-5b93113c-2f41-4cde-91bc-c14aff20fd8b.png)


#### Change
- Wire up confirm status button
- Make map functions as reusable helpers
- Add error handlers for each handler
- Wire up cancel status button
- Add adapter for getting full rotation object

#### Considerations
Dabbled on the idea of using only 1 channel. Albeit the maps being shoved altogether and sacrifice good UI, I can see a reason why people would prefer having everything in one place. It's also less taxing technically as I'll only have to update 1 message per server instead of 2 messages. In the end, I'm going to go with 2 separate channels for now. My gut feeling is telling me to go with my first decision and to choose good UI over potential tech debt

![image](https://user-images.githubusercontent.com/42207245/167880440-4a85c542-f4d2-4080-8b63-25da87acaa77.png)
