### PR TITLE
Add error alert for control

### DIFF
--- a/commands/maps/control.js
+++ b/commands/maps/control.js
@@ -38,6 +38,13 @@ module.exports = {
         true
       );
     } catch (error) {
+      /**
+       * Special error handling here instead of using the error helper
+       * This is due to control being a limited time event and it keeps being taken on and off the game mode list
+       * I've been removing the command and then readding it back in a new release so it's been quite a hassle to actually maintain this
+       * Decided to always just keep it in and show an alert error message when it does fail
+       * Fetches the alert in the alert channel in the support server
+       */
       const uuid = uuidv4();
       const alertChannel = nessie.channels.cache.get('973977422699573258');
       const messageObject = await alertChannel.messages.fetch('989197310502260736');

--- a/commands/maps/control.js
+++ b/commands/maps/control.js
@@ -1,6 +1,6 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const { getControlPubs } = require('../../adapters');
-const { sendErrorLog, generateErrorEmbed, generatePubsEmbed } = require('../../helpers');
+const { sendErrorLog, generateErrorEmbed, generatePubsEmbed, codeBlock } = require('../../helpers');
 const { v4: uuidv4 } = require('uuid');
 const { sendMixpanelEvent } = require('../../analytics');
 
@@ -39,9 +39,23 @@ module.exports = {
       );
     } catch (error) {
       const uuid = uuidv4();
+      const alertChannel = nessie.channels.cache.get('973977422699573258');
+      const messageObject = await alertChannel.messages.fetch('989197310502260736');
+      const errorMessage = messageObject.content;
+      const errorAlert = errorMessage.substring(
+        errorMessage.indexOf('[') + 4,
+        errorMessage.lastIndexOf(']') - 3
+      );
+      const errorEmbed = {
+        description: `${errorAlert}\n\nError: ${
+          error.message ? codeBlock(error.message) : codeBlock('Unexpected Error')
+        }\nError ID: ${codeBlock(
+          uuid
+        )}\nAlternatively, you can also report issue through the [support server](https://discord.gg/FyxVrAbRAd)`,
+        color: 16711680,
+      };
       const type = 'Control';
-      const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
-      await interaction.editReply({ embeds: errorEmbed });
+      await interaction.editReply({ embeds: [errorEmbed] });
       await sendErrorLog({ nessie, error, interaction, type, uuid });
     }
   },


### PR DESCRIPTION
#### Context
Since I've decided to leave control in even when it's not in game, it's good to add a descriptive error message when it does fail. Borrowed how the error helper fetches alert messages and used it in the control catch

In a completely different note, what in the world happened here. I got so confused when I got a 503 and the error implied I was blocked by my test bot. Got fixed in like 2 minutes but still pretty strange discord
![image](https://user-images.githubusercontent.com/42207245/175083808-b44201bd-3030-4f0c-9500-851d3b91f14b.png)

<img width="401" alt="image" src="https://user-images.githubusercontent.com/42207245/175083878-09e70995-5947-49fd-a27b-270a672249e6.png">
<img width="519" alt="image" src="https://user-images.githubusercontent.com/42207245/175083989-7019cc7a-d079-4d1f-814a-3b274149c5de.png">


#### Change
- Add special error handling in control