### PR TITLE
Wire up status start

### DIFF
--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -285,14 +285,18 @@ const _cancelStatusStart = async ({ interaction, nessie }) => {
 const createStatus = async ({ interaction, nessie }) => {
   const isBattleRoyaleSelected = interaction.customId.includes('battle_royale');
   const isArenasSelected = interaction.customId.includes('arenas');
-  const embedLoading = {
+  const embedLoadingChannels = {
     description: `Loading status channels...`,
+    color: 16776960,
+  };
+  const embedLoadingWebhooks = {
+    description: `Loading webhooks...`,
     color: 16776960,
   };
 
   try {
     await interaction.deferUpdate();
-    await interaction.message.edit({ embeds: [embedLoading], components: [] });
+    await interaction.message.edit({ embeds: [embedLoadingChannels], components: [] });
 
     const rotationData = await getRotationData();
     const statusBattleRoyaleEmbed = generateBattleRoyaleStatusEmbeds(rotationData);
@@ -313,6 +317,8 @@ const createStatus = async ({ interaction, nessie }) => {
         parent: statusCategory,
         type: 'GUILD_TEXT',
       }));
+
+    await interaction.message.edit({ embeds: [embedLoadingWebhooks], components: [] });
 
     const statusBattleRoyaleWebhook =
       statusBattleRoyaleChannel &&
@@ -343,9 +349,19 @@ const createStatus = async ({ interaction, nessie }) => {
       }));
 
     const embedSuccess = {
-      description: `Created map status at ${statusBattleRoyaleChannel} and ${statusArenasChannel}`,
+      description: '',
       color: 3066993,
     };
