### PR TITLE
Wire up create status database

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -14,6 +14,6 @@ exports.getApplicationCommands = () => {
     br: require('./commands/maps/battle-royale'),
     arenas: require('./commands/maps/arenas'),
     control: require('./commands/maps/control'),
-    // status: require('./commands/maps/status'),
+    status: require('./commands/maps/status'),
   };
 };

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -1,7 +1,7 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const { MessageActionRow, MessageButton } = require('discord.js');
 const { format } = require('date-fns');
-const { getBattleRoyalePubs, getBattleRoyaleRanked, getRotationData } = require('../../adapters');
+const { getRotationData } = require('../../adapters');
 const {
   generatePubsEmbed,
   generateRankedEmbed,
@@ -198,7 +198,7 @@ const createStatusChannel = async ({ nessie, interaction }) => {
         };
         await interaction.message.edit({ embeds: [embedSuccess], components: [] }); //Sends success message in channel where command got instantiated
       },
-      async () => {
+      async (error) => {
         const uuid = uuidv4();
         const type = 'Inserting New Status in Database';
         const errorEmbed = await generateErrorEmbed(error, uuid, nessie);

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -12,6 +12,11 @@ const { v4: uuidv4 } = require('uuid');
 const { insertNewStatus, getStatus } = require('../../database/handler');
 
 //----- Status Application Command Replies -----//
+/**
+ * Handler for when a user initiates the /status help command
+ * Calls the getStatus handler to see for existing status in the guild
+ * Passes a success and error callback with the former sending an information embed with context depending on status existence
+ */
 const sendHelpInteraction = async ({ interaction, nessie }) => {
   await getStatus(
     interaction.guildId,
@@ -34,6 +39,13 @@ const sendHelpInteraction = async ({ interaction, nessie }) => {
     }
   );
 };
+/**
+ * Handler for when a user initiates the /status start command
+ * Calls the getStatus handler to see for existing status in the guild
+ * Passes a success and error callback with the former:
+ * - Sending an information embed with context depending on status existence
+ * - Sending Cancel and Start buttons; disabled depened on status existence
+ */
 const sendStartInteraction = async ({ interaction, nessie }) => {
   await getStatus(
     interaction.guildId,
@@ -178,6 +190,11 @@ const createStatusChannel = async ({ nessie, interaction }) => {
     const statusPubsMessage = await statusPubsChannel.send({ embeds: statusPubsEmbed }); //Sends initial pubs embed in status channel
     const statusRankedMessage = await statusRankedChannel.send({ embeds: statusRankedEmbed }); //Sends initial ranked embed in status channel
 
+    /**
+     * Creates new status data object to be inserted in our database
+     * We then call the insertNewStatus handler to start insertion
+     * Passes a success and error callback with the former editing the original message with a success embed
+     */
     const newStatus = {
       uuid: uuidv4(),
       guildId: interaction.guildId,
@@ -196,7 +213,7 @@ const createStatusChannel = async ({ nessie, interaction }) => {
           description: `Created map status at ${statusPubsChannel} and ${statusRankedChannel}`,
           color: 3066993,
         };
-        await interaction.message.edit({ embeds: [embedSuccess], components: [] }); //Sends success message in channel where command got instantiated
+        await interaction.message.edit({ embeds: [embedSuccess], components: [] });
       },
       async (error) => {
         const uuid = uuidv4();

--- a/database/handler.js
+++ b/database/handler.js
@@ -113,3 +113,15 @@ exports.removeServerDataFromNessie = (nessie, guild) => {
     });
   });
 };
+exports.createStatusTable = () => {
+  this.pool.connect((err, client, done) => {
+    client.query('BEGIN', (err) => {
+      client.query(
+        'CREATE TABLE IF NOT EXISTS Status(uuid TEXT NOT NULL PRIMARY KEY, guild_id TEXT NOT NULL, category_channel_id TEXT NOT NULL, pubs_channel_id TEXT NOT NULL, ranked_channel_id TEXT NOT NULL, pubs_message_id TEXT NOT NULL, ranked_message_id TEXT NOT NULL, created_by TEXT NOT NULL, created_at TEXT NOT NULL)'
+      );
+      client.query('COMMIT', (err) => {
+        done();
+      });
+    });
+  });
+};

--- a/database/handler.js
+++ b/database/handler.js
@@ -113,33 +113,3 @@ exports.removeServerDataFromNessie = (nessie, guild) => {
     });
   });
 };
