### PR TITLE
Start announcement scheduler

### DIFF
--- a/commands/admin/announcement.js
+++ b/commands/admin/announcement.js
@@ -192,6 +192,7 @@ const createStatusChannels = async ({ nessie, interaction }) => {
     const rotationData = await getRotationData();
     const statusBattleRoyaleEmbed = generateBattleRoyaleStatusEmbeds(rotationData);
     const statusArenasEmbed = generateArenasStatusEmbeds(rotationData);
+    const everyoneRole = interaction.guild.roles.cache.find((role) => role.name === '@everyone');
 
     // //Creates a category channel for better readability
     const statusCategory = await interaction.guild.channels.create('Apex Legends Map Status', {
@@ -203,11 +204,23 @@ const createStatusChannels = async ({ nessie, interaction }) => {
       {
         parent: statusCategory,
         type: 'GUILD_NEWS',
+        permissionOverwrites: [
+          {
+            id: everyoneRole.id,
+            deny: ['SEND_MESSAGES'],
+          },
+        ],
       }
     );
     const statusArenasChannel = await interaction.guild.channels.create('apex-arenas', {
       parent: statusCategory,
       type: 'GUILD_NEWS',
+      permissionOverwrites: [
+        {
+          id: everyoneRole.id,
+          deny: ['SEND_MESSAGES'],
+        },
+      ],
     });
     const statusBattleRoyaleMessage = await statusBattleRoyaleChannel.send({
       embeds: statusBattleRoyaleEmbed,

--- a/commands/admin/announcement.js
+++ b/commands/admin/announcement.js
@@ -391,7 +391,7 @@ const cancelStatusStop = async ({ nessie, interaction }) => {
  * Since the functionalitiy is more or less the same, I'm opting to use the same function with some additions
  */
 const initialiseStatusScheduler = (nessie) => {
-  return new Scheduler('10 */5 * * * *', async () => {
+  return new Scheduler('10 */15 * * * *', async () => {
     getAllStatus(
       async (allStatus, client) => {
         try {
@@ -417,8 +417,16 @@ const initialiseStatusScheduler = (nessie) => {
             });
             const newArenasMessage = await arenasChannel.send({ embeds: arenasEmbed });
 
-            await newBattleRoyaleMessage.crosspost();
-            await newArenasMessage.crosspost();
+            client.query(
+              'UPDATE Status SET br_message_id = ($1), arenas_message_id = ($2) WHERE uuid = ($3)',
+              [`${newBattleRoyaleMessage.id}`, `${newArenasMessage.id}`, `${status.uuid}`],
+              (err, res) => {
+                client.query('COMMIT', async () => {
+                  await newBattleRoyaleMessage.crosspost();
+                  await newArenasMessage.crosspost();
+                });
+              }
+            );
           }
           const statusLogEmbed = {
             title: 'Nessie | Auto Map Status Log',

--- a/database/handler.js
+++ b/database/handler.js
@@ -187,7 +187,6 @@ exports.getStatus = async (guildId, onSuccess, onError) => {
           onError && onError(err.message ? err.message : { message: 'Unexpected Error' });
           return done();
         }
-        console.log(res.rows);
         onSuccess && onSuccess(res.rows.length > 0 ? res.rows[0] : null);
         done();
       });
@@ -207,7 +206,7 @@ exports.getAllStatus = async (onSuccess, onError) => {
           onError && onError(err.message ? err.message : { message: 'Unexpected Error' });
           return done();
         }
-        onSuccess && onSuccess(res.rows.length > 0 ? res.rows : null);
+        onSuccess && onSuccess(res.rows.length > 0 ? res.rows : null, client);
         done();
       });
     });

--- a/events.js
+++ b/events.js
@@ -29,6 +29,7 @@ const {
   cancelStatusStop,
   createStatusChannels,
   deleteStatusChannels,
+  initialiseStatusScheduler,
 } = require('./commands/admin/announcement');
 
 const appCommands = getApplicationCommands(); //Get list of application commands
@@ -59,6 +60,8 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
       nessie.user.setActivity(brPubsData.current.map); //Set current br map as activity status
       sendHealthLog(brPubsData, logChannel, true); //For logging purpose
       setCurrentMapStatus(brPubsData, logChannel, nessie); //Calls status display function
+      const statusScheduler = initialiseStatusScheduler(nessie); //Initialises auto status scheduler
+      statusScheduler.start(); //Starts the scheduler
     } catch (e) {
       console.log(e); //Add proper error handling
     }


### PR DESCRIPTION
#### Context
Similar to the previous pr, this is the counterpart of status scheduler. It's basically it but extra stuff like publishing messages and updating the database with the new created messages. Also found something interesting. Apparently if the announcement channel has message permissions, users won't be able to follow it. Maybe this was intended by Discord so everyone can publish messages in it but seems so weird. Anyway I've denied the permission now when creating them so all good

![image](https://user-images.githubusercontent.com/42207245/172006624-39c20385-f490-44b0-ac62-878d7216765a.png)
![image](https://user-images.githubusercontent.com/42207245/172006676-492f2e2e-49ec-45b6-9758-b5905bcc6b1a.png)
![image](https://user-images.githubusercontent.com/42207245/172006836-e669519b-07ba-4fb6-917f-951f3fae6d4f.png)
![image](https://user-images.githubusercontent.com/42207245/172006790-9dd54307-a473-4dbe-bef5-b58652a85c03.png)

#### Change
- Update status scheduler
- Create status channels with no send messages permissions
- Update database with new status messages