+    isBattleRoyaleSelected && isArenasSelected
+      ? (embedSuccess.description = `Created map status at ${statusBattleRoyaleChannel} and ${statusArenasChannel}`)
+      : null;
+    isBattleRoyaleSelected && !isArenasSelected
+      ? (embedSuccess.description = `Created map status at ${statusBattleRoyaleChannel}`)
+      : null;
+    !isBattleRoyaleSelected && isArenasSelected
+      ? (embedSuccess.description = `Created map status at ${statusArenasChannel}`)
+      : null;
+
     await interaction.message.edit({ embeds: [embedSuccess], components: [] });
   } catch (error) {
     const uuid = uuidv4();

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -305,48 +305,50 @@ const createStatus = async ({ interaction, nessie }) => {
     const statusCategory = await interaction.guild.channels.create('Apex Legends Map Status', {
       type: 'GUILD_CATEGORY',
     });
-    const statusBattleRoyaleChannel =
-      isBattleRoyaleSelected &&
-      (await interaction.guild.channels.create('apex-battle-royale', {
-        parent: statusCategory,
-        type: 'GUILD_TEXT',
-      }));
-    const statusArenasChannel =
-      isArenasSelected &&
-      (await interaction.guild.channels.create('apex-arenas', {
-        parent: statusCategory,
-        type: 'GUILD_TEXT',
-      }));
+    const statusBattleRoyaleChannel = isBattleRoyaleSelected
+      ? await interaction.guild.channels.create('apex-battle-royale', {
+          parent: statusCategory,
+          type: 'GUILD_TEXT',
+        })
+      : null;
+    const statusArenasChannel = isArenasSelected
+      ? await interaction.guild.channels.create('apex-arenas', {
+          parent: statusCategory,
+          type: 'GUILD_TEXT',
+        })
+      : null;
 
     await interaction.message.edit({ embeds: [embedLoadingWebhooks], components: [] });
 
-    const statusBattleRoyaleWebhook =
-      statusBattleRoyaleChannel &&
-      (await statusBattleRoyaleChannel.createWebhook('Nessie Automatic Status', {
-        avatar: nessieLogo,
-        reason: 'Webhook to receive automatic map updates for Apex Battle Royale',
-      }));
-    const statusArenasWebhook =
-      statusArenasChannel &&
-      (await statusArenasChannel.createWebhook('Nessie Automatic Status', {
-        avatar: nessieLogo,
-        reason: 'Webhook to receive automatic map updates for Apex Arenas',
-      }));
+    const statusBattleRoyaleWebhook = statusBattleRoyaleChannel
+      ? await statusBattleRoyaleChannel.createWebhook('Nessie Automatic Status', {
+          avatar: nessieLogo,
+          reason: 'Webhook to receive automatic map updates for Apex Battle Royale',
+        })
+      : null;
+    const statusArenasWebhook = statusArenasChannel
+      ? await statusArenasChannel.createWebhook('Nessie Automatic Status', {
+          avatar: nessieLogo,
+          reason: 'Webhook to receive automatic map updates for Apex Arenas',
+        })
+      : null;
 
-    statusBattleRoyaleWebhook &&
-      (await new WebhookClient({
-        id: statusBattleRoyaleWebhook.id,
-        token: statusBattleRoyaleWebhook.token,
-      }).send({
-        embeds: statusBattleRoyaleEmbed,
-      }));
-    statusArenasWebhook &&
-      (await new WebhookClient({
-        id: statusArenasWebhook.id,
-        token: statusArenasWebhook.token,
-      }).send({
-        embeds: statusArenasEmbed,
-      }));
+    const statusBattleRoyaleMessage = statusBattleRoyaleWebhook
+      ? await new WebhookClient({
+          id: statusBattleRoyaleWebhook.id,
+          token: statusBattleRoyaleWebhook.token,
+        }).send({
+          embeds: statusBattleRoyaleEmbed,
+        })
+      : null;
+    const statusArenasMessage = statusArenasWebhook
+      ? await new WebhookClient({
+          id: statusArenasWebhook.id,
+          token: statusArenasWebhook.token,
+        }).send({
+          embeds: statusArenasEmbed,
+        })
+      : null;
 
     const embedSuccess = {
       description: '',
@@ -362,6 +364,17 @@ const createStatus = async ({ interaction, nessie }) => {
       ? (embedSuccess.description = `Created map status at ${statusArenasChannel}`)
       : null;
 
+    const newStatus = {
+      uuid: uuidv4(),
+      guildId: interaction.guildId,
+      categoryChannelId: statusCategory.id,
+      battleRoyaleChannelId: statusBattleRoyaleChannel.id,
+      arenasChannelId: statusArenasChannel.id,
+      battleRoyaleMessageId: statusBattleRoyaleMessage.id,
+      arenasMessageId: statusArenasMessage.id,
+      createdBy: interaction.user.tag,
+      createdAt: format(new Date(), 'dd MMM yyyy, h:mm a'),
+    };
     await interaction.message.edit({ embeds: [embedSuccess], components: [] });
   } catch (error) {
     const uuid = uuidv4();

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -346,6 +346,7 @@ const createStatus = async ({ interaction, nessie }) => {
         type: 'GUILD_TEXT',
       }));
 
+    //Since webhooks take way longer to create than channels, adding another loading state here
     await interaction.message.edit({ embeds: [embedLoadingWebhooks], components: [] });
 
     const statusBattleRoyaleWebhook =
@@ -378,6 +379,11 @@ const createStatus = async ({ interaction, nessie }) => {
         embeds: statusArenasEmbed,
       }));
 
