### PR TITLE
Wire up status stop

### DIFF
--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -90,7 +90,7 @@ const generateGameModeSelectionMessage = (status) => {
           },
           {
             label: 'Battle Royale',
-            description: 'Pubs and Ranked Map Rotation for Arenas',
+            description: 'Pubs and Ranked Map Rotation for Battle Royale',
             value: 'gameModeDropdown__battleRoyaleValue',
           },
         ])

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -239,6 +239,11 @@ const sendStartInteraction = async ({ interaction, nessie }) => {
     }
   );
 };
+/**
+ * Handler for when a user initiates the /status stop command
+ * Calls the getStatus handler to see for existing status in the guild
+ * Passes a success and error callback with the former sending an information embed with context depending on status existence
+ */
 const sendStopInteraction = async ({ interaction, nessie }) => {
   await getStatus(
     interaction.guildId,
@@ -344,6 +349,10 @@ const _cancelStatusStart = async ({ interaction, nessie }) => {
     await sendErrorLog({ nessie, error, interaction, type, uuid });
   }
 };
+/**
+ * Handler for when a user clicks the cancel button of /status stop
+ * Pretty straightforward; we just edit the initial message with a cancel message similar to the cancel start handler
+ */
 const _cancelStatusStop = async ({ interaction, nessie }) => {
   const embed = {
     description: 'Cancelled automated map status deletion',
@@ -507,6 +516,18 @@ const createStatus = async ({ interaction, nessie }) => {
     await sendErrorLog({ nessie, error, interaction, type, uuid });
   }
 };
+/**
+ * Handler for stopping the process of map status
+ * Gets called when a user clicks the confirm button of the /status stop reply
+ * Main steps upon button click:
+ * - Edits initial message with a loading state
+ * - Calls the deleteStatus handler which returns the status data while also deleting it from the db
+ * - Fetches each of the relevant discord channels with the status data
+ * - Deletes each of of the discord channels
+ * - Edits initial message with a success message
+ *
+ * We don't need to delete the webhooks as they'll be automatically deleted along with its channels
+ */
 const deleteGuildStatus = async ({ interaction, nessie }) => {
   await interaction.deferUpdate();
   await deleteStatus(

--- a/commands/maps/status.js
+++ b/commands/maps/status.js
@@ -344,6 +344,22 @@ const _cancelStatusStart = async ({ interaction, nessie }) => {
     await sendErrorLog({ nessie, error, interaction, type, uuid });
   }
 };
+const _cancelStatusStop = async ({ interaction, nessie }) => {
+  const embed = {
+    description: 'Cancelled automated map status deletion',
+    color: 16711680,
+  };
+  try {
+    await interaction.deferUpdate();
+    await interaction.message.edit({ embeds: [embed], components: [] });
+  } catch (error) {
+    const uuid = uuidv4();
+    const type = 'Status Stop Cancel';
+    const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
+    await interaction.editReply({ embeds: errorEmbed, components: [] });
+    await sendErrorLog({ nessie, error, interaction, type, uuid });
+  }
+};
 /**
  * Handler for when a user clicks the Confirm button in Confirm Status Step
  * This is the most important aspect as it will initialise the process of map status
@@ -541,5 +557,6 @@ module.exports = {
   goToConfirmStatus,
   goBackToGameModeSelection,
   _cancelStatusStart,
+  _cancelStatusStop,
   createStatus,
 };

--- a/events.js
+++ b/events.js
@@ -38,6 +38,7 @@ const {
   goBackToGameModeSelection,
   _cancelStatusStart,
   createStatus,
+  _cancelStatusStop,
 } = require('./commands/maps/status');
 
 const appCommands = getApplicationCommands(); //Get list of application commands
@@ -162,6 +163,10 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
           return goBackToGameModeSelection({ interaction, nessie });
         case 'statusStart__cancelButton':
           return _cancelStatusStart({ interaction, nessie });
+        case 'statusStop__cancelButton':
+          return _cancelStatusStop({ interaction, nessie });
+        case 'statusStop__stopButton':
+          return;
         default:
           if (interaction.customId.includes('statusStart__confirmButton')) {
             return createStatus({ interaction, nessie });

--- a/events.js
+++ b/events.js
@@ -39,6 +39,7 @@ const {
   _cancelStatusStart,
   createStatus,
   _cancelStatusStop,
+  deleteGuildStatus,
 } = require('./commands/maps/status');
 
 const appCommands = getApplicationCommands(); //Get list of application commands
@@ -166,7 +167,7 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
         case 'statusStop__cancelButton':
           return _cancelStatusStop({ interaction, nessie });
         case 'statusStop__stopButton':
-          return;
+          return deleteGuildStatus({ interaction, nessie });
         default:
           if (interaction.customId.includes('statusStart__confirmButton')) {
             return createStatus({ interaction, nessie });


### PR DESCRIPTION
#### Context
Wire up the handlers of the status stop command. Didn't need to update the database functions, just had to wire it up with the new interaction handlers. Pretty straightforward but then again delete is always is compared to create stuff

![delete status](https://user-images.githubusercontent.com/42207245/178157372-9cdf55e1-1e3c-4446-ada7-b45509c26672.gif)

#### Change
- Add ui for status stop
- Wire up cancel and start buttons
- Fix description of br selection

#### Considerations
I'll take a day to figure out a better structure for command files. It's becoming clear that for more complex commands, we can't just shove everything in one file unless we sacrifice readability. Could split them up per subcommands? Or maybe UI? Idk yet but should be worth to spend some time working on it