### PR TITLE
Add next split map for br ranked

### DIFF
--- a/commands/maps/arenas.js
+++ b/commands/maps/arenas.js
@@ -1,83 +1,13 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const { getArenasPubs, getArenasRanked } = require('../../adapters');
-const { sendErrorLog, generateErrorEmbed } = require('../../helpers');
+const {
+  sendErrorLog,
+  generateErrorEmbed,
+  generatePubsEmbed,
+  generateRankedEmbed,
+} = require('../../helpers');
 const { v4: uuidv4 } = require('uuid');
 const { sendMixpanelEvent } = require('../../analytics');
-
-/**
- * Display the time left in a more aethestically manner
- * API returns in the form hr:min:sec (01:02:03)
- * Function returns hr hrs min mins sec secs (01 hrs 02 mins 03 secs);
- * Might want to think of using the number of remaining seconds instead of splitting the timer string in the future
- */
-const getCountdown = (timer) => {
-  const countdown = timer.split(':');
-  const isOverAnHour = countdown[0] && countdown[0] !== '00';
-  return `${isOverAnHour ? `${countdown[0]} hr ` : ''}${countdown[1]} mins ${countdown[2]} secs`;
-};
-/**
- * Embed design for Arenas Pubs
- * Added a hack to display the time for next map regardless of timezone
- * As discord embed has a timestamp property, I added the remianing milliseconds to the current date
- * Make reusable?
- */
-const generatePubsEmbed = (data) => {
-  const embedData = {
-    title: 'Arenas | Pubs',
-    color: 3066993,
-    image: {
-      url: data.current.asset, //Using the scuffed saturated images as it'll be a chore adding custom images for each arenas map(some use areas of br maps)
-    },
-    timestamp: Date.now() + data.current.remainingSecs * 1000,
-    footer: {
-      text: `Next Map: ${data.next.map}`,
-    },
-    fields: [
-      {
-        name: 'Current map',
-        value: '```fix\n\n' + data.current.map + '```',
-        inline: true,
-      },
-      {
-        name: 'Time left',
-        value: '```xl\n\n' + getCountdown(data.current.remainingTimer) + '```',
-        inline: true,
-      },
-    ],
-  };
-  return [embedData];
-};
-/**
- * Embed design for Arenas Ranked
- * Slighly different from BR ranked and similar to its Pubs counterpart
- * Might want to make all of these reusable, a lot of repeats
- */
-const generateRankedEmbed = (data) => {
-  const embedData = {
-    title: 'Arenas | Ranked',
-    color: 7419530,
-    image: {
-      url: data.current.asset, //Using the scuffed saturated images as it'll be a chore adding custom images for each arenas map(some use areas of br maps)
-    },
-    timestamp: Date.now() + data.current.remainingSecs * 1000,
-    footer: {
-      text: `Next Map: ${data.next.map}`,
-    },
-    fields: [
-      {
-        name: 'Current map',
-        value: '```fix\n\n' + data.current.map + '```',
-        inline: true,
-      },
-      {
-        name: 'Time left',
-        value: '```xl\n\n' + getCountdown(data.current.remainingTimer) + '```',
-        inline: true,
-      },
-    ],
-  };
-  return [embedData];
-};
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -106,14 +36,14 @@ module.exports = {
       switch (optionMode) {
         case 'arenas_pubs':
           data = await getArenasPubs();
-          embed = generatePubsEmbed(data);
+          embed = generatePubsEmbed(data, 'Arenas');
           break;
         case 'arenas_ranked':
           data = await getArenasRanked();
-          embed = generateRankedEmbed(data);
+          embed = generateRankedEmbed(data, 'Arenas');
           break;
       }
-      await interaction.editReply({ embeds: embed });
+      await interaction.editReply({ embeds: [embed] });
       sendMixpanelEvent(
         interaction.user,
         interaction.channel,

--- a/commands/maps/battle-royale.js
+++ b/commands/maps/battle-royale.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const { getBattleRoyalePubs, getBattleRoyaleRanked } = require('../../adapters');
-const { sendErrorLog, generateErrorEmbed } = require('../../helpers');
+const { sendErrorLog, generateErrorEmbed, generateRankedEmbed } = require('../../helpers');
 const { v4: uuidv4 } = require('uuid');
 const { sendMixpanelEvent } = require('../../analytics');
 
@@ -82,33 +82,6 @@ const generatePubsEmbed = (data) => {
   };
   return [embedData];
 };
-/**
- * Embed design for BR Ranked
- * Fairly simple, don't need any fancy timers and footers
- */
-const generateRankedEmbed = (data) => {
-  const embedData = {
-    title: 'Battle Royale | Ranked',
-    color: 7419530,
-    image: {
-      url: getMapUrl(data.current.map),
-    },
-    fields: [
-      {
-        name: 'Current map',
-        value: '```fix\n\n' + data.current.map + '```',
-        inline: true,
-      },
-      {
-        name: 'Time left',
-        value: '```xl\n\n' + getCountdown(data.current.remainingTimer) + '```',
-        inline: true,
-      },
-    ],
-  };
-  return [embedData];
-};
-
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('br')
@@ -143,7 +116,7 @@ module.exports = {
           embed = generateRankedEmbed(data);
           break;
       }
-      await interaction.editReply({ embeds: embed });
+      await interaction.editReply({ embeds: [embed] });
       sendMixpanelEvent(
         interaction.user,
         interaction.channel,

--- a/commands/maps/battle-royale.js
+++ b/commands/maps/battle-royale.js
@@ -1,87 +1,14 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const { getBattleRoyalePubs, getBattleRoyaleRanked } = require('../../adapters');
-const { sendErrorLog, generateErrorEmbed, generateRankedEmbed } = require('../../helpers');
+const {
+  sendErrorLog,
+  generateErrorEmbed,
+  generateRankedEmbed,
+  generatePubsEmbed,
+} = require('../../helpers');
 const { v4: uuidv4 } = require('uuid');
 const { sendMixpanelEvent } = require('../../analytics');
 
-/**
- * Gets url link image for each br map
- * Using custom images as the image links sent by API are desaturated for some reason
- * Currently hosted scuffly in discord itself; might want to think of hosting it in cloudfront in the future
- */
-const getMapUrl = (map) => {
-  switch (map) {
-    case 'kings_canyon_rotation':
-      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544176815099954/kings_canyon.jpg';
-    case 'Kings Canyon':
-      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544176815099954/kings_canyon.jpg';
-    case 'worlds_edge_rotation':
-      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544195488129034/worlds_edge.jpg';
-    case `World's Edge`:
-      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544195488129034/worlds_edge.jpg';
-    case 'olympus_rotation':
-      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544165163323402/olympus_nessie.jpg';
-    case 'Olympus':
-      return 'https://cdn.discordapp.com/attachments/896544134813319168/896544165163323402/olympus_nessie.jpg';
-    case 'Storm Point':
-      return 'https://cdn.discordapp.com/attachments/896544134813319168/911631835300237332/storm_point_nessie.jpg';
-    case 'storm_point_rotation':
-      return 'https://cdn.discordapp.com/attachments/896544134813319168/911631835300237332/storm_point_nessie.jpg';
-    default:
-      return '';
-  }
-};
-/**
- * Display the time left in a more aethestically manner
- * API returns in the form hr:min:sec (01:02:03)
- * Function returns hr hrs min mins sec secs (01 hrs 02 mins 03 secs);
- * Might want to think of using the number of remaining seconds instead of splitting the timer string in the future
- */
-const getCountdown = (timer) => {
-  const countdown = timer.split(':');
-  const isOverAnHour = countdown[0] && countdown[0] !== '00';
-  const isOverADay = countdown[0] && parseInt(countdown[0]) >= 24;
-
-  //Since ranked br is usually one map for the whole split, good to show days as well rather than just the usual hours
-  if (isOverADay) {
-    const countdownDays = parseInt(countdown[0]) / 24;
-    const countdownHours = parseInt(countdown[0]) % 24;
-    return `${Math.floor(countdownDays)} days ${countdownHours} hrs ${countdown[1]} mins`;
-  }
-  return `${isOverAnHour ? `${countdown[0]} hr ` : ''}${countdown[1]} mins ${countdown[2]} secs`;
-};
-/**
- * Embed design for BR Pubs
- * Added a hack to display the time for next map regardless of timezone
- * As discord embed has a timestamp propery, I added the remianing milliseconds to the current date
- * Make reusable?
- */
-const generatePubsEmbed = (data) => {
-  const embedData = {
-    title: 'Battle Royale | Pubs',
-    color: 3066993,
-    image: {
-      url: getMapUrl(data.current.code),
-    },
-    timestamp: Date.now() + data.current.remainingSecs * 1000,
-    footer: {
-      text: `Next Map: ${data.next.map}`,
-    },
-    fields: [
-      {
-        name: 'Current map',
-        value: '```fix\n\n' + data.current.map + '```',
-        inline: true,
-      },
-      {
-        name: 'Time left',
-        value: '```xl\n\n' + getCountdown(data.current.remainingTimer) + '```',
-        inline: true,
-      },
-    ],
-  };
-  return [embedData];
-};
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('br')

--- a/commands/maps/control.js
+++ b/commands/maps/control.js
@@ -1,48 +1,9 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const { getControlPubs } = require('../../adapters');
-const { sendErrorLog, generateErrorEmbed } = require('../../helpers');
+const { sendErrorLog, generateErrorEmbed, generatePubsEmbed } = require('../../helpers');
 const { v4: uuidv4 } = require('uuid');
 const { sendMixpanelEvent } = require('../../analytics');
 
-/**
- * TODO: Figure out a system to show custom map images for map commands
- * Aside from br, the rest of the modes rely on the assets return by the API
- * These assets don't look good however I've decided to use them for now as it's direct
- * Manually wiring them up to our images isn't scalable either
- * I'll just leave this comment so I get reminded about it in the future
- */
-const getCountdown = (timer) => {
-  const countdown = timer.split(':');
-  const isOverAnHour = countdown[0] && countdown[0] !== '00';
-  return `${isOverAnHour ? `${countdown[0]} hr ` : ''}${countdown[1]} mins ${countdown[2]} secs`;
-};
-
-const generatePubsEmbed = (data) => {
-  const embedData = {
-    title: 'Control | Pubs',
-    color: 3066993,
-    image: {
-      url: data.current.asset, //Using the scuffed saturated images as it'll be a chore adding custom images for each control map(some use areas of br maps)
-    },
-    timestamp: Date.now() + data.current.remainingSecs * 1000,
-    footer: {
-      text: `Next Map: ${data.next.map}`,
-    },
-    fields: [
-      {
-        name: 'Current map',
-        value: '```fix\n\n' + data.current.map + '```',
-        inline: true,
-      },
-      {
-        name: 'Time left',
-        value: '```xl\n\n' + getCountdown(data.current.remainingTimer) + '```',
-        inline: true,
-      },
-    ],
-  };
-  return [embedData];
-};
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('control')
@@ -63,10 +24,10 @@ module.exports = {
       switch (optionMode) {
         case 'control_pubs':
           data = await getControlPubs();
-          embed = generatePubsEmbed(data);
+          embed = generatePubsEmbed(data, 'Control');
           break;
       }
-      await interaction.editReply({ embeds: embed });
+      await interaction.editReply({ embeds: [embed] });
       sendMixpanelEvent(
         interaction.user,
         interaction.channel,

--- a/events.js
+++ b/events.js
@@ -102,7 +102,7 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
        * Hence, we have a separate handler for these commands in their own files instead of here
        * TODO: Refactor conditional in the future, probably a better way to check since this isn't scalable
        */
-      if (commandName !== 'br' && commandName !== 'arenas') {
+      if (commandName !== 'br' && commandName !== 'arenas' && commandName !== 'control') {
         sendMixpanelEvent(
           interaction.user,
           interaction.channel,

--- a/helpers.js
+++ b/helpers.js
@@ -329,7 +329,7 @@ const generateRankedEmbed = (data, type = 'Battle Royale') => {
       },
     ],
   };
-  if (type === 'Arenas') {
+  if (data.next && data.next.map) {
     embedData.timestamp = Date.now() + data.current.remainingSecs * 1000;
     embedData.footer = {
       text: `Next Map: ${data.next.map}`,

--- a/helpers.js
+++ b/helpers.js
@@ -232,6 +232,11 @@ const generateAnnouncementMessage = (prefix) => {
  * Gets url link image for each br map
  * Using custom images as the image links sent by API are desaturated for some reason
  * Currently hosted scuffly in discord itself; might want to think of hosting it in cloudfront in the future
+ * TODO: Figure out a system to show custom map images for map commands
+ * Aside from br, the rest of the modes rely on the assets return by the API
+ * These assets don't look good however I've decided to use them for now as it's direct
+ * Manually wiring them up to our images isn't scalable either
+ * I'll just leave this comment so I get reminded about it in the future
  */
 const getMapUrl = (map) => {
   switch (map) {


### PR DESCRIPTION
#### Context
With the new season 13 update, the API is now able to show the next map for split 2 in Battle Royale Ranked. I've reflected that change with the br ranked command to now also show the next map in its footer. I'm not really sure if this is going to be always returned by the API so I've added a check to only show the next map footer if the data exists

Also accidentally found out that the control mixpanel event is firing twice, fixed that too

<img width="434" alt="image" src="https://user-images.githubusercontent.com/42207245/168417250-0b7a397a-a52d-49b6-82aa-8cb94dbed804.png">

#### Change
- Add next map for br ranked
- Use reusable map functions for each game mode
- Prevent control miexpanel event from firing twice