+    /**
+     * Create new status data object to be inserted in our database
+     * We then call the insertNewStatus handler to start insertion
+     * * Passes a success and error callback with the former editing the original message with a success embed
+     */
     const newStatus = {
       uuid: uuidv4(),
       guildId: interaction.guildId,
@@ -406,6 +412,7 @@ const createStatus = async ({ interaction, nessie }) => {
           description: '',
           color: 3066993,
         };
+        //TODO: Probably figure out a better way of handling string manipulation
         isBattleRoyaleSelected && isArenasSelected
           ? (embedSuccess.description = `Created map status at ${statusBattleRoyaleChannel} and ${statusArenasChannel}`)
           : null;

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -9,6 +9,7 @@ const { v4: uuidv4 } = require('uuid');
 const { MessageActionRow, MessageSelectMenu, MessageButton, WebhookClient } = require('discord.js');
 const { getRotationData } = require('../../adapters');
 const { nessieLogo } = require('../../constants');
+const { format } = require('date-fns');
 
 /**
  * Handler for when a user initiates the /status help command
@@ -305,50 +306,50 @@ const createStatus = async ({ interaction, nessie }) => {
     const statusCategory = await interaction.guild.channels.create('Apex Legends Map Status', {
       type: 'GUILD_CATEGORY',
     });
-    const statusBattleRoyaleChannel = isBattleRoyaleSelected
-      ? await interaction.guild.channels.create('apex-battle-royale', {
-          parent: statusCategory,
-          type: 'GUILD_TEXT',
-        })
-      : null;
-    const statusArenasChannel = isArenasSelected
-      ? await interaction.guild.channels.create('apex-arenas', {
-          parent: statusCategory,
-          type: 'GUILD_TEXT',
-        })
-      : null;
+    const statusBattleRoyaleChannel =
+      isBattleRoyaleSelected &&
+      (await interaction.guild.channels.create('apex-battle-royale', {
+        parent: statusCategory,
+        type: 'GUILD_TEXT',
+      }));
+    const statusArenasChannel =
+      isArenasSelected &&
+      (await interaction.guild.channels.create('apex-arenas', {
+        parent: statusCategory,
+        type: 'GUILD_TEXT',
+      }));
 
     await interaction.message.edit({ embeds: [embedLoadingWebhooks], components: [] });
 
-    const statusBattleRoyaleWebhook = statusBattleRoyaleChannel
-      ? await statusBattleRoyaleChannel.createWebhook('Nessie Automatic Status', {
-          avatar: nessieLogo,
-          reason: 'Webhook to receive automatic map updates for Apex Battle Royale',
-        })
-      : null;
-    const statusArenasWebhook = statusArenasChannel
-      ? await statusArenasChannel.createWebhook('Nessie Automatic Status', {
-          avatar: nessieLogo,
-          reason: 'Webhook to receive automatic map updates for Apex Arenas',
-        })
-      : null;
+    const statusBattleRoyaleWebhook =
+      statusBattleRoyaleChannel &&
+      (await statusBattleRoyaleChannel.createWebhook('Nessie Automatic Status', {
+        avatar: nessieLogo,
+        reason: 'Webhook to receive automatic map updates for Apex Battle Royale',
+      }));
+    const statusArenasWebhook =
+      statusArenasChannel &&
+      (await statusArenasChannel.createWebhook('Nessie Automatic Status', {
+        avatar: nessieLogo,
+        reason: 'Webhook to receive automatic map updates for Apex Arenas',
+      }));
 
-    const statusBattleRoyaleMessage = statusBattleRoyaleWebhook
-      ? await new WebhookClient({
-          id: statusBattleRoyaleWebhook.id,
-          token: statusBattleRoyaleWebhook.token,
-        }).send({
-          embeds: statusBattleRoyaleEmbed,
-        })
-      : null;
-    const statusArenasMessage = statusArenasWebhook
-      ? await new WebhookClient({
-          id: statusArenasWebhook.id,
-          token: statusArenasWebhook.token,
-        }).send({
-          embeds: statusArenasEmbed,
-        })
-      : null;
+    const statusBattleRoyaleMessage =
+      statusBattleRoyaleWebhook &&
+      (await new WebhookClient({
+        id: statusBattleRoyaleWebhook.id,
+        token: statusBattleRoyaleWebhook.token,
+      }).send({
+        embeds: statusBattleRoyaleEmbed,
+      }));
+    const statusArenasMessage =
+      statusArenasWebhook &&
+      (await new WebhookClient({
+        id: statusArenasWebhook.id,
+        token: statusArenasWebhook.token,
+      }).send({
+        embeds: statusArenasEmbed,
+      }));
 
     const embedSuccess = {
       description: '',
@@ -368,13 +369,23 @@ const createStatus = async ({ interaction, nessie }) => {
       uuid: uuidv4(),
       guildId: interaction.guildId,
       categoryChannelId: statusCategory.id,
-      battleRoyaleChannelId: statusBattleRoyaleChannel.id,
-      arenasChannelId: statusArenasChannel.id,
-      battleRoyaleMessageId: statusBattleRoyaleMessage.id,
-      arenasMessageId: statusArenasMessage.id,
+      battleRoyaleChannelId: statusBattleRoyaleChannel ? statusBattleRoyaleChannel.id : null,
+      arenasChannelId: statusArenasChannel ? statusArenasChannel.id : null,
+      battleRoyaleMessageId: statusBattleRoyaleMessage ? statusBattleRoyaleMessage.id : null,
+      arenasMessageId: statusArenasMessage ? statusArenasMessage.id : null,
+      battleRoyaleWebhookId: statusBattleRoyaleWebhook ? statusBattleRoyaleWebhook.id : null,
+      arenasWebhookId: statusArenasWebhook ? statusArenasWebhook.id : null,
+      originalChannelId: interaction.channelId,
+      gameModeSelected:
+        isBattleRoyaleSelected && isArenasSelected
+          ? 'All'
+          : isBattleRoyaleSelected
+          ? 'Battle Royale'
+          : 'Arenas',
       createdBy: interaction.user.tag,
       createdAt: format(new Date(), 'dd MMM yyyy, h:mm a'),
     };
+    console.log(newStatus);
     await interaction.message.edit({ embeds: [embedSuccess], components: [] });
   } catch (error) {
     const uuid = uuidv4();

--- a/database/handler.js
+++ b/database/handler.js
@@ -122,7 +122,7 @@ exports.createStatusTable = () => {
   this.pool.connect((err, client, done) => {
     client.query('BEGIN', (err) => {
       client.query(
-        'CREATE TABLE IF NOT EXISTS Status(uuid TEXT NOT NULL PRIMARY KEY, guild_id TEXT NOT NULL, category_channel_id TEXT, br_channel_id TEXT NOT NULL, arenas_channel_id TEXT NOT NULL, br_message_id TEXT NOT NULL, arenas_message_id TEXT NOT NULL, br_webhook_id TEXT NOT NULL, arenas_webhook_id TEXT NOT NULL, original_channel_id TEXT NOT NULL, created_by TEXT NOT NULL, created_at TEXT NOT NULL)'
+        'CREATE TABLE IF NOT EXISTS Status(uuid TEXT NOT NULL PRIMARY KEY, guild_id TEXT NOT NULL, category_channel_id TEXT, br_channel_id TEXT, arenas_channel_id TEXT, br_message_id TEXT, arenas_message_id TEXT, br_webhook_id TEXT, arenas_webhook_id TEXT, original_channel_id TEXT NOT NULL, game_mode_selected TEXT NOT NULL, created_by TEXT NOT NULL, created_at TEXT NOT NULL)'
       );
       client.query('COMMIT', (err) => {
         done();

--- a/database/handler.js
+++ b/database/handler.js
@@ -117,6 +117,7 @@ exports.removeServerDataFromNessie = (nessie, guild) => {
  * Creates Status table in our database
  * Straightforward; no additional checks and only creates the table if it does not exist
  * Gets called in the onReady event of Nessie
+ * TODO: Maybe document all the necessary columns we need to create a status in notion
  */
 exports.createStatusTable = () => {
   this.pool.connect((err, client, done) => {

--- a/database/handler.js
+++ b/database/handler.js
@@ -122,7 +122,7 @@ exports.createStatusTable = () => {
   this.pool.connect((err, client, done) => {
     client.query('BEGIN', (err) => {
       client.query(
-        'CREATE TABLE IF NOT EXISTS Status(uuid TEXT NOT NULL PRIMARY KEY, guild_id TEXT NOT NULL, category_channel_id TEXT NOT NULL, br_channel_id TEXT NOT NULL, arenas_channel_id TEXT NOT NULL, br_message_id TEXT NOT NULL, arenas_message_id TEXT NOT NULL, created_by TEXT NOT NULL, created_at TEXT NOT NULL)'
+        'CREATE TABLE IF NOT EXISTS Status(uuid TEXT NOT NULL PRIMARY KEY, guild_id TEXT NOT NULL, category_channel_id TEXT, br_channel_id TEXT NOT NULL, arenas_channel_id TEXT NOT NULL, br_message_id TEXT NOT NULL, arenas_message_id TEXT NOT NULL, br_webhook_id TEXT NOT NULL, arenas_webhook_id TEXT NOT NULL, original_channel_id TEXT NOT NULL, created_by TEXT NOT NULL, created_at TEXT NOT NULL)'
       );
       client.query('COMMIT', (err) => {
         done();

--- a/database/handler.js
+++ b/database/handler.js
@@ -142,7 +142,7 @@ exports.insertNewStatus = async (status, onSuccess, onError) => {
   this.pool.connect((err, client, done) => {
     client.query('BEGIN', (err) => {
       client.query(
-        'INSERT INTO Status (uuid, guild_id, category_channel_id, br_channel_id, arenas_channel_id, br_message_id, arenas_message_id, created_by, created_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9)',
+        'INSERT INTO Status (uuid, guild_id, category_channel_id, br_channel_id, arenas_channel_id, br_message_id, arenas_message_id, br_webhook_id, arenas_webhook_id, original_channel_id, game_mode_selected, created_by, created_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)',
         [
           status.uuid,
           status.guildId,
@@ -151,6 +151,10 @@ exports.insertNewStatus = async (status, onSuccess, onError) => {
           status.arenasChannelId,
           status.battleRoyaleMessageId,
           status.arenasMessageId,
+          status.battleRoyaleWebhookId,
+          status.arenasWebhookId,
+          status.originalChannelId,
+          status.gameModeSelected,
           status.createdBy,
           status.createdAt,
         ],

--- a/migration.js
+++ b/migration.js
@@ -76,17 +76,18 @@ exports.runMigration = (guilds) => {
       // ----
       const selectAllStatus = 'SELECT * FROM Status';
       const deleteAllStatus = 'DELETE FROM Status';
-      // client.query(selectAllStatus, (err, res) => {
-      //   console.log(err);
-      //   console.log(res.rows);
-      //   done();
-      // });
-      client.query(dropStatus, (err, res) => {
+      client.query(selectAllStatus, (err, res) => {
         console.log(err);
         console.log(res);
-        client.query('COMMIT');
+        console.log(res.rows);
         done();
       });
+      // client.query(dropStatus, (err, res) => {
+      //   console.log(err);
+      //   console.log(res);
+      //   client.query('COMMIT');
+      //   done();
+      // });
       // client.query(deleteAllStatus, (err, res) => {
       //   console.log(err);
       //   console.log(res);


### PR DESCRIPTION
#### Context
I don't know what I'm writing anymore. Kek it's working but probably have to figure out how to clean all of this someday. Right now this particular file is becoming less readable with every new pr smh.

Anyway this pr is more on the database side in wiring up the newly created status. Updated the status handlers, create table and create status to support 4 new columns:
- `br_webhook_id`: For referencing webhook under battle royale status channel so we can send/delete rotation message
- `arenas_webhook_id`: For referencing webhook under arenas status channel so we can send/delete rotation message
- `original_channel_id`: Not sure yet if this is needed; definitely a nice-to-have but was thinking of sending a message in this channel if any major error occurs
- `game_mode_selected`: Also not sure what this can be used for yet but probably same as above for error handling

Also changed the UI for /status start to show details of a status if it's existing

![image](https://user-images.githubusercontent.com/42207245/178154299-15f7a611-5663-4386-84fd-3e5582c501b6.png)
![image](https://user-images.githubusercontent.com/42207245/178154292-640d916e-e4ba-4387-8c93-f1d5f5e7f936.png)
<img width="388" alt="image" src="https://user-images.githubusercontent.com/42207245/178154284-3e60bc04-27b2-4c73-af46-c3311483b89b.png">

#### Change
- Update status table to support new columns
- Add loading status to webhook creation
- Only show created channels in embed success
- Wire up inserting new status
- Show status details if there is existing status