### PR TITLE
Create scheduler for status

### DIFF
--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -366,6 +366,20 @@ const cancelStatusStop = async ({ nessie, interaction }) => {
     await sendErrorLog({ nessie, error, interaction, type, uuid });
   }
 };
+/**
+ * Handler in charge in updating map data in the relevant status channels
+ * Uses the Scheduler class to create a cron job that fires every 10th second of every 5 minutes (0:5:10, 0:10:10, 0:15:10, etc)
+ * When the cron job is executed, we then:
+ * - Call the getAllStatus handler to get every existing status in our database
+ * - Upon finishing the query, we then call the API for the current rotation data
+ * - If there are no existing statuses, we don't do anything
+ * - If there are, we then get all the relevant channels and messages from discord for each status
+ * - We then edit those messages with embeds containing the current rotation
+ * - After updating all the guild statuses, we then send a log to our status-log channel in discord
+ * - Currently there's 4 calls to the discord API per status; fetches messages + editing them
+ *
+ * TODO: Figure out how to prevent getting rate limited
+ */
 const initialiseStatusScheduler = (nessie) => {
   return new Scheduler('10 */5 * * * *', async () => {
     getAllStatus(

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -26,7 +26,7 @@ const sendHelpInteraction = async ({ interaction, nessie }) => {
         title: 'Status | Help',
         description: status
           ? `There's currently an existing automated map status active in:\n• <#${status.pubs_channel_id}>\n• <#${status.ranked_channel_id}>\n\nCreated at ${status.created_at} by ${status.created_by}`
-          : 'This command will send automatic updates of Apex Legends Maps in 2 new channels: *apex-pubs* and *apex-ranked*\n\nUpdates occur **every 15 minutes**\n\nRequires:\n• Manage Channel Permissions\n• Send Message Permissions\n• Only Admins can enable automatic status',
+          : 'This command will send automatic updates of Apex Legends Maps in 2 new channels: *apex-pubs* and *apex-ranked*\n\nUpdates occur **every 5 minutes**\n\nRequires:\n• Manage Channel Permissions\n• Send Message Permissions\n• Only Admins can enable automatic status',
         color: 3447003,
       };
       return await interaction.editReply({ embeds: [embedData] });
@@ -56,7 +56,7 @@ const sendStartInteraction = async ({ interaction, nessie }) => {
         color: 3447003,
         description: status
           ? `There's currently an existing automated map status active in:\n• <#${status.pubs_channel_id}>\n• <#${status.ranked_channel_id}>\n\nCreated at ${status.created_at} by ${status.created_by}`
-          : 'By confirming below, Nessie will create a new category channel and 2 new text channels for the automated map status:\n• `Apex Map Status`\n• `#apex-pubs`\n• `#apex-ranked`\n\nNessie will use these channels to send automatic updates every 15 minutes',
+          : 'By confirming below, Nessie will create a new category channel and 2 new text channels for the automated map status:\n• `Apex Map Status`\n• `#apex-pubs`\n• `#apex-ranked`\n\nNessie will use these channels to send automatic updates every 5 minutes',
       };
       const row = new MessageActionRow()
         .addComponents(
@@ -147,7 +147,7 @@ const generatePubsStatusEmbeds = (data) => {
   const arenasEmbed = generatePubsEmbed(data.arenas, 'Arenas');
   const informationEmbed = {
     description:
-      '**Updates occur every 15 minutes**. This feature is currently in beta! For feedback and bug reports, feel free to drop them in the [support server](https://discord.com/invite/47Ccgz9jA4)!',
+      '**Updates occur every 5 minutes**. This feature is currently in beta! For feedback and bug reports, feel free to drop them in the [support server](https://discord.com/invite/47Ccgz9jA4)!',
     color: 3447003,
     timestamp: Date.now(),
     footer: {
@@ -165,7 +165,7 @@ const generateRankedStatusEmbeds = (data) => {
   const arenasEmbed = generateRankedEmbed(data.arenasRanked, 'Arenas');
   const informationEmbed = {
     description:
-      '**Updates occur every 15 minutes**. This feature is currently in beta! For feedback and bug reports, feel free to drop them in the [support server](https://discord.com/invite/47Ccgz9jA4)!',
+      '**Updates occur every 5 minutes**. This feature is currently in beta! For feedback and bug reports, feel free to drop them in the [support server](https://discord.com/invite/47Ccgz9jA4)!',
     color: 3447003,
     timestamp: Date.now(),
     footer: {

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -408,4 +408,6 @@ module.exports = {
   cancelStatusStart,
   cancelStatusStop,
   deleteStatusChannels,
+  generatePubsStatusEmbeds,
+  generateRankedStatusEmbeds,
 };

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -10,7 +10,13 @@ const {
   codeBlock,
 } = require('../../helpers');
 const { v4: uuidv4 } = require('uuid');
-const { insertNewStatus, getStatus, deleteStatus } = require('../../database/handler');
+const {
+  insertNewStatus,
+  getStatus,
+  deleteStatus,
+  getAllStatus,
+} = require('../../database/handler');
+const Scheduler = require('../../scheduler');
 
 //----- Status Application Command Replies -----//
 /**
@@ -360,6 +366,58 @@ const cancelStatusStop = async ({ nessie, interaction }) => {
     await sendErrorLog({ nessie, error, interaction, type, uuid });
   }
 };
+const initialiseStatusScheduler = (nessie) => {
+  return new Scheduler('10 */5 * * * *', async () => {
+    getAllStatus(
+      async (allStatus) => {
+        try {
+          const rotationData = await getRotationData();
+          const statusLogChannel = nessie.channels.cache.get('976863441526595644');
+          if (allStatus) {
+            allStatus.forEach(async (status) => {
+              const pubsChannel = nessie.channels.cache.get(status.pubs_channel_id);
+              const rankedChannel = nessie.channels.cache.get(status.ranked_channel_id);
+              const pubsMessage = await pubsChannel.messages.fetch(status.pubs_message_id);
+              const rankedMessage = await rankedChannel.messages.fetch(status.ranked_message_id);
+
+              const pubsEmbed = generatePubsStatusEmbeds(rotationData);
+              const rankedEmbed = generateRankedStatusEmbeds(rotationData);
+
+              await pubsMessage.edit({ embeds: pubsEmbed });
+              await rankedMessage.edit({ embeds: rankedEmbed });
+              //Figure out rate limiting prevention here
+              //Docs say normal requests is 50 per second but idk if this falls into a special route case
+              //Probably just take a risk and try to send 40 requests (10 servers) and then add a timeout of 1 second?
+            });
+          }
+          const statusLogEmbed = {
+            title: 'Nessie | Auto Map Status Log',
+            description: 'Requested data from API and checked database',
+            timestamp: Date.now(),
+            color: 3066993,
+            fields: [
+              {
+                name: 'Auto Map Status Count:',
+                value: allStatus ? `${allStatus.length}` : '0',
+                inline: true,
+              },
+            ],
+          };
+          await statusLogChannel.send({ embeds: [statusLogEmbed] });
+        } catch (error) {
+          const uuid = uuidv4();
+          const type = 'Status Scheduler (Editing)';
+          await sendErrorLog({ nessie, error, type, uuid, ping: true });
+        }
+      },
+      async (error) => {
+        const uuid = uuidv4();
+        const type = 'Status Scheduler (Database)';
+        await sendErrorLog({ nessie, error, type, uuid, ping: true });
+      }
+    );
+  });
+};
 module.exports = {
   /**
    * Creates Status application command with relevant subcommands
@@ -410,4 +468,5 @@ module.exports = {
   deleteStatusChannels,
   generatePubsStatusEmbeds,
   generateRankedStatusEmbeds,
+  initialiseStatusScheduler,
 };

--- a/database/handler.js
+++ b/database/handler.js
@@ -193,6 +193,20 @@ exports.getStatus = async (guildId, onSuccess, onError) => {
     });
   });
 };
+exports.getAllStatus = async (onSuccess, onError) => {
+  this.pool.connect((err, client, done) => {
+    client.query('BEGIN', (err) => {
+      client.query('SELECT * FROM Status', (err, res) => {
+        if (err) {
+          onError && onError(err.message ? err.message : { message: 'Unexpected Error' });
+          return done();
+        }
+        onSuccess && onSuccess(res.rows.length > 0 ? res.rows : null);
+        done();
+      });
+    });
+  });
+};
 /**
  * Deletes an existing status in our database
  * To do this, we need to get the status tied to the guild first

--- a/database/handler.js
+++ b/database/handler.js
@@ -193,6 +193,11 @@ exports.getStatus = async (guildId, onSuccess, onError) => {
     });
   });
 };
+/**
+ * Gets all existing status in our database
+ * @param onSuccess - function to call when queries are successfully done
+ * @param onError - function to call when queries throw an error
+ */
 exports.getAllStatus = async (onSuccess, onError) => {
   this.pool.connect((err, client, done) => {
     client.query('BEGIN', (err) => {

--- a/events.js
+++ b/events.js
@@ -67,7 +67,7 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
       sendHealthLog(brPubsData, logChannel, true); //For logging purpose
       setCurrentMapStatus(brPubsData, logChannel, nessie); //Calls status display function
 
-      const statusScheduler = new Scheduler('0 */5 * * * *', async () => {
+      const statusScheduler = new Scheduler('10 */5 * * * *', async () => {
         getAllStatus(
           async (allStatus) => {
             try {

--- a/events.js
+++ b/events.js
@@ -67,7 +67,7 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
       sendHealthLog(brPubsData, logChannel, true); //For logging purpose
       setCurrentMapStatus(brPubsData, logChannel, nessie); //Calls status display function
 
-      const statusScheduler = new Scheduler('0 */1 * * * *', async () => {
+      const statusScheduler = new Scheduler('0 */5 * * * *', async () => {
         getAllStatus(
           async (allStatus) => {
             try {

--- a/events.js
+++ b/events.js
@@ -14,6 +14,7 @@ const {
   codeBlock,
   checkIfInDevelopment,
   sendErrorLog,
+  generateErrorEmbed,
 } = require('./helpers');
 const { REST } = require('@discordjs/rest');
 const { Routes } = require('discord-api-types/v9');
@@ -86,6 +87,9 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
 
                   await pubsMessage.edit({ embeds: pubsEmbed });
                   await rankedMessage.edit({ embeds: rankedEmbed });
+                  //Figure out rate limiting prevention here
+                  //Docs say normal requests is 50 per second but idk if this falls into a special route case
+                  //Probably just take a risk and try to send 40 requests (10 servers) and then add a timeout of 1 second?
                 });
               }
               const statusLogEmbed = {
@@ -103,11 +107,15 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
               };
               await statusLogChannel.send({ embeds: [statusLogEmbed] });
             } catch (error) {
-              console.log(error);
+              const uuid = uuidv4();
+              const type = 'Status Scheduler (Editing)';
+              await sendErrorLog({ nessie, error, type, uuid, ping: true });
             }
           },
           async (error) => {
-            console.log(error);
+            const uuid = uuidv4();
+            const type = 'Status Scheduler (Database)';
+            await sendErrorLog({ nessie, error, type, uuid, ping: true });
           }
         );
       });

--- a/events.js
+++ b/events.js
@@ -34,6 +34,7 @@ const {
   deleteStatusChannels,
   generatePubsStatusEmbeds,
   generateRankedStatusEmbeds,
+  initialiseStatusScheduler,
 } = require('./commands/maps/status');
 const Scheduler = require('./scheduler');
 const { v4: uuidv4 } = require('uuid');
@@ -66,60 +67,8 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
       nessie.user.setActivity(brPubsData.current.map); //Set current br map as activity status
       sendHealthLog(brPubsData, logChannel, true); //For logging purpose
       setCurrentMapStatus(brPubsData, logChannel, nessie); //Calls status display function
-
-      const statusScheduler = new Scheduler('10 */5 * * * *', async () => {
-        getAllStatus(
-          async (allStatus) => {
-            try {
-              const rotationData = await getRotationData();
-              const statusLogChannel = nessie.channels.cache.get('976863441526595644');
-              if (allStatus) {
-                allStatus.forEach(async (status) => {
-                  const pubsChannel = nessie.channels.cache.get(status.pubs_channel_id);
-                  const rankedChannel = nessie.channels.cache.get(status.ranked_channel_id);
-                  const pubsMessage = await pubsChannel.messages.fetch(status.pubs_message_id);
-                  const rankedMessage = await rankedChannel.messages.fetch(
-                    status.ranked_message_id
-                  );
-
-                  const pubsEmbed = generatePubsStatusEmbeds(rotationData);
-                  const rankedEmbed = generateRankedStatusEmbeds(rotationData);
-
-                  await pubsMessage.edit({ embeds: pubsEmbed });
-                  await rankedMessage.edit({ embeds: rankedEmbed });
-                  //Figure out rate limiting prevention here
-                  //Docs say normal requests is 50 per second but idk if this falls into a special route case
-                  //Probably just take a risk and try to send 40 requests (10 servers) and then add a timeout of 1 second?
-                });
-              }
-              const statusLogEmbed = {
-                title: 'Nessie | Auto Map Status Log',
-                description: 'Requested data from API and checked database',
-                timestamp: Date.now(),
-                color: 3066993,
-                fields: [
-                  {
-                    name: 'Auto Map Status Count:',
-                    value: allStatus ? `${allStatus.length}` : '0',
-                    inline: true,
-                  },
-                ],
-              };
-              await statusLogChannel.send({ embeds: [statusLogEmbed] });
-            } catch (error) {
-              const uuid = uuidv4();
-              const type = 'Status Scheduler (Editing)';
-              await sendErrorLog({ nessie, error, type, uuid, ping: true });
-            }
-          },
-          async (error) => {
-            const uuid = uuidv4();
-            const type = 'Status Scheduler (Database)';
-            await sendErrorLog({ nessie, error, type, uuid, ping: true });
-          }
-        );
-      });
-      statusScheduler.start();
+      const statusScheduler = initialiseStatusScheduler(nessie); //Initialises auto status scheduler
+      statusScheduler.start(); //Starts the status scheduler
     } catch (e) {
       console.log(e); //Add proper error handling
     }

--- a/events.js
+++ b/events.js
@@ -6,13 +6,14 @@
  * But that would be in another time heh
  */
 const { guildIDs, token } = require('./config/nessie.json');
-const { getBattleRoyalePubs } = require('./adapters');
+const { getBattleRoyalePubs, getRotationData } = require('./adapters');
 const { sendMixpanelEvent } = require('./analytics');
 const {
   sendHealthLog,
   sendGuildUpdateNotification,
   codeBlock,
   checkIfInDevelopment,
+  sendErrorLog,
 } = require('./helpers');
 const { REST } = require('@discordjs/rest');
 const { Routes } = require('discord-api-types/v9');
@@ -23,13 +24,18 @@ const {
   removeServerDataFromNessie,
   pool,
   createStatusTable,
+  getAllStatus,
 } = require('./database/handler');
 const {
   createStatusChannels,
   cancelStatusStart,
   cancelStatusStop,
   deleteStatusChannels,
+  generatePubsStatusEmbeds,
+  generateRankedStatusEmbeds,
 } = require('./commands/maps/status');
+const Scheduler = require('./scheduler');
+const { v4: uuidv4 } = require('uuid');
 
 const appCommands = getApplicationCommands(); //Get list of application commands
 
@@ -59,6 +65,53 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
       nessie.user.setActivity(brPubsData.current.map); //Set current br map as activity status
       sendHealthLog(brPubsData, logChannel, true); //For logging purpose
       setCurrentMapStatus(brPubsData, logChannel, nessie); //Calls status display function
+
+      const statusScheduler = new Scheduler('0 */1 * * * *', async () => {
+        getAllStatus(
+          async (allStatus) => {
+            try {
+              const rotationData = await getRotationData();
+              const statusLogChannel = nessie.channels.cache.get('976863441526595644');
+              if (allStatus) {
+                allStatus.forEach(async (status) => {
+                  const pubsChannel = nessie.channels.cache.get(status.pubs_channel_id);
+                  const rankedChannel = nessie.channels.cache.get(status.ranked_channel_id);
+                  const pubsMessage = await pubsChannel.messages.fetch(status.pubs_message_id);
+                  const rankedMessage = await rankedChannel.messages.fetch(
+                    status.ranked_message_id
+                  );
+
+                  const pubsEmbed = generatePubsStatusEmbeds(rotationData);
+                  const rankedEmbed = generateRankedStatusEmbeds(rotationData);
+
+                  await pubsMessage.edit({ embeds: pubsEmbed });
+                  await rankedMessage.edit({ embeds: rankedEmbed });
+                });
+              }
+              const statusLogEmbed = {
+                title: 'Nessie | Auto Map Status Log',
+                description: 'Requested data from API and checked database',
+                timestamp: Date.now(),
+                color: 3066993,
+                fields: [
+                  {
+                    name: 'Auto Map Status Count:',
+                    value: allStatus ? `${allStatus.length}` : '0',
+                    inline: true,
+                  },
+                ],
+              };
+              await statusLogChannel.send({ embeds: [statusLogEmbed] });
+            } catch (error) {
+              console.log(error);
+            }
+          },
+          async (error) => {
+            console.log(error);
+          }
+        );
+      });
+      statusScheduler.start();
     } catch (e) {
       console.log(e); //Add proper error handling
     }

--- a/events.js
+++ b/events.js
@@ -6,16 +6,9 @@
  * But that would be in another time heh
  */
 const { guildIDs, token } = require('./config/nessie.json');
-const { getBattleRoyalePubs, getRotationData } = require('./adapters');
+const { getBattleRoyalePubs } = require('./adapters');
 const { sendMixpanelEvent } = require('./analytics');
-const {
-  sendHealthLog,
-  sendGuildUpdateNotification,
-  codeBlock,
-  checkIfInDevelopment,
-  sendErrorLog,
-  generateErrorEmbed,
-} = require('./helpers');
+const { sendHealthLog, sendGuildUpdateNotification, checkIfInDevelopment } = require('./helpers');
 const { REST } = require('@discordjs/rest');
 const { Routes } = require('discord-api-types/v9');
 const { getApplicationCommands } = require('./commands');
@@ -23,21 +16,15 @@ const {
   createGuildTable,
   insertNewGuild,
   removeServerDataFromNessie,
-  pool,
   createStatusTable,
-  getAllStatus,
 } = require('./database/handler');
 const {
   createStatusChannels,
   cancelStatusStart,
   cancelStatusStop,
   deleteStatusChannels,
-  generatePubsStatusEmbeds,
-  generateRankedStatusEmbeds,
   initialiseStatusScheduler,
 } = require('./commands/maps/status');
-const Scheduler = require('./scheduler');
-const { v4: uuidv4 } = require('uuid');
 
 const appCommands = getApplicationCommands(); //Get list of application commands
 

--- a/helpers.js
+++ b/helpers.js
@@ -179,6 +179,7 @@ const generateErrorEmbed = async (error, uuid, nessie) => {
  * @param interaction - discord interaction object
  * @param type - which command the error originated from
  * @param uuid - error uuid
+ * @param ping - whether to ping me if an error occured; default false
  */
 const sendErrorLog = async ({ nessie, error, message, interaction, type, uuid, ping = false }) => {
   const errorChannel = nessie.channels.cache.get('938441853542465548');

--- a/helpers.js
+++ b/helpers.js
@@ -180,46 +180,51 @@ const generateErrorEmbed = async (error, uuid, nessie) => {
  * @param type - which command the error originated from
  * @param uuid - error uuid
  */
-const sendErrorLog = async ({ nessie, error, message, interaction, type, uuid }) => {
+const sendErrorLog = async ({ nessie, error, message, interaction, type, uuid, ping = false }) => {
   const errorChannel = nessie.channels.cache.get('938441853542465548');
   const embed = {
     title: message ? `Error | ${type} Prefix Command` : `Error | ${type} Application Command`,
     color: 16711680,
     description: `uuid: ${uuid}\nError: ${error.message ? error.message : 'Unexpected Error'}`,
-    fields: [
-      {
-        name: 'User',
-        value: message ? message.author.username : interaction.user.username,
-        inline: true,
-      },
-      {
-        name: 'User ID',
-        value: message ? message.author.id : interaction.user.id,
-        inline: true,
-      },
-      {
-        name: 'Channel',
-        value: message ? message.channel.name : interaction.channel.name,
-        inline: true,
-      },
-      {
-        name: 'Channel ID',
-        value: message ? message.channel.id : interaction.channelId,
-        inline: true,
-      },
-      {
-        name: 'Guild',
-        value: message ? message.guild.name : interaction.guild.name,
-        inline: true,
-      },
-      {
-        name: 'Guild ID',
-        value: message ? message.guild.id : interaction.guildId,
-        inline: true,
-      },
-    ],
+    fields:
+      message || interaction
+        ? [
+            {
+              name: 'User',
+              value: message ? message.author.username : interaction.user.username,
+              inline: true,
+            },
+            {
+              name: 'User ID',
+              value: message ? message.author.id : interaction.user.id,
+              inline: true,
+            },
+            {
+              name: 'Channel',
+              value: message ? message.channel.name : interaction.channel.name,
+              inline: true,
+            },
+            {
+              name: 'Channel ID',
+              value: message ? message.channel.id : interaction.channelId,
+              inline: true,
+            },
+            {
+              name: 'Guild',
+              value: message ? message.guild.name : interaction.guild.name,
+              inline: true,
+            },
+            {
+              name: 'Guild ID',
+              value: message ? message.guild.id : interaction.guildId,
+              inline: true,
+            },
+          ]
+        : [],
   };
-  return await errorChannel.send({ embeds: [embed] });
+  return ping
+    ? await errorChannel.send({ embeds: [embed], content: '<@183444648360935424>' })
+    : await errorChannel.send({ embeds: [embed] });
 };
 const generateAnnouncementMessage = (prefix) => {
   return (


### PR DESCRIPTION
#### Context
This would have been the most challenging part of the whole status feature until I found out about cron jobs a couple of months before. Now it's so simple and straightforward I'm still always so amazed when it's working lol. Anyway using the Scheduler class I built during the spike, this pr creates a status scheduler that will fire every 10th second of every 5 minutes i.e 0:05:10, 0:10:10, 0:15:10, etc. When it fires, we'll get all the existing status in our database and then for each of them, update the relevant messages with the current rotation data

Only thing left to do is how to prevent rate limiting and edge cases. Shouldn't be too crazy and I think I can get this out in a week

![status update](https://user-images.githubusercontent.com/42207245/169660041-0c4ac5f1-c8b6-4a58-b786-95bfe48023a1.gif)
<img width="561" alt="image" src="https://user-images.githubusercontent.com/42207245/169659852-781f039e-3a08-4a70-8042-29ee501928ab.png">
<img width="320" alt="image" src="https://user-images.githubusercontent.com/42207245/169659869-09c6dd0e-6f40-4ef3-9788-d3aca629192c.png">
<img width="498" alt="image" src="https://user-images.githubusercontent.com/42207245/169659894-4f351576-bbce-401a-8fa2-99e8c215ff41.png">
<img width="522" alt="image" src="https://user-images.githubusercontent.com/42207245/169659956-648bb5e0-61e3-4765-929d-f01bfda1863e.png">


#### Change
- Create scheduler for status updates
- Add error handling
- Change update to every 5 minutes

#### Considerations
Changed the update from 15 minutes to 5 minutes since I think the former is a bit too long. Granted I put this value at the start as I was unsure on how rate limiting is gonna play out and putting a smaller window in updates means higher risk in complicating things. That being said, I kinda have an idea on how to prevent it and it really shouldn't take 5 minutes to update every message. Possibly 2 minutes at most for 1000 servers but I'll know more at the actual pr