-/**
- * Updates prefix with the new custom prefix provided by the user
- * This will be deprecated in april but might as well migrate it along with the rest of the queries
- * @param message - discord message object
- * @param newPrefix - new custom prefix
- * @param embed - embed message to send back to user after successfully updating
- */
-exports.setCustomPrefix = (message, newPrefix, embed) => {
-  this.pool.connect((err, client, done) => {
-    client.query('BEGIN', (err) => {
-      client.query(
-        'UPDATE Guild SET prefix = ($1) WHERE uuid = ($2)',
-        [`${newPrefix}`, `${message.guildId}`],
-        (err) => {
-          if (err) {
-            console.log(err);
-            return message.channel.send('Oops something went wrong! Try again!'); //Maybe add link to support server here?
-          }
-          client.query('COMMIT', () => {
-            if (err) {
-              console.log(err);
-            }
-            message.channel.send({ embeds: embed });
-            done();
-          });
-        }
-      );
-    });
-  });
-};

--- a/database/handler.js
+++ b/database/handler.js
@@ -143,6 +143,7 @@ exports.insertNewStatus = async (status, onSuccess, onError) => {
         ],
         (err, res) => {
           if (err) {
+            return onError && onError(err.message ? err.message : { message: 'Unexpected Error' });
           }
           client.query('COMMIT', (err) => {
             if (err) {

--- a/database/handler.js
+++ b/database/handler.js
@@ -146,13 +146,26 @@ exports.insertNewStatus = async (status, onSuccess, onError) => {
           }
           client.query('COMMIT', (err) => {
             if (err) {
-              onError && onError();
+              return onError && onError(err.message ? err.message : 'Unexpected Error');
             }
             onSuccess && onSuccess();
             done();
           });
         }
       );
+    });
+  });
+};
+exports.getStatus = async (guildId, onSuccess, onError) => {
+  this.pool.connect((err, client, done) => {
+    client.query('BEGIN', (err) => {
+      client.query('SELECT * FROM Status WHERE guild_id = ($1)', [guildId], (err, res) => {
+        if (err) {
+          return onError && onError(err.message ? err.message : 'Unexpected Error');
+        }
+        onSuccess && onSuccess(res.rows.length > 0 ? res.rows[0] : null);
+        done();
+      });
     });
   });
 };

--- a/database/handler.js
+++ b/database/handler.js
@@ -146,7 +146,9 @@ exports.insertNewStatus = async (status, onSuccess, onError) => {
           }
           client.query('COMMIT', (err) => {
             if (err) {
-              return onError && onError(err.message ? err.message : 'Unexpected Error');
+              return (
+                onError && onError(err.message ? err.message : { message: 'Unexpected Error' })
+              );
             }
             onSuccess && onSuccess();
             done();
@@ -161,7 +163,7 @@ exports.getStatus = async (guildId, onSuccess, onError) => {
     client.query('BEGIN', (err) => {
       client.query('SELECT * FROM Status WHERE guild_id = ($1)', [guildId], (err, res) => {
         if (err) {
-          return onError && onError(err.message ? err.message : 'Unexpected Error');
+          return onError && onError(err.message ? err.message : { message: 'Unexpected Error' });
         }
         onSuccess && onSuccess(res.rows.length > 0 ? res.rows[0] : null);
         done();

--- a/database/handler.js
+++ b/database/handler.js
@@ -125,3 +125,34 @@ exports.createStatusTable = () => {
     });
   });
 };
+exports.insertNewStatus = async (status, onSuccess, onError) => {
+  this.pool.connect((err, client, done) => {
+    client.query('BEGIN', (err) => {
+      client.query(
+        'INSERT INTO Status (uuid, guild_id, category_channel_id, pubs_channel_id, ranked_channel_id, pubs_message_id, ranked_message_id, created_by, created_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)',
+        [
+          status.uuid,
+          status.guildId,
+          status.categoryChannelId,
+          status.pubsChannelId,
+          status.rankedChannelId,
+          status.pubsMessageId,
+          status.rankedMessageId,
+          status.createdBy,
+          status.createdAt,
+        ],
+        (err, res) => {
+          if (err) {
+          }
+          client.query('COMMIT', (err) => {
+            if (err) {
+              onError && onError();
+            }
+            onSuccess && onSuccess();
+            done();
+          });
+        }
+      );
+    });
+  });
+};

--- a/database/handler.js
+++ b/database/handler.js
@@ -113,6 +113,11 @@ exports.removeServerDataFromNessie = (nessie, guild) => {
     });
   });
 };
