### PR TITLE
Add restarts to announcement status

### DIFF
--- a/commands/admin/announcement.js
+++ b/commands/admin/announcement.js
@@ -595,6 +595,22 @@ const restartStatus = async ({ interaction, nessie, restartId }) => {
     }
   );
 };
+const cancelStatusRestart = async ({ nessie, interaction }) => {
+  try {
+    await interaction.deferUpdate();
+    const embedSuccess = {
+      description: 'Cancelled automated map status restart',
+      color: 16711680,
+    };
+    await interaction.message.edit({ embeds: [embedSuccess], components: [] });
+  } catch (error) {
+    const uuid = uuidv4();
+    const type = 'Status Start Cancel Button';
+    const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
+    await interaction.message.edit({ embeds: errorEmbed, components: [] });
+    await sendErrorLog({ nessie, error, interaction, type, uuid });
+  }
+};
 module.exports = {
   /**
    * Creates Status application command with relevant subcommands
@@ -662,4 +678,5 @@ module.exports = {
   deleteStatusChannels,
   initialiseStatusScheduler,
   restartStatus,
+  cancelStatusRestart,
 };

--- a/commands/admin/announcement.js
+++ b/commands/admin/announcement.js
@@ -502,7 +502,19 @@ module.exports = {
       subCommand.setName('stop').setDescription('Stops an existing automated status')
     )
     .addSubcommand((subCommand) =>
-      subCommand.setName('restart').setDescription('Restarts automated status')
+      subCommand
+        .setName('restart')
+        .setDescription('Restarts automated status')
+        .addStringOption((option) =>
+          option
+            .setName('type')
+            .setDescription('Restart Type')
+            .setRequired(true)
+            .addChoice('all', 'all')
+            .addChoice('all missing', 'all_missing')
+            .addChoice('br missing', 'br_missing')
+            .addChoice('arenas missing', 'arenas_missing')
+        )
     ),
   /**
    * Send correct reply based on the user's subcommand input
@@ -513,6 +525,7 @@ module.exports = {
    */
   async execute({ nessie, interaction }) {
     const statusOption = interaction.options.getSubcommand();
+    const optionType = interaction.options.getString('type');
     try {
       await interaction.deferReply();
       switch (statusOption) {

--- a/commands/admin/announcement.js
+++ b/commands/admin/announcement.js
@@ -500,6 +500,9 @@ module.exports = {
     )
     .addSubcommand((subCommand) =>
       subCommand.setName('stop').setDescription('Stops an existing automated status')
+    )
+    .addSubcommand((subCommand) =>
+      subCommand.setName('restart').setDescription('Restarts automated status')
     ),
   /**
    * Send correct reply based on the user's subcommand input
@@ -517,6 +520,8 @@ module.exports = {
           return await sendStartInteraction({ interaction, nessie });
         case 'stop':
           return await sendStopInteraction({ interaction, nessie });
+        case 'restart':
+          return await interaction.editReply('Restart status');
       }
     } catch (error) {
       console.log(error);

--- a/commands/admin/announcement.js
+++ b/commands/admin/announcement.js
@@ -478,6 +478,17 @@ const initialiseStatusScheduler = (nessie) => {
     );
   });
 };
+/**
+ * Below are the handlers for announcement restart
+ * Options: all, all missing, br missing and arenas missing
+ * Came about from an error during the status scheduler where the br message got deleted but failed halfway
+ * This resulted in the br message deleted while the arenas message still there
+ * The real problem is due to us only updating our status database after both are done; with the br message now missing, the next cycle will still try to delete the old missing message
+ * Since it's missing, discord js throws an error that it can't find it (a bit weirdchamp here, why not just return null)
+ * I don't think this can be prevented from happening but we can add a way to easily fix it if it does happen
+ * Had to go into the droplet and fix this in production which wasn't ideal
+ * Doing this too since if it messes up here, it's bound to mess up in the actual status feature so we can probably tweak this implementation then
+ */
 const sendRestartInteraction = ({ interaction, type }) => {
   getStatus(
     interaction.guildId,

--- a/commands/admin/announcement.js
+++ b/commands/admin/announcement.js
@@ -491,7 +491,22 @@ const sendRestartInteraction = ({ interaction, type }) => {
             }>\n`
           : `There's currently no active map status to stop`,
       };
-      return await interaction.editReply({ embeds: [embedData] });
+      const row = new MessageActionRow()
+        .addComponents(
+          new MessageButton()
+            .setCustomId('statusRestart__cancelButton')
+            .setLabel('Cancel')
+            .setStyle('SECONDARY')
+            .setDisabled(!status ? true : false)
+        )
+        .addComponents(
+          new MessageButton()
+            .setCustomId(`statusRestart__${type}`)
+            .setLabel('Restart')
+            .setStyle('SUCCESS')
+            .setDisabled(!status ? true : false)
+        );
+      return await interaction.editReply({ components: [row], embeds: [embedData] });
     },
     async (error) => {
       const uuid = uuidv4();
@@ -534,9 +549,9 @@ module.exports = {
             .setDescription('Restart Type')
             .setRequired(true)
             .addChoice('All', 'all')
-            .addChoice('All Missing', 'all_missing')
-            .addChoice('Br Missing', 'br_missing')
-            .addChoice('Arenas Missing', 'arenas_missing')
+            .addChoice('All Missing', 'allMissing')
+            .addChoice('Br Missing', 'brMissing')
+            .addChoice('Arenas Missing', 'arenasMissing')
         )
     ),
   /**

--- a/commands/admin/announcement.js
+++ b/commands/admin/announcement.js
@@ -501,7 +501,7 @@ const sendRestartInteraction = ({ interaction, type }) => {
         )
         .addComponents(
           new MessageButton()
-            .setCustomId(`statusRestart__${type}`)
+            .setCustomId(`statusRestart__${type}Button`)
             .setLabel('Restart')
             .setStyle('SUCCESS')
             .setDisabled(!status ? true : false)

--- a/events.js
+++ b/events.js
@@ -131,6 +131,7 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
      * Will still have to check the customId for each of the buttons here though
      */
     if (interaction.isButton()) {
+      console.log(interaction);
       switch (interaction.customId) {
         case 'statusStart__startButton':
           return createStatusChannels({ interaction, nessie });
@@ -140,6 +141,16 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
           return deleteStatusChannels({ interaction, nessie });
         case 'statusStop__cancelButton':
           return cancelStatusStop({ interaction, nessie });
+        case 'statusRestart__cancelButton':
+          return interaction.channel.send(`Clicked restart cancel button`);
+        case 'statusRestart__allButton':
+          return interaction.channel.send(`Clicked restart all button`);
+        case 'statusRestart__allMissingButton':
+          return interaction.channel.send(`Clicked restart allMissing button`);
+        case 'statusRestart__brMissingButton':
+          return interaction.channel.send(`Clicked restart brMissing button`);
+        case 'statusRestart__arenasMissingButton':
+          return interaction.channel.send(`Clicked restart arenasMissing button`);
       }
     }
   });

--- a/events.js
+++ b/events.js
@@ -147,11 +147,11 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
         case 'statusRestart__allButton':
           return restartStatus({ interaction, nessie, restartId: interaction.customId });
         case 'statusRestart__allMissingButton':
-          return interaction.channel.send(`Clicked restart allMissing button`);
+          return restartStatus({ interaction, nessie, restartId: interaction.customId });
         case 'statusRestart__brMissingButton':
-          return interaction.channel.send(`Clicked restart brMissing button`);
+          return restartStatus({ interaction, nessie, restartId: interaction.customId });
         case 'statusRestart__arenasMissingButton':
-          return interaction.channel.send(`Clicked restart arenasMissing button`);
+          return restartStatus({ interaction, nessie, restartId: interaction.customId });
       }
     }
   });

