### PR TITLE
Spike on webhooks

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -17,5 +17,6 @@ exports.getApplicationCommands = () => {
     status: require('./commands/maps/status'),
     //Admin
     announcement: require('./commands/admin/announcement'),
+    webhook: require('./commands/admin/webhook'),
   };
 };

--- a/commands/admin/webhook.js
+++ b/commands/admin/webhook.js
@@ -46,6 +46,7 @@ module.exports = {
           await interaction.editReply({ content: 'Edit Webhook' });
           break;
         case 'delete':
+          await webhook.deleteMessage('989556889429880932');
           await interaction.editReply({ content: 'Delete Webhook' });
       }
     } catch (error) {}

--- a/commands/admin/webhook.js
+++ b/commands/admin/webhook.js
@@ -7,23 +7,43 @@ const { nessieLogo } = require('../../constants');
 
 module.exports = {
   isAdmin: true,
-  data: new SlashCommandBuilder().setName('webhook').setDescription('Testing Webhooks'),
+  data: new SlashCommandBuilder()
+    .setName('webhook')
+    .setDescription('Testing Webhooks')
+    .addSubcommand((subCommand) =>
+      subCommand.setName('send').setDescription('Send Webhook Message')
+    )
+    .addSubcommand((subCommand) =>
+      subCommand.setName('edit').setDescription('Edit Webhook Message')
+    )
+    .addSubcommand((subCommand) =>
+      subCommand.setName('delete').setDescription('Delete Webhook Message')
+    ),
   async execute({ nessie, interaction }) {
+    const statusOption = interaction.options.getSubcommand();
     const webhook = new WebhookClient({
       id: testWebhook.id,
       token: testWebhook.token,
     });
-
     try {
       await interaction.deferReply();
-      const data = await getBattleRoyalePubs();
-      const embed = generatePubsEmbed(data);
-      await webhook.send({
-        username: 'Nessie Map Status',
-        avatarURL: nessieLogo,
-        embeds: [embed],
-      });
-      await interaction.editReply({ content: 'Sent Webhook' });
+      switch (statusOption) {
+        case 'send':
+          const data = await getBattleRoyalePubs();
+          const embed = generatePubsEmbed(data);
+          await webhook.send({
+            username: 'Nessie Map Status',
+            avatarURL: nessieLogo,
+            embeds: [embed],
+          });
+          await interaction.editReply({ content: 'Sent Webhook' });
+          break;
+        case 'edit':
+          await interaction.editReply({ content: 'Edit Webhook' });
+          break;
+        case 'delete':
+          await interaction.editReply({ content: 'Delete Webhook' });
+      }
     } catch (error) {}
   },
 };

--- a/commands/admin/webhook.js
+++ b/commands/admin/webhook.js
@@ -1,0 +1,19 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const { WebhookClient } = require('discord.js');
+const { testWebhook } = require('../../config/nessie.json');
+
+module.exports = {
+  isAdmin: true,
+  data: new SlashCommandBuilder().setName('webhook').setDescription('Testing Webhooks'),
+  async execute({ nessie, interaction }) {
+    const webhook = new WebhookClient({
+      id: testWebhook.id,
+      token: testWebhook.token,
+    });
+    try {
+      await interaction.deferReply();
+      await webhook.send({ content: 'test' });
+      await interaction.editReply({ content: 'Sent Webhook' });
+    } catch (error) {}
+  },
+};

--- a/commands/admin/webhook.js
+++ b/commands/admin/webhook.js
@@ -5,6 +5,22 @@ const { testWebhook } = require('../../config/nessie.json');
 const { generatePubsEmbed } = require('../../helpers');
 const { nessieLogo } = require('../../constants');
 
+/**
+ * Temporary command to test how to use webhooks
+ * Tbh after testing this and realising how straightforward it is, makes me wonder why I even bothered making announcements kek
+ * Either way, pretty good to know to have this. Got a good feeling this will make auto updates a reality
+ * Things to consider during the user mapping/prototype iteration:
+ * - Webhooks rate limit
+ * - Storing webhook data
+ * - Create + delete, create or edit?
+ * - 1 channel or 2
+ * - Control?
+ * - Creating a webhook during status initialisation
+ *
+ * Useful documentation:
+ * https://discordjs.guide/popular-topics/webhooks.html#sending-messages
+ * https://discord.com/developers/docs/resources/webhook#execute-webhook
+ */
 module.exports = {
   isAdmin: true,
   data: new SlashCommandBuilder()

--- a/commands/admin/webhook.js
+++ b/commands/admin/webhook.js
@@ -39,6 +39,10 @@ module.exports = {
           await interaction.editReply({ content: 'Sent Webhook' });
           break;
         case 'edit':
+          await webhook.editMessage('', {
+            content: 'Edit Message',
+            embeds: [],
+          });
           await interaction.editReply({ content: 'Edit Webhook' });
           break;
         case 'delete':

--- a/commands/admin/webhook.js
+++ b/commands/admin/webhook.js
@@ -1,6 +1,9 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const { WebhookClient } = require('discord.js');
+const { getBattleRoyalePubs } = require('../../adapters');
 const { testWebhook } = require('../../config/nessie.json');
+const { generatePubsEmbed } = require('../../helpers');
+const { nessieLogo } = require('../../constants');
 
 module.exports = {
   isAdmin: true,
@@ -10,9 +13,16 @@ module.exports = {
       id: testWebhook.id,
       token: testWebhook.token,
     });
+
     try {
       await interaction.deferReply();
-      await webhook.send({ content: 'test' });
+      const data = await getBattleRoyalePubs();
+      const embed = generatePubsEmbed(data);
+      await webhook.send({
+        username: 'Nessie Map Status',
+        avatarURL: nessieLogo,
+        embeds: [embed],
+      });
       await interaction.editReply({ content: 'Sent Webhook' });
     } catch (error) {}
   },


### PR DESCRIPTION
#### Context
Came in here thinking webhooks would take me a while to figure out. It's the reason why I made the announcement feature so that's there's something out there at least. Now I'm thinking why I even bothered in the first place since implementing webhooks looks so straightforward lmaoo smh. Jokes aside, dev time would still take some time cuz of prototype iterations and it's good to see some adoption beforehand

Anyway basically the whole process of getting status updates is flipped; from a user sending a request to us which we then request discord, we now send a request to the user. At a glance, this will ultimately solve our rate limiting problems when using normal messages since every guild will have their own webhooks which have their own set of ratelimits. I hope at least

I'll start prototyping v0.3 of auto status in the next couple of days and hopefully start development by end of next week. Faster I finish this, faster I can finish the website and start on Yagi. August 31 can't come any sooner orz

<img width="442" alt="image" src="https://user-images.githubusercontent.com/42207245/175347706-298f7f01-b7ca-4cc4-addf-1d243f5f4841.png">
<img width="577" alt="image" src="https://user-images.githubusercontent.com/42207245/175347989-ce3153f4-1eb2-4f3c-aefc-5197f53eeab0.png">

#### Change
- Create test webhook command
- Add delete, send, edit options