### PR TITLE
Retrieve alert messages from channel message

### DIFF
--- a/commands/hub/updates.js
+++ b/commands/hub/updates.js
@@ -2,12 +2,31 @@ const { SlashCommandBuilder } = require('@discordjs/builders');
 const { nessieLogo } = require('../../constants');
 const { version } = require('../../package.json');
 
-const sendUpdatesEmbed = async ({ interaction }) => {
+/**
+ * Send the latest news and updates of Nessie
+ * Initially this was hardcoded here everytime before a release is made
+ * However following the change in error handling getting an alert message from a discord message, I want to carry that over there too
+ * Similar to the error handling, we get the specific message by fetching it through the channel it's in
+ * With that message, we then trim the content inside the code block
+ * An addition is that we also want to show the current update date so I've passed it in the message too wrapped in {}
+ */
+const sendUpdatesEmbed = async ({ nessie, interaction }) => {
+  const alertChannel = nessie.channels.cache.get('973977422699573258');
+  const messageObject = await alertChannel.messages.fetch('973978605044514826');
+
+  const updateMessage = messageObject.content;
+  const updateAlert = updateMessage.substring(
+    updateMessage.indexOf('[') + 4,
+    updateMessage.lastIndexOf(']') - 3
+  );
+  const updateDate = updateMessage.substring(
+    updateMessage.indexOf('{') + 1,
+    updateMessage.lastIndexOf('}')
+  );
   const embed = {
-    title: `v${version} | 15 April 2022`,
+    title: `v${version} | ${updateDate}`,
     color: 3447003,
-    description:
-      "**Battle Royale Ranked Timer**\nJust a quick small update. With the latest release of the apex legends api, it’s now possible to directly show the current timer of battle royale ranked from it. This is a pretty cool change as I’ve opted to not have the timer before as it’s a hassle to manually change the ending dates. However, Nessie’s battle royale ranked command will now show not only the map but also the remaining time left of the split! Go see it now through `/br ranked`\n\nSorry if the updates are not as consistent. Been having a rough couple of weeks mentally and it’s honestly draining trying to get stuff done. No worries though, I’ll get myself back up and running! Had a bad 2 weeks but won’t let it shape the rest of the month/year **(ง •̀ω•́)ง.** That being said, I’ve shelfed the website for now and currently working on the automatic status. Don’t want to give any deadlines but I’ll try to get this cool new feature out by the end of April! Wish me luck :D\n\nThat's about it for now. Stay Classy, Legends\n-----\nFor a full list of previous release notes, check it out [here](https://github.com/vexuas/nessie/releases)!",
+    description: updateAlert,
     thumbnail: {
       url: nessieLogo,
     },
@@ -18,7 +37,7 @@ module.exports = {
   data: new SlashCommandBuilder()
     .setName('updates')
     .setDescription('Displays latest news and updates of Nessie'),
-  async execute({ interaction }) {
-    sendUpdatesEmbed({ interaction });
+  async execute({ nessie, interaction }) {
+    sendUpdatesEmbed({ nessie, interaction });
   },
 };

--- a/commands/maps/arenas.js
+++ b/commands/maps/arenas.js
@@ -125,11 +125,8 @@ module.exports = {
       );
     } catch (error) {
       const uuid = uuidv4();
-      const type = 'Battle Royale';
-      const errorEmbed = generateErrorEmbed(
-        'Oops something went wrong! D: Try again in a bit!',
-        uuid
-      );
+      const type = 'Arenas';
+      const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
       await interaction.editReply({ embeds: errorEmbed });
       await sendErrorLog({ nessie, error, type, interaction, uuid });
     }

--- a/commands/maps/battle-royale.js
+++ b/commands/maps/battle-royale.js
@@ -132,7 +132,6 @@ module.exports = {
     let embed;
     try {
       await interaction.deferReply();
-      throw new Error('Test Error');
       const optionMode = interaction.options.getString('mode');
       switch (optionMode) {
         case 'br_pubs':

--- a/commands/maps/battle-royale.js
+++ b/commands/maps/battle-royale.js
@@ -157,7 +157,7 @@ module.exports = {
     } catch (error) {
       const uuid = uuidv4();
       const type = 'Battle Royale';
-      const errorEmbed = await generateErrorEmbed(error, uuid);
+      const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
       await interaction.editReply({ embeds: errorEmbed });
       await sendErrorLog({ nessie, error, interaction, type, uuid });
     }

--- a/commands/maps/battle-royale.js
+++ b/commands/maps/battle-royale.js
@@ -132,6 +132,7 @@ module.exports = {
     let embed;
     try {
       await interaction.deferReply();
+      throw new Error('Test Error');
       const optionMode = interaction.options.getString('mode');
       switch (optionMode) {
         case 'br_pubs':
@@ -156,10 +157,7 @@ module.exports = {
     } catch (error) {
       const uuid = uuidv4();
       const type = 'Battle Royale';
-      const errorEmbed = generateErrorEmbed(
-        'Oops something went wrong! D: Try again in a bit!',
-        uuid
-      );
+      const errorEmbed = await generateErrorEmbed(error, uuid);
       await interaction.editReply({ embeds: errorEmbed });
       await sendErrorLog({ nessie, error, interaction, type, uuid });
     }

--- a/commands/maps/control.js
+++ b/commands/maps/control.js
@@ -79,10 +79,7 @@ module.exports = {
     } catch (error) {
       const uuid = uuidv4();
       const type = 'Control';
-      const errorEmbed = generateErrorEmbed(
-        'Oops something went wrong! D: Try again in a bit!',
-        uuid
-      );
+      const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
       await interaction.editReply({ embeds: errorEmbed });
       await sendErrorLog({ nessie, error, interaction, type, uuid });
     }

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -155,10 +155,7 @@ const createStatusChannel = async ({ nessie, interaction }) => {
   } catch (error) {
     const uuid = uuidv4();
     const type = 'Status Start Button';
-    const errorEmbed = generateErrorEmbed(
-      'Oops something went wrong! D: Try again in a bit!',
-      uuid
-    );
+    const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
     await interaction.message.edit({ embeds: errorEmbed, components: [] });
     await sendErrorLog({ nessie, error, interaction, type, uuid });
   }
@@ -170,6 +167,7 @@ const createStatusChannel = async ({ nessie, interaction }) => {
  */
 const cancelStatusStart = async ({ nessie, interaction }) => {
   interaction.deferUpdate();
+
   try {
     const embedSuccess = {
       description: 'Cancelled automated map status setup',
@@ -179,10 +177,7 @@ const cancelStatusStart = async ({ nessie, interaction }) => {
   } catch (error) {
     const uuid = uuidv4();
     const type = 'Status Cancel Button';
-    const errorEmbed = generateErrorEmbed(
-      'Oops something went wrong! D: Try again in a bit!',
-      uuid
-    );
+    const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
     await interaction.message.edit({ embeds: errorEmbed, components: [] });
     await sendErrorLog({ nessie, error, interaction, type, uuid });
   }

--- a/helpers.js
+++ b/helpers.js
@@ -142,9 +142,13 @@ const checkIfInDevelopment = (client) => {
  * @param message - error description/message
  * @param uuid - error uuid
  */
-const generateErrorEmbed = (message, uuid) => {
+const generateErrorEmbed = async (error, uuid) => {
   const embed = {
-    description: `${message}\n\nError ID: ${uuid}\nAlternatively, you can also report issue through the [support server](https://discord.com/invite/47Ccgz9jA4)`,
+    description: `\n\nError: ${
+      error.message ? codeBlock(error.message) : codeBlock('Unexpected Error')
+    }\nError ID: ${codeBlock(
+      uuid
+    )}\nAlternatively, you can also report issue through the [support server](https://discord.com/invite/47Ccgz9jA4)`,
     color: 16711680,
   };
   return [embed];

--- a/helpers.js
+++ b/helpers.js
@@ -1,6 +1,5 @@
 const { format } = require('date-fns');
 const { nessieLogo } = require('./constants');
-
 //----------
 /**
  * Function to send health status so that I can monitor how the status update for br pub maps is doing
@@ -139,12 +138,28 @@ const checkIfInDevelopment = (client) => {
 /**
  * Generates an error embed to be replied to the user when an error occurs with a command
  * Mainly used for failed promises
+ * Added an extra layer of complication for the sake of easy announcements
+ * Ever since the disastrous outage of the API for a full day and the influx of users to the support server, I realised a generic message isn't gonna cut it
+ * Although we won't be able to fix the issues of the API on our end, we can at least let users know what's going on
+ * Instead of passing a message to the function, it now gets a specific message from the support server
+ * With this, I can edit that message to reflect the current situation and it'll be shown along with the error message
  * @param message - error description/message
  * @param uuid - error uuid
+ * @param nessie = client
  */
-const generateErrorEmbed = async (error, uuid) => {
+const generateErrorEmbed = async (error, uuid, nessie) => {
+  //To get a specific message, we need to get the channel it's in before fetching it
+  const alertChannel = nessie.channels.cache.get('973977422699573258');
+  const messageObject = await alertChannel.messages.fetch('973981539731922946');
+  const errorMessage = messageObject.content;
+  //Since the message is inside a code block we want to trim everything outside of it; made a hack of wrapping it between [] to make it easier to trim
+  const errorAlert = errorMessage.substring(
+    errorMessage.indexOf('[') + 4,
+    errorMessage.lastIndexOf(']') - 3
+  );
+
   const embed = {
-    description: `\n\nError: ${
+    description: `${errorAlert}\n\nError: ${
       error.message ? codeBlock(error.message) : codeBlock('Unexpected Error')
     }\nError ID: ${codeBlock(
       uuid


### PR DESCRIPTION
#### Context
Following the full-day API outage a couple of days ago, I've come to realise my error handling doesn't really tell anything to the user. Although we can't do anything to fix API issues, we can at least tell people what's going on. Before this I used to go inside the droplet and change the error message there lol. But with this pr it makes it a whole lot easier for alerts to be shown to the userbase.

Basically Nessie will fetch a specific message in the support server and after trimming it down, use that as the main error message. I've done this for the `/updates` command too so I don't have to keep hardcoding it everytime before a release. Should be working on the auto status right now but I think this change is pretty important too. Saves me from headaches and time
<img width="430" alt="image" src="https://user-images.githubusercontent.com/42207245/167913443-e10b918a-fea3-461a-a9bb-684fc6775d62.png">
<img width="521" alt="image" src="https://user-images.githubusercontent.com/42207245/167913393-8b4adfb6-beea-4883-b197-0c7c3c6357a0.png">
<img width="953" alt="image" src="https://user-images.githubusercontent.com/42207245/167913498-f0a30110-e152-4751-9d0c-7abca8a882ff.png">

#### Change
- Pass in error object instead of generic message
- Retrieve alerts from specific discord messages
- Update error and update handlers