--- a/events.js
+++ b/events.js
@@ -31,6 +31,7 @@ const {
   deleteStatusChannels,
   initialiseStatusScheduler,
   restartStatus,
+  cancelStatusRestart,
 } = require('./commands/admin/announcement');
 
 const appCommands = getApplicationCommands(); //Get list of application commands
@@ -143,7 +144,7 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
         case 'statusStop__cancelButton':
           return cancelStatusStop({ interaction, nessie });
         case 'statusRestart__cancelButton':
-          return interaction.channel.send(`Clicked restart cancel button`);
+          return cancelStatusRestart({ interaction, nessie });
         case 'statusRestart__allButton':
           return restartStatus({ interaction, nessie, restartId: interaction.customId });
         case 'statusRestart__allMissingButton':

--- a/events.js
+++ b/events.js
@@ -133,7 +133,6 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
      * Will still have to check the customId for each of the buttons here though
      */
     if (interaction.isButton()) {
-      console.log(interaction);
       switch (interaction.customId) {
         case 'statusStart__startButton':
           return createStatusChannels({ interaction, nessie });
@@ -157,7 +156,6 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
     }
   });
   nessie.on('rateLimit', async (data) => {
-    console.log(data);
     const uuid = uuidv4();
     const type = 'Rate Limited';
     const error = {

--- a/events.js
+++ b/events.js
@@ -30,6 +30,7 @@ const {
   createStatusChannels,
   deleteStatusChannels,
   initialiseStatusScheduler,
+  restartStatus,
 } = require('./commands/admin/announcement');
 
 const appCommands = getApplicationCommands(); //Get list of application commands
@@ -144,7 +145,7 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
         case 'statusRestart__cancelButton':
           return interaction.channel.send(`Clicked restart cancel button`);
         case 'statusRestart__allButton':
-          return interaction.channel.send(`Clicked restart all button`);
+          return restartStatus({ interaction, nessie, restartId: interaction.customId });
         case 'statusRestart__allMissingButton':
           return interaction.channel.send(`Clicked restart allMissing button`);
         case 'statusRestart__brMissingButton':


### PR DESCRIPTION
#### Context
There was a problem with the announcement status a couple of days ago where somehow during one of the scheduled cycles, the br message got deleted and threw an error. This resulted in the scheduler to not fully go through; didn't create a new br + arenas messages but more importantly didn't get to update our database. Which was the main issue because the scheduler is now stuck in an endless loop of errors trying to fetch + delete a non-existing message. In the end I had to manually change the implementation in production for one cycle then revert it on the next which was definitely a hassle

We probably can't prevent this from happening again but we can make it easier to fix hence this change. Also went ahead in doing this since if it happened in announcement, it's bound to happen as well in the actual status feature so it's good to have this up already. 

Anyway this command will restart the announcement channels with the following options:
- `All`: Nasically no issues, both messages are present, just to have an option to restart when we want
- `All Missing`: Both messages are missing
- `Br Missing`: Only Br message is missing
- `Arenas Missing`: Only Arenas message is missing

Scuffed definitely but hey it's working. Also I haven't slept and it's almost 10am I'm dying send help my sleep schedule is wack

#### Change
- Add restart subcommand to announcement
- Add options to restart
- Wire up restart interactions