### PR TITLE
Create map status

### DIFF
--- a/commands/admin/announcement.js
+++ b/commands/admin/announcement.js
@@ -8,6 +8,7 @@ const {
   generateErrorEmbed,
   sendErrorLog,
   codeBlock,
+  checkIfInDevelopment,
 } = require('../../helpers');
 const { v4: uuidv4 } = require('uuid');
 const {
@@ -412,7 +413,7 @@ const initialiseStatusScheduler = (nessie) => {
     getAllStatus(
       async (allStatus, client) => {
         try {
-          const rotationData = await getRotationData();
+          const rotationData = !checkIfInDevelopment(nessie) && (await getRotationData());
           const statusLogChannel = nessie.channels.cache.get('976863441526595644');
           if (allStatus) {
             const status = allStatus[0];
@@ -463,7 +464,9 @@ const initialiseStatusScheduler = (nessie) => {
               },
             ],
           };
-          await statusLogChannel.send({ embeds: [statusLogEmbed] });
+
+          !checkIfInDevelopment(nessie) &&
+            (await statusLogChannel.send({ embeds: [statusLogEmbed] }));
         } catch (error) {
           const uuid = uuidv4();
           const type = 'Status Scheduler Config';

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -8,6 +8,7 @@ const {
 const { v4: uuidv4 } = require('uuid');
 const { MessageActionRow, MessageSelectMenu, MessageButton } = require('discord.js');
 const { getRotationData } = require('../../adapters');
+const { nessieLogo } = require('../../constants');
 
 /**
  * Handler for when a user initiates the /status help command
@@ -292,11 +293,18 @@ const createStatus = async ({ interaction, nessie }) => {
         type: 'GUILD_TEXT',
       }));
 
-    statusBattleRoyaleChannel &&
-      (await statusBattleRoyaleChannel.send({
-        embeds: statusBattleRoyaleEmbed,
+    const statusBattleRoyaleWebhook =
+      statusBattleRoyaleChannel &&
+      (await statusBattleRoyaleChannel.createWebhook('Nessie Automatic Status', {
+        avatar: nessieLogo,
+        reason: 'Webhook to receive automatic map updates for Apex Battle Royale',
       }));
-    statusArenasChannel && (await statusArenasChannel.send({ embeds: statusArenasEmbed }));
+    const statusArenasWebhook =
+      statusArenasChannel &&
+      (await statusArenasChannel.createWebhook('Nessie Automatic Status', {
+        avatar: nessieLogo,
+        reason: 'Webhook to receive automatic map updates for Apex Arenas',
+      }));
 
     const embedSuccess = {
       description: `Created map status at ${statusBattleRoyaleChannel} and ${statusArenasChannel}`,

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -6,7 +6,7 @@ const {
   generateRankedEmbed,
 } = require('../../helpers');
 const { v4: uuidv4 } = require('uuid');
-const { MessageActionRow, MessageSelectMenu, MessageButton } = require('discord.js');
+const { MessageActionRow, MessageSelectMenu, MessageButton, WebhookClient } = require('discord.js');
 const { getRotationData } = require('../../adapters');
 const { nessieLogo } = require('../../constants');
 
@@ -304,6 +304,21 @@ const createStatus = async ({ interaction, nessie }) => {
       (await statusArenasChannel.createWebhook('Nessie Automatic Status', {
         avatar: nessieLogo,
         reason: 'Webhook to receive automatic map updates for Apex Arenas',
+      }));
+
+    statusBattleRoyaleWebhook &&
+      (await new WebhookClient({
+        id: statusBattleRoyaleWebhook.id,
+        token: statusBattleRoyaleWebhook.token,
+      }).send({
+        embeds: statusBattleRoyaleEmbed,
+      }));
+    statusArenasWebhook &&
+      (await new WebhookClient({
+        id: statusArenasWebhook.id,
+        token: statusArenasWebhook.token,
+      }).send({
+        embeds: statusArenasEmbed,
       }));
 
     const embedSuccess = {

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -101,6 +101,12 @@ const generateGameModeSelectionMessage = () => {
   };
 };
 const generateConfirmStatusMessage = ({ interaction }) => {
+  /**
+   * The game mode selections are passed down from the dropdown interaction in step 1
+   * However, there's no direct way of passing them down along with the confirm button interaction
+   * To solve this, we're going to append the selected game modes on the customId of the button itself
+   * Going to treat them like query params (?x&y)
+   */
   const isBattleRoyaleSelected = interaction.values.find(
     (value) => value === 'gameModeDropdown__battleRoyaleValue'
   );
@@ -108,9 +114,12 @@ const generateConfirmStatusMessage = ({ interaction }) => {
     (value) => value === 'gameModeDropdown__arenasValue'
   );
   const modeLength = interaction.values.length;
+
   const confirmButtonId = `statusStart__confirmButton${modeLength > 0 ? '?' : ''}${
     isBattleRoyaleSelected ? 'battle_royale' : ''
-  }${modeLength > 1 ? '&' : ''}${isArenasSelected ? 'arenas' : ''}`;
+  }${modeLength > 1 ? '&' : ''}${isArenasSelected ? 'arenas' : ''}`; //Full selection: statusStart__confirmButton?battle_royale&arenas;
+
+  //TODO: Cleanup the selected game mode display below
   const mapOptions = {
     gameModeDropdown__battleRoyaleValue: 'Battle Royale',
     gameModeDropdown__arenasValue: 'Arenas',
@@ -259,7 +268,19 @@ const _cancelStatusStart = async ({ interaction, nessie }) => {
 };
 /**
  * Handler for when a user clicks the Confirm button in Confirm Status Step
- * Placeholder for now but this is where most of the magic will happen
+ * This is the most important aspect as it will initialise the process of map status
+ * Main steps upon button click:
+ * - Check which game modes have been selected based on button customId
+ * - Edits initial message with a loading state
+ * - Calls the API for the rotation data
+ * - Create embeds for each status channel
+ * - Creates a category channel and relevant text channels under it
+ * - Creates relevant webhooks
+ * - Send embeds to respective channels through webhooks
+ * - Edits initial message with a success message
+ *
+ * TODO: Save status data in our database
+ * TODO: Maybe separate ui and wiring up to respective files/folders for better readability
  */
 const createStatus = async ({ interaction, nessie }) => {
   const isBattleRoyaleSelected = interaction.customId.includes('battle_royale');

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -263,11 +263,11 @@ const _cancelStatusStart = async ({ interaction, nessie }) => {
 const createStatus = async ({ interaction, nessie }) => {
   const isBattleRoyaleSelected = interaction.customId.includes('battle_royale');
   const isArenasSelected = interaction.customId.includes('arenas');
-  console.log(interaction);
   const embedLoading = {
     description: `Loading status channels...`,
     color: 16776960,
   };
+
   try {
     await interaction.deferUpdate();
     await interaction.message.edit({ embeds: [embedLoading], components: [] });
@@ -291,6 +291,18 @@ const createStatus = async ({ interaction, nessie }) => {
         parent: statusCategory,
         type: 'GUILD_TEXT',
       }));
+
+    statusBattleRoyaleChannel &&
+      (await statusBattleRoyaleChannel.send({
+        embeds: statusBattleRoyaleEmbed,
+      }));
+    statusArenasChannel && (await statusArenasChannel.send({ embeds: statusArenasEmbed }));
+
+    const embedSuccess = {
+      description: `Created map status at ${statusBattleRoyaleChannel} and ${statusArenasChannel}`,
+      color: 3066993,
+    };
+    await interaction.message.edit({ embeds: [embedSuccess], components: [] });
   } catch (error) {
     const uuid = uuidv4();
     const type = 'Status Start Confirm';

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -110,9 +110,6 @@ const generateConfirmStatusMessage = ({ interaction }) => {
   const confirmButtonId = `statusStart__confirmButton${modeLength > 0 ? '?' : ''}${
     isBattleRoyaleSelected ? 'battle_royale' : ''
   }${modeLength > 1 ? '&' : ''}${isArenasSelected ? 'arenas' : ''}`;
-  console.log(isBattleRoyaleSelected);
-  console.log(isArenasSelected);
-  console.log(confirmButtonId);
   const mapOptions = {
     gameModeDropdown__battleRoyaleValue: 'Battle Royale',
     gameModeDropdown__arenasValue: 'Arenas',
@@ -264,6 +261,8 @@ const _cancelStatusStart = async ({ interaction, nessie }) => {
  * Placeholder for now but this is where most of the magic will happen
  */
 const createStatus = async ({ interaction, nessie }) => {
+  const isBattleRoyaleSelected = interaction.customId.includes('battle_royale');
+  const isArenasSelected = interaction.customId.includes('arenas');
   console.log(interaction);
   const embedLoading = {
     description: `Loading status channels...`,
@@ -276,6 +275,22 @@ const createStatus = async ({ interaction, nessie }) => {
     const rotationData = await getRotationData();
     const statusBattleRoyaleEmbed = generateBattleRoyaleStatusEmbeds(rotationData);
     const statusArenasEmbed = generateArenasStatusEmbeds(rotationData);
+
+    const statusCategory = await interaction.guild.channels.create('Apex Legends Map Status', {
+      type: 'GUILD_CATEGORY',
+    });
+    const statusBattleRoyaleChannel =
+      isBattleRoyaleSelected &&
+      (await interaction.guild.channels.create('apex-battle-royale', {
+        parent: statusCategory,
+        type: 'GUILD_TEXT',
+      }));
+    const statusArenasChannel =
+      isArenasSelected &&
+      (await interaction.guild.channels.create('apex-arenas', {
+        parent: statusCategory,
+        type: 'GUILD_TEXT',
+      }));
   } catch (error) {
     const uuid = uuidv4();
     const type = 'Status Start Confirm';

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -100,10 +100,24 @@ const generateGameModeSelectionMessage = () => {
   };
 };
 const generateConfirmStatusMessage = ({ interaction }) => {
+  const isBattleRoyaleSelected = interaction.values.find(
+    (value) => value === 'gameModeDropdown__battleRoyaleValue'
+  );
+  const isArenasSelected = interaction.values.find(
+    (value) => value === 'gameModeDropdown__arenasValue'
+  );
+  const modeLength = interaction.values.length;
+  const confirmButtonId = `statusStart__confirmButton${modeLength > 0 ? '?' : ''}${
+    isBattleRoyaleSelected ? 'battle_royale' : ''
+  }${modeLength > 1 ? '&' : ''}${isArenasSelected ? 'arenas' : ''}`;
+  console.log(isBattleRoyaleSelected);
+  console.log(isArenasSelected);
+  console.log(confirmButtonId);
   const mapOptions = {
     gameModeDropdown__battleRoyaleValue: 'Battle Royale',
     gameModeDropdown__arenasValue: 'Arenas',
   };
+
   let selectedValues = '';
   interaction.values.forEach((value, index) => {
     selectedValues += `${index > 0 ? ', ' : ''}${mapOptions[value]}`;
@@ -122,10 +136,7 @@ const generateConfirmStatusMessage = ({ interaction }) => {
         .setCustomId('statusStart__cancelButton')
     )
     .addComponents(
-      new MessageButton()
-        .setLabel("Let's go!")
-        .setStyle('SUCCESS')
-        .setCustomId('statusStart__confirmButton')
+      new MessageButton().setLabel("Let's go!").setStyle('SUCCESS').setCustomId(confirmButtonId)
     );
   const embed = {
     title: 'Step 2 | Status Confirmation',
@@ -253,6 +264,7 @@ const _cancelStatusStart = async ({ interaction, nessie }) => {
  * Placeholder for now but this is where most of the magic will happen
  */
 const createStatus = async ({ interaction, nessie }) => {
+  console.log(interaction);
   const embedLoading = {
     description: `Loading status channels...`,
     color: 16776960,

--- a/database/handler.js
+++ b/database/handler.js
@@ -122,7 +122,7 @@ exports.createStatusTable = () => {
   this.pool.connect((err, client, done) => {
     client.query('BEGIN', (err) => {
       client.query(
-        'CREATE TABLE IF NOT EXISTS Status(uuid TEXT NOT NULL PRIMARY KEY, guild_id TEXT NOT NULL, category_channel_id TEXT, br_channel_id TEXT, arenas_channel_id TEXT, webhook_id TEXT NOT NULL, created_by TEXT NOT NULL, created_at TEXT NOT NULL)'
+        'CREATE TABLE IF NOT EXISTS Status(uuid TEXT NOT NULL PRIMARY KEY, guild_id TEXT NOT NULL, category_channel_id TEXT NOT NULL, br_channel_id TEXT NOT NULL, arenas_channel_id TEXT NOT NULL, br_message_id TEXT NOT NULL, arenas_message_id TEXT NOT NULL, created_by TEXT NOT NULL, created_at TEXT NOT NULL)'
       );
       client.query('COMMIT', (err) => {
         done();

--- a/database/handler.js
+++ b/database/handler.js
@@ -122,7 +122,7 @@ exports.createStatusTable = () => {
   this.pool.connect((err, client, done) => {
     client.query('BEGIN', (err) => {
       client.query(
-        'CREATE TABLE IF NOT EXISTS Status(uuid TEXT NOT NULL PRIMARY KEY, guild_id TEXT NOT NULL, category_channel_id TEXT NOT NULL, br_channel_id TEXT NOT NULL, arenas_channel_id TEXT NOT NULL, br_message_id TEXT NOT NULL, arenas_message_id TEXT NOT NULL, created_by TEXT NOT NULL, created_at TEXT NOT NULL)'
+        'CREATE TABLE IF NOT EXISTS Status(uuid TEXT NOT NULL PRIMARY KEY, guild_id TEXT NOT NULL, category_channel_id TEXT, br_channel_id TEXT, arenas_channel_id TEXT, webhook_id TEXT NOT NULL, created_by TEXT NOT NULL, created_at TEXT NOT NULL)'
       );
       client.query('COMMIT', (err) => {
         done();

--- a/events.js
+++ b/events.js
@@ -162,8 +162,10 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
           return goBackToGameModeSelection({ interaction, nessie });
         case 'statusStart__cancelButton':
           return _cancelStatusStart({ interaction, nessie });
-        case 'statusStart__confirmButton':
-          return createStatus({ interaction, nessie });
+        default:
+          if (interaction.customId.includes('statusStart__confirmButton')) {
+            return createStatus({ interaction, nessie });
+          }
       }
     }
     if (interaction.isSelectMenu()) {


### PR DESCRIPTION
#### Context
Flow for creation of automatic map status. Again similar changes to how it was before/announcement command with the main difference being the creation of webhooks and using them to send messages.

Pretty straightforward aside from having to pass down the selected game modes to the confirm interaction. Since the values for these comes from the interaction before, we can't directly tell the confirm interaction that these are the values selected. To solve this, we'll append the game modes in the confirm button `customId` as query params, i.e. `statusStart__confirmButton?battle_royale&arenas`.

Full flow:
- User selects game modes from select menu
- User confirms status
- Nessie creates relevant channels
- Nessie creates relevant webhooks
- Nessie uses the webhooks to send current rotation data

I'll wire up the database changes in upcoming prs
<img width="534" alt="image" src="https://user-images.githubusercontent.com/42207245/178111148-ec7100a2-7038-433f-be08-4c55ebdb009c.png">
<img width="192" alt="image" src="https://user-images.githubusercontent.com/42207245/178111150-999f7ca0-0cb4-466a-8d12-f0d4b0c2e88e.png">
<img width="613" alt="image" src="https://user-images.githubusercontent.com/42207245/178111160-528c1ea2-3f57-45fa-97fa-c4ea72bac456.png">


#### Change
- Add game modes selected as query params in custom button id
- Create channels based on selections
- Create webhooks in created channels
- Use webhooks to send rotation message
