### PR TITLE
Spike menu selects

### DIFF
--- a/commands.js
+++ b/commands.js
@@ -18,5 +18,6 @@ exports.getApplicationCommands = () => {
     //Admin
     announcement: require('./commands/admin/announcement'),
     webhook: require('./commands/admin/webhook'),
+    selectmenu: require('./commands/admin/selectMenu'),
   };
 };

--- a/commands/admin/selectMenu.js
+++ b/commands/admin/selectMenu.js
@@ -1,0 +1,32 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const { MessageActionRow, MessageSelectMenu } = require('discord.js');
+
+module.exports = {
+  isAdmin: true,
+  data: new SlashCommandBuilder().setName('selectmenu').setDescription('Testing select menus'),
+  async execute({ interaction }) {
+    try {
+      await interaction.deferReply();
+      const selectMenuRow = new MessageActionRow().addComponents(
+        new MessageSelectMenu()
+          .setCustomId('selectMenu__mapOptions')
+          .setPlaceholder("I'm a select menu")
+          .setMinValues(1)
+          .setMaxValues(2)
+          .addOptions([
+            {
+              label: 'Battle Royale',
+              description: 'Battle Royale Map Rotation',
+              value: 'selectMenu__brValue',
+            },
+            {
+              label: 'Arenas',
+              description: 'Arenas Map Rotation',
+              value: 'selectMenu__arenasValue',
+            },
+          ])
+      );
+      await interaction.editReply({ components: [selectMenuRow] });
+    } catch (error) {}
+  },
+};

--- a/commands/admin/selectMenu.js
+++ b/commands/admin/selectMenu.js
@@ -1,13 +1,56 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
-const { MessageActionRow, MessageSelectMenu } = require('discord.js');
+const { MessageActionRow, MessageSelectMenu, MessageButton } = require('discord.js');
 
+const mapOptions = {
+  selectMenu__brValue: 'Battle Royale',
+  selectMenu__arenasValue: 'Arenas',
+};
+const selectMenuReply = async ({ interaction }) => {
+  let selectedValues = '';
+  interaction.values.forEach((value, index) => {
+    selectedValues += `${index > 0 ? ', ' : ''}${mapOptions[value]}`;
+  });
+  try {
+    await interaction.deferUpdate();
+    const embed = {
+      title: 'Step 2 | Status Confirmation',
+      description: `Selected ${selectedValues}\n\nChannels, webhooks to create yada yada`,
+      color: 3447003,
+    };
+    const row = new MessageActionRow()
+      .addComponents(
+        new MessageButton()
+          .setLabel('Back')
+          .setStyle('SECONDARY')
+          .setDisabled(true)
+          .setCustomId('backTest')
+      )
+      .addComponents(
+        new MessageButton()
+          .setLabel('Cancel')
+          .setStyle('DANGER')
+          .setDisabled(true)
+          .setCustomId('cancelTest')
+      )
+      .addComponents(
+        new MessageButton()
+          .setLabel('Confirm')
+          .setStyle('SUCCESS')
+          .setDisabled(true)
+          .setCustomId('confirmTest')
+      );
+    await interaction.message.edit({ embeds: [embed], components: [row] });
+  } catch (error) {
+    console.log(error);
+  }
+};
 module.exports = {
   isAdmin: true,
   data: new SlashCommandBuilder().setName('selectmenu').setDescription('Testing select menus'),
   async execute({ interaction }) {
     try {
       await interaction.deferReply();
-      const selectMenuRow = new MessageActionRow().addComponents(
+      const row = new MessageActionRow().addComponents(
         new MessageSelectMenu()
           .setCustomId('selectMenu__mapOptions')
           .setPlaceholder("I'm a select menu")
@@ -26,7 +69,13 @@ module.exports = {
             },
           ])
       );
-      await interaction.editReply({ components: [selectMenuRow] });
+      const embed = {
+        title: `Step 1 | Game Mode Selection`,
+        description: 'Choose which game modes to receive automatic updates',
+        color: 3447003,
+      };
+      await interaction.editReply({ embeds: [embed], components: [row] });
     } catch (error) {}
   },
+  selectMenuReply,
 };

--- a/events.js
+++ b/events.js
@@ -33,6 +33,7 @@ const {
   restartStatus,
   cancelStatusRestart,
 } = require('./commands/admin/announcement');
+const { selectMenuReply } = require('./commands/admin/selectMenu');
 
 const appCommands = getApplicationCommands(); //Get list of application commands
 
@@ -152,6 +153,13 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
           return restartStatus({ interaction, nessie, restartId: interaction.customId });
         case 'statusRestart__arenasMissingButton':
           return restartStatus({ interaction, nessie, restartId: interaction.customId });
+      }
+    }
+    if (interaction.isSelectMenu()) {
+      console.log(interaction);
+      switch (interaction.customId) {
+        case 'selectMenu__mapOptions':
+          return selectMenuReply({ interaction });
       }
     }
   });


### PR DESCRIPTION
#### Context
What is this scope creep 👀 Tbh the current implementation of announcement can be used for the status feature with a few tweaks in creating webhooks. But I figured since I bought myself some extra time, might as well make the design + implementation as robust and intuitive as possible. 

Going down the route of customisation of what game mode to select for status might be troublesome in nailing down edge cases but the end result looks pretty good in my mind.

<img width="397" alt="image" src="https://user-images.githubusercontent.com/42207245/176223621-93e5fd52-3e6f-42fd-8ea5-e5f5783d04b4.png">
<img width="291" alt="image" src="https://user-images.githubusercontent.com/42207245/176223649-69f88582-775d-4e5a-a3e8-935f530fce6b.png">

![spike select menu](https://user-images.githubusercontent.com/42207245/176224259-39c5bde2-714b-47a2-bc23-cbb30c5c6258.gif)


#### Change
- Create select menu admin command
- Add test interactions