### PR TITLE
Create status help command

### DIFF
--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -1,16 +1,22 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
-const { MessageActionRow, MessageButton } = require('discord.js');
 const { generateErrorEmbed, sendErrorLog } = require('../../helpers');
 const { v4: uuidv4 } = require('uuid');
 
+/**
+ * Handler for when a user initiates the /status help command
+ * Displays information of status command, explains what it does and permissions it needs
+ * Feeling a bit wacky so added a dynamic checklist of required permissions
+ * Will either show a tick or mark if the permission is missing
+ * Shows a success/warning at the end if any of the permissions are missing
+ */
 const sendHelpInteraction = async ({ interaction, nessie }) => {
-  const isAdminUser = interaction.member.permissions.has('ADMINISTRATOR');
+  const isAdminUser = interaction.member.permissions.has('ADMINISTRATOR'); //Checks if user who initiated command is an Admin
   const hasAdmin = interaction.guild.me.permissions.has('ADMINISTRATOR');
   const hasManageChannels = interaction.guild.me.permissions.has('MANAGE_CHANNELS', false);
   const hasManageWebhooks = interaction.guild.me.permissions.has('MANAGE_WEBHOOKS', false);
   const hasSendMessages = interaction.guild.me.permissions.has('SEND_MESSAGES', false);
   const hasMissingPermissions =
-    (!hasManageChannels || !hasManageWebhooks || !hasSendMessages) && !hasAdmin;
+    (!hasManageChannels || !hasManageWebhooks || !hasSendMessages) && !hasAdmin; //Overrides missing permissions if nessie has Admin
 
   try {
     const embedData = {

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -8,6 +8,7 @@ const sendHelpInteraction = async ({ interaction, nessie }) => {
   const hasManageChannels = interaction.guild.me.permissions.has('MANAGE_CHANNELS', false);
   const hasManageWebhooks = interaction.guild.me.permissions.has('MANAGE_WEBHOOKS', false);
   const hasSendMessages = interaction.guild.me.permissions.has('SEND_MESSAGES', false);
+  const hasMissingPermissions = !hasManageChannels || !hasManageWebhooks || !hasSendMessages;
   try {
     const embedData = {
       title: 'Status | Help',
@@ -21,7 +22,11 @@ const sendHelpInteraction = async ({ interaction, nessie }) => {
           name: 'Bot Permissions',
           value: `${hasManageChannels ? '✅ ' : '❌'} Manage Channels\n${
             hasManageWebhooks ? '✅ ' : '❌'
-          } Manage Webhooks\n${hasSendMessages ? '✅ ' : '❌'} Send Messages`,
+          } Manage Webhooks\n${hasSendMessages ? '✅ ' : '❌'} Send Messages\n\n${
+            hasMissingPermissions
+              ? 'Looks like there are missing permissions. Make sure to add the above permissions to be able to create automatic map updates!'
+              : 'Looks like everything is set, use `/status start` to get started!'
+          }`,
         },
       ],
       color: 3447003,

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -5,10 +5,13 @@ const { v4: uuidv4 } = require('uuid');
 
 const sendHelpInteraction = async ({ interaction, nessie }) => {
   console.log(interaction);
+  const isAdminUser = interaction.member.permissions.has('ADMINISTRATOR');
+  const hasAdmin = interaction.guild.me.permissions.has('ADMINISTRATOR');
   const hasManageChannels = interaction.guild.me.permissions.has('MANAGE_CHANNELS', false);
   const hasManageWebhooks = interaction.guild.me.permissions.has('MANAGE_WEBHOOKS', false);
   const hasSendMessages = interaction.guild.me.permissions.has('SEND_MESSAGES', false);
-  const hasMissingPermissions = !hasManageChannels || !hasManageWebhooks || !hasSendMessages;
+  const hasMissingPermissions =
+    (!hasManageChannels || !hasManageWebhooks || !hasSendMessages) && !hasAdmin;
   try {
     const embedData = {
       title: 'Status | Help',
@@ -16,14 +19,14 @@ const sendHelpInteraction = async ({ interaction, nessie }) => {
       fields: [
         {
           name: 'User Permissions',
-          value: '• Administrator',
+          value: `${isAdminUser ? '✅' : '❌'} Administrator`,
         },
         {
           name: 'Bot Permissions',
-          value: `${hasManageChannels ? '✅ ' : '❌'} Manage Channels\n${
-            hasManageWebhooks ? '✅ ' : '❌'
-          } Manage Webhooks\n${hasSendMessages ? '✅ ' : '❌'} Send Messages\n\n${
-            hasMissingPermissions
+          value: `${hasAdmin || hasManageChannels ? '✅' : '❌'} Manage Channels\n${
+            hasAdmin || hasManageWebhooks ? '✅' : '❌'
+          } Manage Webhooks\n${hasAdmin || hasSendMessages ? '✅' : '❌'} Send Messages\n\n${
+            !isAdminUser || hasMissingPermissions
               ? 'Looks like there are missing permissions. Make sure to add the above permissions to be able to create automatic map updates!'
               : 'Looks like everything is set, use `/status start` to get started!'
           }`,

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -4,7 +4,6 @@ const { generateErrorEmbed, sendErrorLog } = require('../../helpers');
 const { v4: uuidv4 } = require('uuid');
 
 const sendHelpInteraction = async ({ interaction, nessie }) => {
-  console.log(interaction);
   const isAdminUser = interaction.member.permissions.has('ADMINISTRATOR');
   const hasAdmin = interaction.guild.me.permissions.has('ADMINISTRATOR');
   const hasManageChannels = interaction.guild.me.permissions.has('MANAGE_CHANNELS', false);
@@ -12,10 +11,12 @@ const sendHelpInteraction = async ({ interaction, nessie }) => {
   const hasSendMessages = interaction.guild.me.permissions.has('SEND_MESSAGES', false);
   const hasMissingPermissions =
     (!hasManageChannels || !hasManageWebhooks || !hasSendMessages) && !hasAdmin;
+
   try {
     const embedData = {
       title: 'Status | Help',
-      description: 'Something here',
+      description:
+        "• Explain the status command does\n• Explain what it'll create; channels, webhooks\n• Explain necessary user permissions; admin\n• Explain bot permissions; whatever nessie needs to operate",
       fields: [
         {
           name: 'User Permissions',

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -36,12 +36,31 @@ const sendHelpInteraction = async ({ interaction, nessie }) => {
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('status')
-    .setDescription('Displays information on how to get automatic map updates'),
+    .setDescription('Get your automatic map updates here!')
+    .addSubcommand((subCommand) =>
+      subCommand
+        .setName('help')
+        .setDescription('Displays information on setting up automatic map updates')
+    )
+    .addSubcommand((subCommand) =>
+      subCommand.setName('start').setDescription('Set up automatic map updates')
+    )
+    .addSubcommand((subCommand) =>
+      subCommand.setName('stop').setDescription('Stops existing automatic map updates')
+    ),
 
   async execute({ nessie, interaction, mixpanel }) {
+    const statusOption = interaction.options.getSubcommand();
     try {
       await interaction.deferReply();
-      return await sendHelpInteraction({ interaction, nessie });
+      switch (statusOption) {
+        case 'help':
+          return interaction.editReply('Selected status help');
+        case 'start':
+          return interaction.editReply('Selected status start');
+        case 'stop':
+          return interaction.editReply('Selected status stop');
+      }
     } catch (error) {
       console.log(error);
     }

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -3,28 +3,31 @@ const { MessageActionRow, MessageButton } = require('discord.js');
 const { generateErrorEmbed, sendErrorLog } = require('../../helpers');
 const { v4: uuidv4 } = require('uuid');
 
-/**
- * Temporary handler for status command
- * Just displays information on why there's no proper status yet
- * Also has an invite button to redirect people to the support server
- * TODO: Probably need to make the support server an actual community server with actual rules and stuff
- */
 const sendHelpInteraction = async ({ interaction, nessie }) => {
+  console.log(interaction);
+  const hasManageChannels = interaction.guild.me.permissions.has('MANAGE_CHANNELS', false);
+  const hasManageWebhooks = interaction.guild.me.permissions.has('MANAGE_WEBHOOKS', false);
+  const hasSendMessages = interaction.guild.me.permissions.has('SEND_MESSAGES', false);
   try {
     const embedData = {
-      title: 'Status | About',
-      description:
-        "Due to technical limitations with Discord, automatic updates through normal messages/interactions isn't possible in a large scale. Fortunately an alternative approach is being worked on but it might take a while before it gets released\n\nAs a temporary solution, I've set up automatic map updates in announcement channels in the support server.\n\nFeel free to join and follow the channels!",
+      title: 'Status | Help',
+      description: 'Something here',
+      fields: [
+        {
+          name: 'User Permissions',
+          value: '• Administrator',
+        },
+        {
+          name: 'Bot Permissions',
+          value: `${hasManageChannels ? '✅ ' : '❌'} Manage Channels\n${
+            hasManageWebhooks ? '✅ ' : '❌'
+          } Manage Webhooks\n${hasSendMessages ? '✅ ' : '❌'} Send Messages`,
+        },
+      ],
       color: 3447003,
     };
-    const row = new MessageActionRow().addComponents(
-      new MessageButton()
-        .setLabel("To Nessie's Canyon")
-        .setStyle('LINK')
-        .setURL('https://discord.gg/FyxVrAbRAd')
-    );
 
-    return await interaction.editReply({ components: [row], embeds: [embedData] });
+    return await interaction.editReply({ embeds: [embedData] });
   } catch (error) {
     const uuid = uuidv4();
     const type = 'Status About';
@@ -55,7 +58,7 @@ module.exports = {
       await interaction.deferReply();
       switch (statusOption) {
         case 'help':
-          return interaction.editReply('Selected status help');
+          return sendHelpInteraction({ interaction, nessie });
         case 'start':
           return interaction.editReply('Selected status start');
         case 'stop':


### PR DESCRIPTION
#### Design
https://www.figma.com/file/Zw83AgLQpObLpPlSoeEWjq/Automatic-Status-Prototype?node-id=151%3A8064

#### Context
Interaction for status help. Was feeling a bit wacky so I added an extra feature of having a checklist for required permissions. Placeholder description for now since I don't really have enough brainpower tonight to think of some good copy

Created subcommands for status start and status stop as well albeit nothing in them

<img width="400" alt="image" src="https://user-images.githubusercontent.com/42207245/177199743-b8312c23-a257-434a-b23f-52199aeff541.png">
<img width="485" alt="image" src="https://user-images.githubusercontent.com/42207245/177199769-2eacb019-161a-4145-9cbb-78742625ca6f.png">
<img width="474" alt="image" src="https://user-images.githubusercontent.com/42207245/177199779-2a4d0c4e-a80e-4811-8a98-1bab172ca83f.png">

#### Change
- Create subcommands for status
- Check if bot and user has required permissions
- Add success/warning if permissions are complete