### PR TITLE
Update info for announcement

### DIFF
--- a/commands/admin/announcement.js
+++ b/commands/admin/announcement.js
@@ -412,6 +412,7 @@ const initialiseStatusScheduler = (nessie) => {
     getAllStatus(
       async (allStatus, client) => {
         try {
+          throw new Error('Test Error');
           const rotationData = await getRotationData();
           const statusLogChannel = nessie.channels.cache.get('976863441526595644');
           if (allStatus) {

--- a/commands/admin/announcement.js
+++ b/commands/admin/announcement.js
@@ -133,7 +133,7 @@ const generateBattleRoyaleStatusEmbeds = (data) => {
   const battleRoyaleRankedEmbed = generateRankedEmbed(data.ranked);
   const informationEmbed = {
     description:
-      '**Updates occur every 15 minutes**. This feature is currently in beta! For feedback and bug reports, feel free to drop them in the [support server](https://discord.com/invite/47Ccgz9jA4)!',
+      '**Updates occur every 15 minutes**. This is a temporary feature while a more refined solution is being worked on to get automatic map updates directly in your servers. For feedback, bug reports or news update, feel free visit the [support server](https://discord.com/invite/47Ccgz9jA4)!',
     color: 3447003,
     timestamp: Date.now(),
     footer: {
@@ -152,7 +152,7 @@ const generateArenasStatusEmbeds = (data) => {
   const arenasRankedEmbed = generateRankedEmbed(data.arenasRanked, 'Arenas');
   const informationEmbed = {
     description:
-      '**Updates occur every 15 minutes**. This feature is currently in beta! For feedback and bug reports, feel free to drop them in the [support server](https://discord.com/invite/47Ccgz9jA4)!',
+      '**Updates occur every 15 minutes**. This is a temporary feature while a more refined solution is being worked on to get automatic map updates directly in your servers. For feedback, bug reports or news update, feel free visit the [support server](https://discord.com/invite/47Ccgz9jA4)!',
     color: 3447003,
     timestamp: Date.now(),
     footer: {
@@ -412,7 +412,6 @@ const initialiseStatusScheduler = (nessie) => {
     getAllStatus(
       async (allStatus, client) => {
         try {
-          throw new Error('Test Error');
           const rotationData = await getRotationData();
           const statusLogChannel = nessie.channels.cache.get('976863441526595644');
           if (allStatus) {
@@ -467,7 +466,7 @@ const initialiseStatusScheduler = (nessie) => {
           await statusLogChannel.send({ embeds: [statusLogEmbed] });
         } catch (error) {
           const uuid = uuidv4();
-          const type = 'Status Scheduler (Editing)';
+          const type = 'Status Scheduler Config';
           await sendErrorLog({ nessie, error, type, uuid, ping: true });
         }
       },

--- a/commands/admin/announcement.js
+++ b/commands/admin/announcement.js
@@ -133,7 +133,7 @@ const generateBattleRoyaleStatusEmbeds = (data) => {
   const battleRoyaleRankedEmbed = generateRankedEmbed(data.ranked);
   const informationEmbed = {
     description:
-      '**Updates occur every 15 minutes**. This is a temporary feature while a more refined solution is being worked on to get automatic map updates directly in your servers. For feedback, bug reports or news update, feel free visit the [support server](https://discord.com/invite/47Ccgz9jA4)!',
+      '**Updates occur every 15 minutes**. This is a temporary feature while a more refined solution is being worked on to get automatic map updates directly in your servers. For feedback, bug reports or news update, feel free visit the [support server](https://discord.gg/FyxVrAbRAd)!',
     color: 3447003,
     timestamp: Date.now(),
     footer: {
@@ -152,7 +152,7 @@ const generateArenasStatusEmbeds = (data) => {
   const arenasRankedEmbed = generateRankedEmbed(data.arenasRanked, 'Arenas');
   const informationEmbed = {
     description:
-      '**Updates occur every 15 minutes**. This is a temporary feature while a more refined solution is being worked on to get automatic map updates directly in your servers. For feedback, bug reports or news update, feel free visit the [support server](https://discord.com/invite/47Ccgz9jA4)!',
+      '**Updates occur every 15 minutes**. This is a temporary feature while a more refined solution is being worked on to get automatic map updates directly in your servers. For feedback, bug reports or news update, feel free visit the [support server](https://discord.gg/FyxVrAbRAd)!',
     color: 3447003,
     timestamp: Date.now(),
     footer: {

--- a/commands/hub/about.js
+++ b/commands/hub/about.js
@@ -39,7 +39,7 @@ const sendAboutEmbed = async ({ nessie, interaction }) => {
       },
       {
         name: 'Support Server',
-        value: '[Link](https://discord.com/invite/47Ccgz9jA4)',
+        value: '[Link](https://discord.gg/FyxVrAbRAd)',
         inline: true,
       },
     ],

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -21,7 +21,7 @@ const sendHelpInteraction = async ({ interaction, nessie }) => {
       new MessageButton()
         .setLabel("To Nessie's Canyon")
         .setStyle('LINK')
-        .setURL('https://discord.com/invite/47Ccgz9jA4')
+        .setURL('https://discord.gg/FyxVrAbRAd')
     );
 
     return await interaction.editReply({ components: [row], embeds: [embedData] });

--- a/helpers.js
+++ b/helpers.js
@@ -163,7 +163,7 @@ const generateErrorEmbed = async (error, uuid, nessie) => {
       error.message ? codeBlock(error.message) : codeBlock('Unexpected Error')
     }\nError ID: ${codeBlock(
       uuid
-    )}\nAlternatively, you can also report issue through the [support server](https://discord.com/invite/47Ccgz9jA4)`,
+    )}\nAlternatively, you can also report issue through the [support server](https://discord.gg/FyxVrAbRAd`,
     color: 16711680,
   };
   return [embed];


### PR DESCRIPTION
#### Context
Was going to add a special handling when the API throws an error during the 15 minute interval for announcement status. This came about because in the past month, the API has gone complete bonkers twice and has been down for like at least 8 hours because the guy running it lives in Europe. We can't fix the problem but best thing we can do is to let people know there is a problem. In that line of thought, was going to publish the error message instead of the next rotation data but quickly realised the effort of knowing what to delete, deleting, updating the message id with the error id etc is going to be insane so just opted to ping me and let it fail silently lol

Probably last pr before we open the floodgates. Just gotta clean up the support server before we release

![image](https://user-images.githubusercontent.com/42207245/174487716-881aa6f2-1d68-4373-8de2-66902fbdb98a.png)
<img width="415" alt="image" src="https://user-images.githubusercontent.com/42207245/174487739-33167870-83bb-40a7-b74e-c9e891763738.png">

#### Change
- Update announcement info
- Update invite links

#### Considerations
There might be merit on looking into map data fallbacks. Could be in the form of getting it from another API or hardcoding the current split rotation. It's all up in the air for now, just wondering what's the best approach in minimising downtime