### PR TITLE
Add permissions errors in status commands

### DIFF
--- a/commands/maps/status/help/index.js
+++ b/commands/maps/status/help/index.js
@@ -1,5 +1,10 @@
 const { v4: uuidv4 } = require('uuid');
-const { generateErrorEmbed, sendErrorLog } = require('../../../../helpers');
+const {
+  generateErrorEmbed,
+  sendErrorLog,
+  checkMissingBotPermissions,
+  checkIfAdminUser,
+} = require('../../../../helpers');
 
 /**
  * Handler for when a user initiates the /status help command
@@ -9,13 +14,9 @@ const { generateErrorEmbed, sendErrorLog } = require('../../../../helpers');
  * Shows a success/warning at the end if any of the permissions are missing
  */
 const sendHelpInteraction = async ({ interaction, nessie }) => {
-  const isAdminUser = interaction.member.permissions.has('ADMINISTRATOR'); //Checks if user who initiated command is an Admin
-  const hasAdmin = interaction.guild.me.permissions.has('ADMINISTRATOR');
-  const hasManageChannels = interaction.guild.me.permissions.has('MANAGE_CHANNELS', false);
-  const hasManageWebhooks = interaction.guild.me.permissions.has('MANAGE_WEBHOOKS', false);
-  const hasSendMessages = interaction.guild.me.permissions.has('SEND_MESSAGES', false);
-  const hasMissingPermissions =
-    (!hasManageChannels || !hasManageWebhooks || !hasSendMessages) && !hasAdmin; //Overrides missing permissions if nessie has Admin
+  const { hasAdmin, hasManageChannels, hasManageWebhooks, hasSendMessages, hasMissingPermissions } =
+    checkMissingBotPermissions(interaction);
+  const isAdminUser = checkIfAdminUser(interaction);
 
   try {
     const embedData = {

--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -9,6 +9,7 @@ const {
   sendMissingBotPermissionsError,
   checkIfAdminUser,
   sendOnlyAdminError,
+  sendMissingAllPermissionsError,
 } = require('../../../../helpers');
 const { getRotationData } = require('../../../../adapters');
 const { nessieLogo } = require('../../../../constants');
@@ -177,11 +178,12 @@ const sendStartInteraction = async ({ interaction, nessie }) => {
       const isAdminUser = checkIfAdminUser(interaction);
       try {
         if (!status) {
-          if (hasMissingPermissions) {
-            return sendMissingBotPermissionsError({ interaction, title: 'Status | Start' });
-          }
-          if (!isAdminUser) {
-            return sendOnlyAdminError({ interaction, title: 'Status | Start' });
+          if (hasMissingPermissions && !isAdminUser) {
+            return sendMissingAllPermissionsError({ interaction, title: 'Status | Start' });
+          } else {
+            if (hasMissingPermissions)
+              return sendMissingBotPermissionsError({ interaction, title: 'Status | Start' });
+            if (!isAdminUser) return sendOnlyAdminError({ interaction, title: 'Status | Start' });
           }
         }
         await interaction.editReply({ embeds: [embed], components: row ? [row] : [] });

--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -414,7 +414,7 @@ const createStatus = async ({ interaction, nessie }) => {
  */
 const scheduleStatus = (nessie) => {
   return new Scheduler(
-    '10 */1 * * * *',
+    '10 */15 * * * *',
     async () => {
       getAllStatus(async (allStatus, client) => {
         try {

--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -5,6 +5,8 @@ const {
   sendErrorLog,
   generatePubsEmbed,
   generateRankedEmbed,
+  checkMissingBotPermissions,
+  sendMissingBotPermissionsError,
 } = require('../../../../helpers');
 const { getRotationData } = require('../../../../adapters');
 const { nessieLogo } = require('../../../../constants');
@@ -169,7 +171,11 @@ const sendStartInteraction = async ({ interaction, nessie }) => {
     interaction.guildId,
     async (status) => {
       const { embed, row } = generateGameModeSelectionMessage(status);
+      const { hasMissingPermissions } = checkMissingBotPermissions(interaction);
       try {
+        if (!status && hasMissingPermissions) {
+          return sendMissingBotPermissionsError({ interaction, title: 'Status | Start' });
+        }
         await interaction.editReply({ embeds: [embed], components: row ? [row] : [] });
       } catch (error) {
         const uuid = uuidv4();

--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -7,6 +7,8 @@ const {
   generateRankedEmbed,
   checkMissingBotPermissions,
   sendMissingBotPermissionsError,
+  checkIfAdminUser,
+  sendOnlyAdminError,
 } = require('../../../../helpers');
 const { getRotationData } = require('../../../../adapters');
 const { nessieLogo } = require('../../../../constants');
@@ -172,9 +174,15 @@ const sendStartInteraction = async ({ interaction, nessie }) => {
     async (status) => {
       const { embed, row } = generateGameModeSelectionMessage(status);
       const { hasMissingPermissions } = checkMissingBotPermissions(interaction);
+      const isAdminUser = checkIfAdminUser(interaction);
       try {
-        if (!status && hasMissingPermissions) {
-          return sendMissingBotPermissionsError({ interaction, title: 'Status | Start' });
+        if (!status) {
+          if (hasMissingPermissions) {
+            return sendMissingBotPermissionsError({ interaction, title: 'Status | Start' });
+          }
+          if (!isAdminUser) {
+            return sendOnlyAdminError({ interaction, title: 'Status | Start' });
+          }
         }
         await interaction.editReply({ embeds: [embed], components: row ? [row] : [] });
       } catch (error) {

--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -168,6 +168,8 @@ const generateArenasStatusEmbeds = (data) => {
 /**
  * Handler for when a user initiates the /status start command
  * Shows the first step of the status start wizard: Game Mode Selection
+ * We want to show permissions errors only when status do not exist
+ * We want to show them existing status details but block them if they want to create one
  */
 const sendStartInteraction = async ({ interaction, nessie }) => {
   await getStatus(

--- a/commands/maps/status/stop/index.js
+++ b/commands/maps/status/stop/index.js
@@ -15,6 +15,7 @@ const { getStatus, deleteStatus } = require('../../../../database/handler');
  * Handler for when a user initiates the /status stop command
  * Calls the getStatus handler to see for existing status in the guild
  * Passes a success and error callback with the former sending an information embed with context depending on status existence
+ * Also, we want to show permissions errors but only if a status exists as we want to block them from interacting with components
  */
 const sendStopInteraction = async ({ interaction, nessie }) => {
   await getStatus(

--- a/commands/maps/status/stop/index.js
+++ b/commands/maps/status/stop/index.js
@@ -1,4 +1,13 @@
-const { generateErrorEmbed, sendErrorLog, codeBlock } = require('../../../../helpers');
+const {
+  generateErrorEmbed,
+  sendErrorLog,
+  codeBlock,
+  checkMissingBotPermissions,
+  checkIfAdminUser,
+  sendMissingAllPermissionsError,
+  sendMissingBotPermissionsError,
+  sendOnlyAdminError,
+} = require('../../../../helpers');
 const { v4: uuidv4 } = require('uuid');
 const { MessageActionRow, MessageButton } = require('discord.js');
 const { getStatus, deleteStatus } = require('../../../../database/handler');
@@ -11,6 +20,17 @@ const sendStopInteraction = async ({ interaction, nessie }) => {
   await getStatus(
     interaction.guildId,
     async (status) => {
+      const { hasMissingPermissions } = checkMissingBotPermissions(interaction);
+      const isAdminUser = checkIfAdminUser(interaction);
+      if (status) {
+        if (hasMissingPermissions && !isAdminUser) {
+          return sendMissingAllPermissionsError({ interaction, title: 'Status | Stop' });
+        } else {
+          if (hasMissingPermissions)
+            return sendMissingBotPermissionsError({ interaction, title: 'Status | Stop' });
+          if (!isAdminUser) return sendOnlyAdminError({ interaction, title: 'Status | Stop' });
+        }
+      }
       const embed = {
         title: 'Status | Stop',
         color: 3447003,

--- a/helpers.js
+++ b/helpers.js
@@ -369,6 +369,15 @@ const checkMissingBotPermissions = (interaction) => {
 const checkIfAdminUser = (interaction) => {
   return interaction.member.permissions.has('ADMINISTRATOR'); //Checks if user who initiated command is an Admin
 };
+const sendMissingBotPermissionsError = async ({ interaction, title }) => {
+  const embed = {
+    title,
+    description:
+      'Oops looks like Nessie is missing some permissions D:\n\nThese bot permissions are required to create automatic map updates:\n• Manage Channels\n• Manage Webhooks\n• Send Messages',
+    color: 16711680,
+  };
+  return await interaction.editReply({ embeds: [embed], components: [] });
+};
 //---------
 module.exports = {
   checkIfInDevelopment,
@@ -385,4 +394,5 @@ module.exports = {
   generateRankedEmbed,
   checkMissingBotPermissions,
   checkIfAdminUser,
+  sendMissingBotPermissionsError,
 };

--- a/helpers.js
+++ b/helpers.js
@@ -366,7 +366,7 @@ const checkMissingBotPermissions = (interaction) => {
     hasMissingPermissions,
   };
 };
-const checkMissingUserPermissions = (interaction) => {
+const checkIfAdminUser = (interaction) => {
   return interaction.member.permissions.has('ADMINISTRATOR'); //Checks if user who initiated command is an Admin
 };
 //---------
@@ -383,4 +383,6 @@ module.exports = {
   getCountdown,
   generatePubsEmbed,
   generateRankedEmbed,
+  checkMissingBotPermissions,
+  checkIfAdminUser,
 };

--- a/helpers.js
+++ b/helpers.js
@@ -348,6 +348,27 @@ const generateRankedEmbed = (data, type = 'Battle Royale') => {
   }
   return embedData;
 };
+
+const checkMissingBotPermissions = (interaction) => {
+  const hasAdmin = interaction.guild.me.permissions.has('ADMINISTRATOR');
+  const hasManageChannels = interaction.guild.me.permissions.has('MANAGE_CHANNELS', false);
+  const hasManageWebhooks = interaction.guild.me.permissions.has('MANAGE_WEBHOOKS', false);
+  const hasSendMessages = interaction.guild.me.permissions.has('SEND_MESSAGES', false);
+
+  const hasMissingPermissions =
+    (!hasManageChannels || !hasManageWebhooks || !hasSendMessages) && !hasAdmin; //Overrides missing permissions if nessie has Admin
+
+  return {
+    hasAdmin,
+    hasManageChannels,
+    hasManageWebhooks,
+    hasSendMessages,
+    hasMissingPermissions,
+  };
+};
+const checkMissingUserPermissions = (interaction) => {
+  return interaction.member.permissions.has('ADMINISTRATOR'); //Checks if user who initiated command is an Admin
+};
 //---------
 module.exports = {
   checkIfInDevelopment,

--- a/helpers.js
+++ b/helpers.js
@@ -387,6 +387,15 @@ const sendOnlyAdminError = async ({ interaction, title }) => {
   };
   return await interaction.editReply({ embeds: [embed], components: [] });
 };
+const sendMissingAllPermissionsError = async ({ interaction, title }) => {
+  const embed = {
+    title,
+    description:
+      "Oops looks there are some issues to resolve before you're able to create automatic map updates D:\n\nRequired Bot Permissions\n• Manage Channels\n• Manage Webhooks\n• Send Messages\n\nRequired User Permissions:\n• Administrator",
+    color: 16711680,
+  };
+  return await interaction.editReply({ embeds: [embed], components: [] });
+};
 //---------
 module.exports = {
   checkIfInDevelopment,
@@ -405,4 +414,5 @@ module.exports = {
   checkIfAdminUser,
   sendMissingBotPermissionsError,
   sendOnlyAdminError,
+  sendMissingAllPermissionsError,
 };

--- a/helpers.js
+++ b/helpers.js
@@ -378,6 +378,15 @@ const sendMissingBotPermissionsError = async ({ interaction, title }) => {
   };
   return await interaction.editReply({ embeds: [embed], components: [] });
 };
+const sendOnlyAdminError = async ({ interaction, title }) => {
+  const embed = {
+    title,
+    description:
+      'Oops only Admins can create automatic map updates D:\n\nRequired User Permissions:\n• Administrator',
+    color: 16711680,
+  };
+  return await interaction.editReply({ embeds: [embed], components: [] });
+};
 //---------
 module.exports = {
   checkIfInDevelopment,
@@ -395,4 +404,5 @@ module.exports = {
   checkMissingBotPermissions,
   checkIfAdminUser,
   sendMissingBotPermissionsError,
+  sendOnlyAdminError,
 };

--- a/helpers.js
+++ b/helpers.js
@@ -372,8 +372,9 @@ const checkIfAdminUser = (interaction) => {
 const sendMissingBotPermissionsError = async ({ interaction, title }) => {
   const embed = {
     title,
-    description:
-      'Oops looks like Nessie is missing some permissions D:\n\nThese bot permissions are required to create automatic map updates:\n• Manage Channels\n• Manage Webhooks\n• Send Messages',
+    description: `Oops looks like Nessie is missing some permissions D:\n\nThese bot permissions are required to create automatic map updates:\n• Manage Channels\n• Manage Webhooks\n• Send Messages\n\nFor more details, use ${codeBlock(
+      '/status help'
+    )}`,
     color: 16711680,
   };
   return await interaction.editReply({ embeds: [embed], components: [] });
@@ -381,8 +382,9 @@ const sendMissingBotPermissionsError = async ({ interaction, title }) => {
 const sendOnlyAdminError = async ({ interaction, title }) => {
   const embed = {
     title,
-    description:
-      'Oops only Admins can create automatic map updates D:\n\nRequired User Permissions:\n• Administrator',
+    description: `Oops only Admins can create automatic map updates D:\n\nRequired User Permissions:\n• Administrator\n\nFor more details, use ${codeBlock(
+      '/status help'
+    )}`,
     color: 16711680,
   };
   return await interaction.editReply({ embeds: [embed], components: [] });
@@ -390,8 +392,9 @@ const sendOnlyAdminError = async ({ interaction, title }) => {
 const sendMissingAllPermissionsError = async ({ interaction, title }) => {
   const embed = {
     title,
-    description:
-      "Oops looks there are some issues to resolve before you're able to create automatic map updates D:\n\nRequired Bot Permissions\n• Manage Channels\n• Manage Webhooks\n• Send Messages\n\nRequired User Permissions:\n• Administrator",
+    description: `Oops looks there are some issues to resolve before you're able to create automatic map updates D:\n\nRequired Bot Permissions\n• Manage Channels\n• Manage Webhooks\n• Send Messages\n\nRequired User Permissions:\n• Administrator\n\nFor more details, use ${codeBlock(
+      '/status help'
+    )}`,
     color: 16711680,
   };
   return await interaction.editReply({ embeds: [embed], components: [] });


### PR DESCRIPTION
#### Design
https://www.figma.com/file/Zw83AgLQpObLpPlSoeEWjq/Automatic-Status-Prototype?node-id=151%3A10320

#### Context
Definitely a nice to have feature, arguably the nicest to have in this project but I had time to spare. This will show error embeds for status commands depending on missing bot permissions, missing user permissions or both

<img width="410" alt="image" src="https://user-images.githubusercontent.com/42207245/178526619-d5424187-6099-40f3-a181-08a2ce6abfec.png">
<img width="489" alt="image" src="https://user-images.githubusercontent.com/42207245/178526650-9e23d544-7890-42ff-82af-7855f7dfdaf2.png">
<img width="349" alt="image" src="https://user-images.githubusercontent.com/42207245/178526707-57a2c66a-a419-40d2-826e-88bfa4efc705.png">

#### Change
- Create helpers to check missing bot permissions and user permissions
- Create helpers to send error embeds for missing bot/user/all permissions
- Send permission errors for status start and status stop
