### PR TITLE
Add announcement info in status

### DIFF
--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -1,7 +1,7 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
+const { MessageActionRow, MessageButton } = require('discord.js');
 const { generateErrorEmbed, sendErrorLog } = require('../../helpers');
 const { v4: uuidv4 } = require('uuid');
-const { getStatus } = require('../../database/handler');
 
 //----- Status Application Command Replies -----//
 /**
@@ -10,24 +10,28 @@ const { getStatus } = require('../../database/handler');
  * Passes a success and error callback with the former sending an information embed with context depending on status existence
  */
 const sendHelpInteraction = async ({ interaction, nessie }) => {
-  await getStatus(
-    interaction.guildId,
-    async (status) => {
-      const embedData = {
-        title: 'Status | Help',
-        description: 'To be filled',
-        color: 3447003,
-      };
-      return await interaction.editReply({ embeds: [embedData] });
-    },
-    async (error) => {
-      const uuid = uuidv4();
-      const type = 'Getting Status in Database (Help)';
-      const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
-      interaction.editReply({ embeds: errorEmbed });
-      await sendErrorLog({ nessie, error, interaction, type, uuid });
-    }
-  );
+  try {
+    const embedData = {
+      title: 'Status | About',
+      description:
+        "Due to technical limitations with Discord, automatic updates through normal messages/interactions isn't possible in a large scale. Fortunately an alternative approach is being worked on but it might take a while before it gets released\n\nAs a temporary solution, I've set up automatic map updates in announcement channels in the support server.\n\nFeel free to join and follow the channels!",
+      color: 3447003,
+    };
+    const row = new MessageActionRow().addComponents(
+      new MessageButton()
+        .setLabel("To Nessie's Canyon")
+        .setStyle('LINK')
+        .setURL('https://discord.com/invite/47Ccgz9jA4')
+    );
+
+    return await interaction.editReply({ components: [row], embeds: [embedData] });
+  } catch (error) {
+    const uuid = uuidv4();
+    const type = 'Status About';
+    const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
+    await interaction.editReply({ embeds: errorEmbed });
+    await sendErrorLog({ nessie, error, interaction, type, uuid });
+  }
 };
 module.exports = {
   data: new SlashCommandBuilder().setName('status').setDescription('To be filled'),

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -3,11 +3,11 @@ const { MessageActionRow, MessageButton } = require('discord.js');
 const { generateErrorEmbed, sendErrorLog } = require('../../helpers');
 const { v4: uuidv4 } = require('uuid');
 
-//----- Status Application Command Replies -----//
 /**
- * Handler for when a user initiates the /status help command
- * Calls the getStatus handler to see for existing status in the guild
- * Passes a success and error callback with the former sending an information embed with context depending on status existence
+ * Temporary handler for status command
+ * Just displays information on why there's no proper status yet
+ * Also has an invite button to redirect people to the support server
+ * TODO: Probably need to make the support server an actual community server with actual rules and stuff
  */
 const sendHelpInteraction = async ({ interaction, nessie }) => {
   try {

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -34,7 +34,9 @@ const sendHelpInteraction = async ({ interaction, nessie }) => {
   }
 };
 module.exports = {
-  data: new SlashCommandBuilder().setName('status').setDescription('To be filled'),
+  data: new SlashCommandBuilder()
+    .setName('status')
+    .setDescription('Displays information on how to get automatic map updates'),
 
   async execute({ nessie, interaction, mixpanel }) {
     try {


### PR DESCRIPTION
#### Context
Pretty much just adding the announcement info in the status command. Probably have to set up the support server to look like an actual community server before the next release lol. Might be a good idea to finish up the terms of service and privacy policy too heh

<img width="503" alt="image" src="https://user-images.githubusercontent.com/42207245/172057013-3edfb7fe-cf91-4a04-8453-3603bbd626a5.png">

#### Change
- Add announcement info
- Add invite button for support server