### PR TITLE
Initialise status scheduler

### DIFF
--- a/events.js
+++ b/events.js
@@ -38,6 +38,7 @@ const {
   goBackToGameModeSelection,
   _cancelStatusStart,
   createStatus,
+  scheduleStatus,
 } = require('./commands/maps/status/start');
 const { _cancelStatusStop, deleteGuildStatus } = require('./commands/maps/status/stop');
 
@@ -69,8 +70,11 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
       nessie.user.setActivity(brPubsData.current.map); //Set current br map as activity status
       sendHealthLog(brPubsData, logChannel, true); //For logging purpose
       setCurrentMapStatus(brPubsData, logChannel, nessie); //Calls status display function
-      const statusScheduler = initialiseStatusScheduler(nessie); //Initialises auto status scheduler
-      statusScheduler.start(); //Starts the scheduler
+      // const statusScheduler = initialiseStatusScheduler(nessie); //Initialises auto status scheduler
+      // statusScheduler.start(); //Starts the scheduler
+
+      const statusSchedule = scheduleStatus(nessie);
+      statusSchedule.start();
     } catch (e) {
       console.log(e); //Add proper error handling
     }


### PR DESCRIPTION
#### Context
Big pain. We might have solved the rate limiting problem but here comes the time problem. This pr was only supposed to wire up the scheduling aspect of status but after implementing it and testing it out, I noticed that it took a total of about 6 seconds for a full br+arenas status to finish. Upon investigating, this was a result of our awaits on fetching webhooks, deleting old rotation message and creating new ones.

This proves to be huge problem as we're going to be back to square one if we keep this in; in a large scale it'll take hours for all the guilds to have their rotation data updated. Fortunately we can do without asynchronous fetching of webhooks and deleting but the main issue is how do we get the id of the newly created rotation message without having it blocking. I don't have any concrete ideas right now

Last boss to slay I guess smh

With all asynchronous:
![image](https://user-images.githubusercontent.com/42207245/178291773-5bcbba7e-775d-4639-9055-c4dd92a0b7d4.png)

With only create async:
![image](https://user-images.githubusercontent.com/42207245/178291836-e0ba08a5-f8b4-472f-a58b-47a767f827cb.png)

With no blockers:
![image](https://user-images.githubusercontent.com/42207245/178291888-73520f1a-5660-4726-9066-17558b9adce9.png)

#### Changes
- Create scheduler