+/**
+ * Creates Status table in our database
+ * Straightforward; no additional checks and only creates the table if it does not exist
+ * Gets called in the onReady event of Nessie
+ */
 exports.createStatusTable = () => {
   this.pool.connect((err, client, done) => {
     client.query('BEGIN', (err) => {
@@ -125,6 +130,14 @@ exports.createStatusTable = () => {
     });
   });
 };
+/**
+ * Inserts new status in our database
+ * Takes in a status object with all the relevant data for scheduler usage
+ * Was feeling intuitive so added callback functions for both success and error
+ * @param status - new status data object
+ * @param onSuccess - function to call when queries are successfully done
+ * @param onError - function to call when queries throw an error
+ */
 exports.insertNewStatus = async (status, onSuccess, onError) => {
   this.pool.connect((err, client, done) => {
     client.query('BEGIN', (err) => {
@@ -159,6 +172,13 @@ exports.insertNewStatus = async (status, onSuccess, onError) => {
     });
   });
 };
+/**
+ * Gets an existing status in our database
+ * Takes in the guild id of the interaction to be able to query correctly
+ * @param guildId - guild id of the interaction
+ * @param onSuccess - function to call when queries are successfully done
+ * @param onError - function to call when queries throw an error
+ */
 exports.getStatus = async (guildId, onSuccess, onError) => {
   this.pool.connect((err, client, done) => {
     client.query('BEGIN', (err) => {

--- a/events.js
+++ b/events.js
@@ -22,6 +22,7 @@ const {
   insertNewGuild,
   removeServerDataFromNessie,
   pool,
+  createStatusTable,
 } = require('./database/handler');
 const { createStatusChannel, cancelStatusStart } = require('./commands/maps/status');
 
@@ -44,6 +45,7 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
        * See relevant files under database/* for more information
        */
       createGuildTable(nessie.guilds.cache, nessie);
+      createStatusTable();
       /**
        * Changes Nessie's activity when the current map has switched over to the next
        * Refer to the setCurrentMapStatus function for more information

--- a/migration.js
+++ b/migration.js
@@ -73,8 +73,20 @@ exports.runMigration = (guilds) => {
       //   client.query('COMMIT');
       // });
       // ----
+      const selectAllStatus = 'SELECT * FROM Status';
+      const deleteAllStatus = 'DELETE FROM Status';
+      client.query(selectAllStatus, (err, res) => {
+        console.log(err);
+        console.log(res.rows);
+        done();
+      });
+      // client.query(deleteAllStatus, (err, res) => {
+      //   console.log(err);
+      //   console.log(res);
+      //   client.query('COMMIT');
+      // });
     });
   });
 };
 
-// this.runMigration();
+this.runMigration();


### PR DESCRIPTION
#### Context
Create status table along with wiring up to the database for the status start interactions. Currently the rows that I think that are important to store:
- uuid
- guild_id
- category_channel_id
- pubs_channel_id
- ranked_channel_id
- pubs_message_id
- ranked_message_id
- created_by
- created_at

This is probably enough for the scheduler to work but will just add more rows when I need them. Also was feeling a bit intuitive and actually added error handling for database errors

<img width="380" alt="image" src="https://user-images.githubusercontent.com/42207245/168442683-88d472ad-61b5-461e-89a9-c68b0e31c742.png">
<img width="370" alt="image" src="https://user-images.githubusercontent.com/42207245/168442699-88c69498-e98a-4c03-8a01-b8c5ebc62dc5.png">
<img width="470" alt="image" src="https://user-images.githubusercontent.com/42207245/168442728-eecb4ebe-80b0-4395-a2e5-bc8794028a80.png">
<img width="395" alt="image" src="https://user-images.githubusercontent.com/42207245/168442779-172638a3-3449-4070-92a1-51c9c333820e.png">

#### Change
- Remove setCustomPrefix database handler
- Create status table in db
- Create insertNewStatus handler
- Create getStatus handler
- Show existing status in status help and start
- Add error handling for each of the database handlers
