### PR TITLE
Wire up delete status

### DIFF
--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -158,7 +158,7 @@ const generateRankedStatusEmbeds = (data) => {
  * TODO: Start the auto-update scheduler
  * TODO: Create tables in database to store status data
  */
-const createStatusChannel = async ({ nessie, interaction }) => {
+const createStatusChannels = async ({ nessie, interaction }) => {
   interaction.deferUpdate();
   try {
     /**
@@ -253,6 +253,23 @@ const cancelStatusStart = async ({ nessie, interaction }) => {
     await sendErrorLog({ nessie, error, interaction, type, uuid });
   }
 };
+const cancelStatusStop = async ({ nessie, interaction }) => {
+  interaction.deferUpdate();
+
+  try {
+    const embedSuccess = {
+      description: 'Cancelled automated map status deletion',
+      color: 16711680,
+    };
+    await interaction.message.edit({ embeds: [embedSuccess], components: [] });
+  } catch (error) {
+    const uuid = uuidv4();
+    const type = 'Status Cancel Button';
+    const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
+    await interaction.message.edit({ embeds: errorEmbed, components: [] });
+    await sendErrorLog({ nessie, error, interaction, type, uuid });
+  }
+};
 module.exports = {
   /**
    * Creates Status application command with relevant subcommands
@@ -297,6 +314,7 @@ module.exports = {
       console.log(error);
     }
   },
-  createStatusChannel,
+  createStatusChannels,
   cancelStatusStart,
+  cancelStatusStop,
 };

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -85,6 +85,11 @@ const sendStartInteraction = async ({ interaction, nessie }) => {
     }
   );
 };
+/**
+ * Handler for when a user initiates the /status stop command
+ * Calls the getStatus handler to see for existing status in the guild
+ * Passes a success and error callback with the former sending an information embed with context depending on status existence
+ */
 const sendStopInteraction = async ({ interaction, nessie }) => {
   await getStatus(
     interaction.guildId,
@@ -177,10 +182,11 @@ const generateRankedStatusEmbeds = (data) => {
  * - Calls the API for the rotation data
  * - Create embeds for each status channel
  * - Creates a category channel and 2 new text channels under it
- * - Sends embeds to respective channels and edits initial message with a success message
+ * - Sends embeds to respective channels
+ * - Inserts a new Status row in our database with all the relevant data
+ * - Edits initial message with a success message
  * -
  * TODO: Start the auto-update scheduler
- * TODO: Create tables in database to store status data
  */
 const createStatusChannels = async ({ nessie, interaction }) => {
   interaction.deferUpdate();
@@ -277,6 +283,18 @@ const cancelStatusStart = async ({ nessie, interaction }) => {
     await sendErrorLog({ nessie, error, interaction, type, uuid });
   }
 };
+/**
+ * Handler for stopping the process of map status
+ * Gets called when a user clicks the confirm button of the /status stop reply
+ * Main steps upon button click:
+ * - Edits initial message with a loading state
+ * - Calls the deleteStatus handler which returns the status data while also deleting it from the db
+ * - Fetches each of the relevant discord channels with the status data
+ * - Deletes each of of the discord channels
+ * - Edits initial message with a success message
+ * -
+ * TODO: Stop the auto-update-scheduler
+ */
 const deleteStatusChannels = async ({ interaction, nessie }) => {
   interaction.deferUpdate();
   await deleteStatus(
@@ -320,6 +338,11 @@ const deleteStatusChannels = async ({ interaction, nessie }) => {
     }
   );
 };
+/**
+ * Handler for cancelling the wizard of /status stop
+ * Gets called when a user clicks the cancel button of the /status stop reply
+ * Pretty straightforward; we just edit the initial message with a cancel message similar to the start handler
+ */
 const cancelStatusStop = async ({ nessie, interaction }) => {
   interaction.deferUpdate();
 

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -127,7 +127,7 @@ const sendStopInteraction = async ({ interaction, nessie }) => {
 
       return await interaction.editReply({ components: [row], embeds: [embedData] });
     },
-    async () => {
+    async (error) => {
       const uuid = uuidv4();
       const type = 'Getting Status in Database (Stop)';
       const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
@@ -277,7 +277,7 @@ const cancelStatusStart = async ({ nessie, interaction }) => {
     await interaction.message.edit({ embeds: [embedSuccess], components: [] });
   } catch (error) {
     const uuid = uuidv4();
-    const type = 'Status Cancel Button';
+    const type = 'Status Start Cancel Button';
     const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
     await interaction.message.edit({ embeds: errorEmbed, components: [] });
     await sendErrorLog({ nessie, error, interaction, type, uuid });
@@ -331,7 +331,7 @@ const deleteStatusChannels = async ({ interaction, nessie }) => {
     },
     async (error) => {
       const uuid = uuidv4();
-      const type = 'Getting Status in Database (Stop Button)';
+      const type = 'Getting/Deleting Status in Database (Stop Button)';
       const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
       await interaction.message.edit({ embeds: errorEmbed, components: [] });
       await sendErrorLog({ nessie, error, interaction, type, uuid });
@@ -354,7 +354,7 @@ const cancelStatusStop = async ({ nessie, interaction }) => {
     await interaction.message.edit({ embeds: [embedSuccess], components: [] });
   } catch (error) {
     const uuid = uuidv4();
-    const type = 'Status Cancel Button';
+    const type = 'Status Stop Cancel Button';
     const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
     await interaction.message.edit({ embeds: errorEmbed, components: [] });
     await sendErrorLog({ nessie, error, interaction, type, uuid });

--- a/database/handler.js
+++ b/database/handler.js
@@ -192,3 +192,29 @@ exports.getStatus = async (guildId, onSuccess, onError) => {
     });
   });
 };
+exports.deleteStatus = async (guildId, onSuccess, onError) => {
+  this.pool.connect((err, client, done) => {
+    client.query('BEGIN', (err) => {
+      client.query('SELECT * FROM Status WHERE guild_id = ($1)', [guildId], (err, res) => {
+        if (err) {
+          return onError && onError(err.message ? err.message : { message: 'Unexpected Error' });
+        }
+
+        client.query('DELETE FROM Status WHERE guild_id = ($1)', [guildId], (err) => {
+          if (err) {
+            return onError && onError(err.message ? err.message : { message: 'Unexpected Error' });
+          }
+          client.query('COMMIT', (err) => {
+            if (err) {
+              return (
+                onError && onError(err.message ? err.message : { message: 'Unexpected Error' })
+              );
+            }
+            onSuccess && onSuccess(res.rows.length > 0 ? res.rows[0] : null);
+            done();
+          });
+        });
+      });
+    });
+  });
+};

--- a/database/handler.js
+++ b/database/handler.js
@@ -156,13 +156,13 @@ exports.insertNewStatus = async (status, onSuccess, onError) => {
         ],
         (err, res) => {
           if (err) {
-            return onError && onError(err.message ? err.message : { message: 'Unexpected Error' });
+            onError && onError(err.message ? err.message : { message: 'Unexpected Error' });
+            return done();
           }
           client.query('COMMIT', (err) => {
             if (err) {
-              return (
-                onError && onError(err.message ? err.message : { message: 'Unexpected Error' })
-              );
+              onError && onError(err.message ? err.message : { message: 'Unexpected Error' });
+              return done();
             }
             onSuccess && onSuccess();
             done();
@@ -184,7 +184,8 @@ exports.getStatus = async (guildId, onSuccess, onError) => {
     client.query('BEGIN', (err) => {
       client.query('SELECT * FROM Status WHERE guild_id = ($1)', [guildId], (err, res) => {
         if (err) {
-          return onError && onError(err.message ? err.message : { message: 'Unexpected Error' });
+          onError && onError(err.message ? err.message : { message: 'Unexpected Error' });
+          return done();
         }
         onSuccess && onSuccess(res.rows.length > 0 ? res.rows[0] : null);
         done();
@@ -209,18 +210,20 @@ exports.deleteStatus = async (guildId, onSuccess, onError) => {
     client.query('BEGIN', (err) => {
       client.query('SELECT * FROM Status WHERE guild_id = ($1)', [guildId], (err, res) => {
         if (err) {
-          return onError && onError(err.message ? err.message : { message: 'Unexpected Error' });
+          //Returning on done to close the connecting to the db; will really need to figure out a better way for error handling here
+          onError && onError(err.message ? err.message : { message: 'Unexpected Error' });
+          return done();
         }
 
         client.query('DELETE FROM Status WHERE guild_id = ($1)', [guildId], (err) => {
           if (err) {
-            return onError && onError(err.message ? err.message : { message: 'Unexpected Error' });
+            onError && onError(err.message ? err.message : { message: 'Unexpected Error' });
+            return done();
           }
           client.query('COMMIT', (err) => {
             if (err) {
-              return (
-                onError && onError(err.message ? err.message : { message: 'Unexpected Error' })
-              );
+              onError && onError(err.message ? err.message : { message: 'Unexpected Error' });
+              return done();
             }
             onSuccess && onSuccess(res.rows.length > 0 ? res.rows[0] : null);
             done();

--- a/database/handler.js
+++ b/database/handler.js
@@ -192,6 +192,18 @@ exports.getStatus = async (guildId, onSuccess, onError) => {
     });
   });
 };
+/**
+ * Deletes an existing status in our database
+ * To do this, we need to get the status tied to the guild first
+ * This is important as we would need the relevant channel ids to be able to delete those channels in discord
+ * Was initially thinking of adding an onGet callback; we delete the discord channels after we query the data
+ * Had troubles in making it work tho as it was firing it at the same time as the delete queries
+ * Probably doing something wrong but I've opted to just deleting the channels after we delete the status from our database
+ * Prayers to discord's API to not go down when this is happening :prayge:
+ * @param guildId - guild id of the interaction
+ * @param onSuccess - function to call when queries are successfully done
+ * @param onError - function to call when queries throws an error
+ */
 exports.deleteStatus = async (guildId, onSuccess, onError) => {
   this.pool.connect((err, client, done) => {
     client.query('BEGIN', (err) => {

--- a/events.js
+++ b/events.js
@@ -28,6 +28,7 @@ const {
   createStatusChannels,
   cancelStatusStart,
   cancelStatusStop,
+  deleteStatusChannels,
 } = require('./commands/maps/status');
 
 const appCommands = getApplicationCommands(); //Get list of application commands
@@ -132,6 +133,8 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
           return await createStatusChannels({ nessie, interaction });
         case 'statusStart__cancelButton':
           return await cancelStatusStart({ nessie, interaction });
+        case 'statusStop__stopButton':
+          return await deleteStatusChannels({ nessie, interaction });
         case 'statusStop__cancelButton':
           return await cancelStatusStop({ nessie, interaction });
       }

--- a/events.js
+++ b/events.js
@@ -24,7 +24,11 @@ const {
   pool,
   createStatusTable,
 } = require('./database/handler');
-const { createStatusChannel, cancelStatusStart } = require('./commands/maps/status');
+const {
+  createStatusChannels,
+  cancelStatusStart,
+  cancelStatusStop,
+} = require('./commands/maps/status');
 
 const appCommands = getApplicationCommands(); //Get list of application commands
 
@@ -125,9 +129,11 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
     if (interaction.isButton()) {
       switch (interaction.customId) {
         case 'statusStart__startButton':
-          return await createStatusChannel({ nessie, interaction });
+          return await createStatusChannels({ nessie, interaction });
         case 'statusStart__cancelButton':
           return await cancelStatusStart({ nessie, interaction });
+        case 'statusStop__cancelButton':
+          return await cancelStatusStop({ nessie, interaction });
       }
     }
   });


### PR DESCRIPTION
#### Context
With #66 addressing the creation of the status table as well as inserting new status rows along with its relevant interactions, this pr addresses the delete aspect of statuses. Not too complicated on this one although there's a bit of a hiccup on the handler for the delete status queries. I wanted to delete the discord channels after querying for the existing status data and then deleting the data after the channels are done being deleted. However I couldn't really figure it out so I've opted to just doing query existing -> delete data -> delete channels -> success message. Not a big deal but poses a risk if ever the discord API fails after deleting the data already. 

Added the same error handling as in the previous pr but probably would need to do a better way in the future

![status stop](https://user-images.githubusercontent.com/42207245/168868268-a961fdff-3d62-43ce-996b-4bf49d25f2de.gif)
<img width="364" alt="image" src="https://user-images.githubusercontent.com/42207245/168870518-1696c464-3b58-433e-a45b-72f7953a08ef.png">

<img width="455" alt="image" src="https://user-images.githubusercontent.com/42207245/168870458-5ccc7139-397d-4455-be65-58d3635b60b6.png">

#### Change
- Add cancel status stop interaction
- Add cancel status confirm interaction
- Wire up delete handler for database queries
