### PR TITLE
Spike on announcement channels

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -10,7 +10,7 @@ exports.getApplicationCommands = () => {
     help: require('./commands/hub/help'),
     invite: require('./commands/hub/invite'),
     updates: require('./commands/hub/updates'),
-    // ratelimit: require('./commands/hub/rateLimit'),
+    ratelimit: require('./commands/hub/rateLimit'),
     // Maps
     br: require('./commands/maps/battle-royale'),
     arenas: require('./commands/maps/arenas'),

--- a/commands/hub/rateLimit.js
+++ b/commands/hub/rateLimit.js
@@ -25,10 +25,15 @@ module.exports = {
           text: 'Last Update',
         },
       };
-      await brAnnouncement.send({
+      const brMessage = await brAnnouncement.send({
         embeds: [informationEmbed, battleRoyaleRanked, battleRoyalePubs],
       });
-      await arenasAnnouncement.send({ embeds: [informationEmbed, arenasRanked, arenasPubs] });
+      const arenasMessage = await arenasAnnouncement.send({
+        embeds: [informationEmbed, arenasRanked, arenasPubs],
+      });
+
+      await brMessage.crosspost();
+      await arenasMessage.crosspost();
       await interaction.editReply('Testing Announcements');
     } catch (data) {
       console.log(data);

--- a/commands/hub/rateLimit.js
+++ b/commands/hub/rateLimit.js
@@ -2,6 +2,8 @@ const { SlashCommandBuilder } = require('@discordjs/builders');
 const { sendErrorLog } = require('../../helpers');
 const { v4: uuidv4 } = require('uuid');
 const { format } = require('date-fns');
+const { getRotationData } = require('../../adapters');
+const { generateFullStatusEmbeds } = require('../maps/status');
 
 module.exports = {
   data: new SlashCommandBuilder().setName('ratelimit').setDescription('Testing rate limiting'),
@@ -9,9 +11,10 @@ module.exports = {
     try {
       await interaction.deferReply();
       const testAnnouncement = nessie.channels.cache.get('981566881993490453');
+      const rotationData = await getRotationData();
+      const statusEmbed = generateFullStatusEmbeds(rotationData);
 
-      await testAnnouncement.send('Test');
-
+      await testAnnouncement.send({ embeds: statusEmbed });
       await interaction.editReply('Testing Announcements');
     } catch (data) {
       console.log(data);

--- a/commands/hub/rateLimit.js
+++ b/commands/hub/rateLimit.js
@@ -1,20 +1,34 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
-const { sendErrorLog } = require('../../helpers');
+const { sendErrorLog, generatePubsEmbed, generateRankedEmbed } = require('../../helpers');
 const { v4: uuidv4 } = require('uuid');
-const { format } = require('date-fns');
 const { getRotationData } = require('../../adapters');
-const { generateFullStatusEmbeds } = require('../maps/status');
 
 module.exports = {
   data: new SlashCommandBuilder().setName('ratelimit').setDescription('Testing rate limiting'),
   async execute({ nessie, interaction }) {
     try {
       await interaction.deferReply();
-      const testAnnouncement = nessie.channels.cache.get('981566881993490453');
+      const brAnnouncement = nessie.channels.cache.get('981566881993490453');
+      const arenasAnnouncement = nessie.channels.cache.get('981594277593374821');
       const rotationData = await getRotationData();
-      const statusEmbed = generateFullStatusEmbeds(rotationData);
+      const battleRoyalePubs = generatePubsEmbed(rotationData.battle_royale);
+      const battleRoyaleRanked = generateRankedEmbed(rotationData.ranked);
+      const arenasPubs = generatePubsEmbed(rotationData.arenas, 'Arenas');
+      const arenasRanked = generateRankedEmbed(rotationData.arenasRanked, 'Arenas');
 
-      await testAnnouncement.send({ embeds: statusEmbed });
+      const informationEmbed = {
+        description:
+          '**Updates occur every X minutes**. This feature is currently in beta! For feedback and bug reports, feel free to drop them in the [support server](https://discord.com/invite/47Ccgz9jA4)!',
+        color: 3447003,
+        timestamp: Date.now(),
+        footer: {
+          text: 'Last Update',
+        },
+      };
+      await brAnnouncement.send({
+        embeds: [informationEmbed, battleRoyaleRanked, battleRoyalePubs],
+      });
+      await arenasAnnouncement.send({ embeds: [informationEmbed, arenasRanked, arenasPubs] });
       await interaction.editReply('Testing Announcements');
     } catch (data) {
       console.log(data);

--- a/commands/hub/rateLimit.js
+++ b/commands/hub/rateLimit.js
@@ -8,66 +8,11 @@ module.exports = {
   async execute({ nessie, interaction }) {
     try {
       await interaction.deferReply();
-      const testChannelOne = nessie.channels.cache.get('978325622537453578');
+      const testAnnouncement = nessie.channels.cache.get('981566881993490453');
 
-      // const testChannelTwo = nessie.channels.cache.get('976863441526595644');
-      // const testMessageTwo = await testChannelTwo.messages.fetch('977980466617544725');
-      // await testMessageTwo.edit({ embeds: [embed] });
-      const messagesToDelete = [
-        '978706671012548608',
-        '978706676922327140',
-        '978706682962145311',
-        '978706690499305545',
-        '978706696513912902',
-        '978706703979774023',
-        '978706712192245781',
-        '978706718513070160',
-        '978706725085520002',
-        '978706730928177162',
-        '978706737077026937',
-        '978706743431430234',
-        '978706749395726437',
-        '978706756299550740',
-        '978706764935626762',
-        '978706770845392976',
-        '978706777992495124',
-        '978706784225210468',
-        '978706791875637278',
-        '978706798515216454',
-      ];
-      let count = 0;
-      const testLoop = () => {
-        setTimeout(async () => {
-          if (count < 20) {
-            // const embed = {
-            //   title: 'Testing Rate Limit',
-            //   description: `Current Count: ${count}`,
-            // };
-            // const testMessageOne = await testChannelOne.send({ embeds: [embed] });
-            // const currentTime = format(new Date(), 'h:mm:ss a');
-            // // console.log(count, ' | ', currentTime);
-            // console.log(testMessageOne.id.toString(), ',');
-            const m = await testChannelOne.messages.fetch(messagesToDelete[count]);
-            const y = await testChannelOne.messages.fetch(messagesToDelete[count + 1]);
-            await m.delete();
-            await y.delete();
-            const currentTime = format(new Date(), 'h:mm:ss a');
-            console.log(count, ' | ', currentTime);
-            count += 2;
-            testLoop();
-          }
-        }, 1670);
-      };
-      testLoop();
+      await testAnnouncement.send('Test');
 
-      // messagesToDelete.forEach(async (message) => {
-      //   count += 1;
-      //   const m = await testChannelOne.messages.fetch(message.toString());
-      //   await m.delete();
-      //   const currentTime = format(new Date(), 'h:mm:ss a');
-      //   console.log(count, ' | ', currentTime);
-      // });
-      await interaction.editReply('Testing Rate Limits');
+      await interaction.editReply('Testing Announcements');
     } catch (data) {
       console.log(data);
       const uuid = uuidv4();

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -180,29 +180,6 @@ const generateRankedStatusEmbeds = (data) => {
   };
   return [informationEmbed, battleRoyaleEmbed, arenasEmbed];
 };
-const generateFullStatusEmbeds = (data) => {
-  const battleRoyalePubsEmbed = generatePubsEmbed(data.battle_royale);
-  const battleRoyaleRankedEmbed = generateRankedEmbed(data.ranked);
-  const arenasPubsEmbed = generatePubsEmbed(data.arenas, 'Arenas');
-  const arenasRankedEmbed = generateRankedEmbed(data.arenasRanked, 'Arenas');
-
-  const informationEmbed = {
-    description:
-      '**Updates occur every X minutes**. This feature is currently in beta! For feedback and bug reports, feel free to drop them in the [support server](https://discord.com/invite/47Ccgz9jA4)!',
-    color: 3447003,
-    timestamp: Date.now(),
-    footer: {
-      text: 'Last Update',
-    },
-  };
-  return [
-    informationEmbed,
-    arenasRankedEmbed,
-    arenasPubsEmbed,
-    battleRoyaleRankedEmbed,
-    battleRoyalePubsEmbed,
-  ];
-};
 /**
  * Handler for initialising the process of map status
  * Gets called when a user clicks the confirm button of the /status start reply
@@ -505,6 +482,5 @@ module.exports = {
   deleteStatusChannels,
   generatePubsStatusEmbeds,
   generateRankedStatusEmbeds,
-  generateFullStatusEmbeds,
   initialiseStatusScheduler,
 };

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -180,6 +180,29 @@ const generateRankedStatusEmbeds = (data) => {
   };
   return [informationEmbed, battleRoyaleEmbed, arenasEmbed];
 };
+const generateFullStatusEmbeds = (data) => {
+  const battleRoyalePubsEmbed = generatePubsEmbed(data.battle_royale);
+  const battleRoyaleRankedEmbed = generateRankedEmbed(data.ranked);
+  const arenasPubsEmbed = generatePubsEmbed(data.arenas, 'Arenas');
+  const arenasRankedEmbed = generateRankedEmbed(data.arenasRanked, 'Arenas');
+
+  const informationEmbed = {
+    description:
+      '**Updates occur every X minutes**. This feature is currently in beta! For feedback and bug reports, feel free to drop them in the [support server](https://discord.com/invite/47Ccgz9jA4)!',
+    color: 3447003,
+    timestamp: Date.now(),
+    footer: {
+      text: 'Last Update',
+    },
+  };
+  return [
+    informationEmbed,
+    arenasRankedEmbed,
+    arenasPubsEmbed,
+    battleRoyaleRankedEmbed,
+    battleRoyalePubsEmbed,
+  ];
+};
 /**
  * Handler for initialising the process of map status
  * Gets called when a user clicks the confirm button of the /status start reply
@@ -482,5 +505,6 @@ module.exports = {
   deleteStatusChannels,
   generatePubsStatusEmbeds,
   generateRankedStatusEmbeds,
+  generateFullStatusEmbeds,
   initialiseStatusScheduler,
 };


### PR DESCRIPTION
#### Context
With the initial plan now in flames, we move on to finding another solution into this automatic status mess we've stumbled upon. Really should have looked into my gut feeling when I questioned why I've never seen any bot doing any auto updating on a massive scale. But enough brooding because I've already thought of 2 alternatives. One of which is sure to be one of the best ideas I've thought in a while but that can wait since it's probably gonna take quite some time to do. 

That being said, the other idea concerns this pr. Announcement channels and boy do they work wonders getting updates everywhere. Then again I suppose that is what they're for heh. Again I've put my ramblings in this doc https://shizuka.notion.site/Adventures-in-Discord-s-Rate-Limits-4ef7fa20481f4e3b8a388d9cdb1021e7 but in summary the rate limits are:
- You can only publish 10 times within the hour, resets in the next hour
- Editing a published message can only be done 3 times within an hour, resets after 1 hour of first edit
- I tried deleting a bunch of messages but couldn't get rate limited so maybe there's none? Or at least it's high enough that we wont hit it
- Best part: Rate limits are constrained within the channel

A damn good alternative

#### Change
- Send message on an announcement channel
- Send br and arenas embeds
- Publish messages

#### Considerations
Looking at product usage, looks like the overwhelming favourite is battle royale. Not surprising but I didn't quite expect the distribution to be bad. In the last 3 months, Arenas Pubs averages at 47 with its ranked at 33. Battle Royale ranked however is easily more popular at 75. Br Pubs? 1358 and May being the highest recorded so far at 2571

Absolutely insane but it had me thinking of changing how we show status maps now. It only makes sense to have br and arenas instead of pubs and ranked now

![image](https://user-images.githubusercontent.com/42207245/171652578-8d0f0b12-2504-4bbe-8157-f999b12b67f5.png)

