### PR TITLE
Spike time taken for status cycles

### DIFF
--- a/adapters.js
+++ b/adapters.js
@@ -97,6 +97,6 @@ exports.getRotationData = async () => {
   const data = await axios.get(url).then((response) => {
     return response.data;
   });
-  console.log(data);
+  // console.log(data);
   return data;
 };

--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -415,7 +415,7 @@ const createStatus = async ({ interaction, nessie }) => {
  */
 const scheduleStatus = (nessie) => {
   return new Scheduler(
-    '10 */2 * * * *',
+    '10 */1 * * * *',
     async () => {
       const startTime = format(new Date(), 'h:mm:ss a');
       console.log('Start: ', format(new Date(), 'h:mm:ss a'));
@@ -424,7 +424,7 @@ const scheduleStatus = (nessie) => {
           if (allStatus) {
             console.log('After Database: ', format(new Date(), 'h:mm:ss a'));
             const rotationData = await getRotationData();
-            allStatus.forEach(async (status) => {
+            allStatus.forEach(async (status, index) => {
               const brWebhook =
                 status.br_webhook_id && (await nessie.fetchWebhook(status.br_webhook_id));
               const arenasWebhook =
@@ -470,20 +470,23 @@ const scheduleStatus = (nessie) => {
                 ],
                 (err, res) => {
                   client.query('COMMIT', async () => {
-                    const testChannel = nessie.channels.cache.get('889212328539725824');
-                    const endTime = format(new Date(), 'h:mm:ss a');
                     console.log('After Update: ', format(new Date(), 'h:mm:ss a'));
-                    testChannel.send({
-                      embeds: [
-                        {
-                          description: `Start of Cycle: ${codeBlock(
-                            startTime
-                          )}\nEnd of Cycle: ${codeBlock(endTime)}\n\nNo. of guilds: ${
-                            allStatus.length
-                          }`,
-                        },
-                      ],
-                    });
+                    console.log('----------------');
+                    const testChannel = nessie.channels.cache.get('889212328539725824');
+                    if (index === allStatus.length - 1) {
+                      const endTime = format(new Date(), 'h:mm:ss a');
+                      testChannel.send({
+                        embeds: [
+                          {
+                            description: `Start of Cycle: ${codeBlock(
+                              startTime
+                            )}\nEnd of Cycle: ${codeBlock(endTime)}\n\nNo. of guilds: ${
+                              allStatus.length
+                            }`,
+                          },
+                        ],
+                      });
+                    }
                   });
                 }
               );

--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -415,7 +415,7 @@ const createStatus = async ({ interaction, nessie }) => {
  */
 const scheduleStatus = (nessie) => {
   return new Scheduler(
-    '10 */5 * * * *',
+    '10 */2 * * * *',
     async () => {
       const startTime = format(new Date(), 'h:mm:ss a');
       console.log('Start: ', format(new Date(), 'h:mm:ss a'));

--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -279,7 +279,6 @@ const _cancelStatusStart = async ({ interaction, nessie }) => {
  * TODO: Save status data in our database
  * TODO: Maybe separate ui and wiring up to respective files/folders for better readability
  */
-let testStatus = [];
 const createStatus = async ({ interaction, nessie }) => {
   const isBattleRoyaleSelected = interaction.customId.includes('battle_royale');
   const isArenasSelected = interaction.customId.includes('arenas');
@@ -348,13 +347,7 @@ const createStatus = async ({ interaction, nessie }) => {
       }).send({
         embeds: statusArenasEmbed,
       }));
-    testStatus.push({
-      brId: statusBattleRoyaleWebhook.id,
-      brToken: statusBattleRoyaleWebhook.token,
-      arenasId: statusArenasWebhook.id,
-      arenasToken: statusArenasWebhook.token,
-    });
-    console.log(testStatus);
+
     /**
      * Create new status data object to be inserted in our database
      * We then call the insertNewStatus handler to start insertion
@@ -466,19 +459,39 @@ const scheduleStatus = (nessie) => {
 
               if (brWebhookClient) {
                 const brStatusEmbeds = generateBattleRoyaleStatusEmbeds(rotationData);
-                await brWebhookClient.deleteMessage(status.br_message_id);
-                console.log('After BR Delete: ', format(new Date(), 'h:mm:ss a'));
-                newBrMessage = await brWebhookClient.send({ embeds: brStatusEmbeds });
-                console.log('After BR Message: ', format(new Date(), 'h:mm:ss a'));
+                // await brWebhookClient.deleteMessage(status.br_message_id);
+                // console.log('After BR Delete: ', format(new Date(), 'h:mm:ss a'));
+                // newBrMessage = await brWebhookClient.send({ embeds: brStatusEmbeds });
+                // console.log('After BR Message: ', format(new Date(), 'h:mm:ss a'));
+                await brWebhookClient.editMessage(status.br_message_id, { embeds: brStatusEmbeds });
               }
               if (arenasWebhookClient) {
                 const arenasStatusEmbeds = generateArenasStatusEmbeds(rotationData);
-                await arenasWebhookClient.deleteMessage(status.arenas_message_id);
-                console.log('After Arenas Delete: ', format(new Date(), 'h:mm:ss a'));
-                newArenasMessage = await arenasWebhookClient.send({ embeds: arenasStatusEmbeds });
-                console.log('After Arenas Message: ', format(new Date(), 'h:mm:ss a'));
+                // await arenasWebhookClient.deleteMessage(status.arenas_message_id);
+                // console.log('After Arenas Delete: ', format(new Date(), 'h:mm:ss a'));
+                // newArenasMessage = await arenasWebhookClient.send({ embeds: arenasStatusEmbeds });
+                // console.log('After Arenas Message: ', format(new Date(), 'h:mm:ss a'));
+                await arenasWebhookClient.editMessage(status.arenas_message_id, {
+                  embeds: arenasStatusEmbeds,
+                });
               }
-
+              console.log('After Update: ', format(new Date(), 'h:mm:ss a'));
+              console.log('----------------');
+              const testChannel = nessie.channels.cache.get('889212328539725824');
+              if (index === allStatus.length - 1) {
+                const endTime = format(new Date(), 'h:mm:ss a');
+                testChannel.send({
+                  embeds: [
+                    {
+                      description: `Start of Cycle: ${codeBlock(
+                        startTime
+                      )}\nEnd of Cycle: ${codeBlock(endTime)}\n\nNo. of guilds: ${
+                        allStatus.length
+                      }`,
+                    },
+                  ],
+                });
+              }
               /**
                * Tbh I'm a bit worried about having this query here
                * It seems to be working during development but I'm not sure if it's actually firing only after the message promises are done
@@ -486,35 +499,35 @@ const scheduleStatus = (nessie) => {
                *
                * TODO: Figure out how to cut down time with this, maybe collect all new messages first then updating database? Rather than updating per iteration
                */
-              client.query(
-                'UPDATE Status SET br_message_id = ($1), arenas_message_id = ($2) WHERE uuid = ($3)',
-                [
-                  newBrMessage ? newBrMessage.id.toString() : null,
-                  newArenasMessage ? newArenasMessage.id.toString() : null,
-                  status.uuid.toString(),
-                ],
-                (err, res) => {
-                  client.query('COMMIT', async () => {
-                    console.log('After Update: ', format(new Date(), 'h:mm:ss a'));
-                    console.log('----------------');
-                    const testChannel = nessie.channels.cache.get('889212328539725824');
-                    if (index === allStatus.length - 1) {
-                      const endTime = format(new Date(), 'h:mm:ss a');
-                      testChannel.send({
-                        embeds: [
-                          {
-                            description: `Start of Cycle: ${codeBlock(
-                              startTime
-                            )}\nEnd of Cycle: ${codeBlock(endTime)}\n\nNo. of guilds: ${
-                              allStatus.length
-                            }`,
-                          },
-                        ],
-                      });
-                    }
-                  });
-                }
-              );
+              // client.query(
+              //   'UPDATE Status SET br_message_id = ($1), arenas_message_id = ($2) WHERE uuid = ($3)',
+              //   [
+              //     newBrMessage ? newBrMessage.id.toString() : null,
+              //     newArenasMessage ? newArenasMessage.id.toString() : null,
+              //     status.uuid.toString(),
+              //   ],
+              //   (err, res) => {
+              //     client.query('COMMIT', async () => {
+              //       console.log('After Update: ', format(new Date(), 'h:mm:ss a'));
+              //       console.log('----------------');
+              //       const testChannel = nessie.channels.cache.get('889212328539725824');
+              //       if (index === allStatus.length - 1) {
+              //         const endTime = format(new Date(), 'h:mm:ss a');
+              //         testChannel.send({
+              //           embeds: [
+              //             {
+              //               description: `Start of Cycle: ${codeBlock(
+              //                 startTime
+              //               )}\nEnd of Cycle: ${codeBlock(endTime)}\n\nNo. of guilds: ${
+              //                 allStatus.length
+              //               }`,
+              //             },
+              //           ],
+              //         });
+              //       }
+              //     });
+              //   }
+              // );
             });
           }
         } catch (error) {

--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -279,6 +279,7 @@ const _cancelStatusStart = async ({ interaction, nessie }) => {
  * TODO: Save status data in our database
  * TODO: Maybe separate ui and wiring up to respective files/folders for better readability
  */
+let testStatus = [];
 const createStatus = async ({ interaction, nessie }) => {
   const isBattleRoyaleSelected = interaction.customId.includes('battle_royale');
   const isArenasSelected = interaction.customId.includes('arenas');
@@ -347,7 +348,13 @@ const createStatus = async ({ interaction, nessie }) => {
       }).send({
         embeds: statusArenasEmbed,
       }));
-
+    testStatus.push({
+      brId: statusBattleRoyaleWebhook.id,
+      brToken: statusBattleRoyaleWebhook.token,
+      arenasId: statusArenasWebhook.id,
+      arenasToken: statusArenasWebhook.token,
+    });
+    console.log(testStatus);
     /**
      * Create new status data object to be inserted in our database
      * We then call the insertNewStatus handler to start insertion

--- a/events.js
+++ b/events.js
@@ -258,10 +258,26 @@ const registerApplicationCommands = async (nessie) => {
   const rest = new REST({ version: '9' }).setToken(token);
 
   if (isInDevelopment) {
+    const testGuilds = [
+      '996084542064558091',
+      '996084495843340348',
+      '996084451400486962',
+      '996083985132298382',
+      '996083929972998296',
+      '996083244346912770',
+      '996083190634659880',
+      '996081513554776154',
+      '996081433829462156',
+    ];
     //Guild register
     try {
       await rest.put(Routes.applicationGuildCommands('929421200797626388', guildIDs), {
         body: fullCommandList,
+      });
+      testGuilds.forEach(async (testGuild) => {
+        await rest.put(Routes.applicationGuildCommands('929421200797626388', testGuild), {
+          body: fullCommandList,
+        });
       });
       console.log('Successfully registered guild application commands');
     } catch (e) {

--- a/helpers.js
+++ b/helpers.js
@@ -348,7 +348,12 @@ const generateRankedEmbed = (data, type = 'Battle Royale') => {
   }
   return embedData;
 };
-
+/**
+ * Helper to check if nessie has missing permissions to properly work
+ * Most of these permissions are for the status command
+ * Since having admin trumps every other permission, we also have to check if nessie has that to overwrite missing permissions
+ * Useful to have as a helper so we can quickly check when we need them in commands
+ */
 const checkMissingBotPermissions = (interaction) => {
   const hasAdmin = interaction.guild.me.permissions.has('ADMINISTRATOR');
   const hasManageChannels = interaction.guild.me.permissions.has('MANAGE_CHANNELS', false);
@@ -366,9 +371,16 @@ const checkMissingBotPermissions = (interaction) => {
     hasMissingPermissions,
   };
 };
+/**
+ * Helper to check if user who initiated a command has the admin permission
+ * Since we want to only give power to admins when it comes to important commands, this comes useful to reuse
+ */
 const checkIfAdminUser = (interaction) => {
   return interaction.member.permissions.has('ADMINISTRATOR'); //Checks if user who initiated command is an Admin
 };
+/**
+ * Helper to send an error message regarding missing bot permissions
+ */
 const sendMissingBotPermissionsError = async ({ interaction, title }) => {
   const embed = {
     title,
@@ -379,6 +391,9 @@ const sendMissingBotPermissionsError = async ({ interaction, title }) => {
   };
   return await interaction.editReply({ embeds: [embed], components: [] });
 };
+/**
+ * Helper to send an error message regarding missing bot permissions
+ */
 const sendOnlyAdminError = async ({ interaction, title }) => {
   const embed = {
     title,
@@ -389,6 +404,9 @@ const sendOnlyAdminError = async ({ interaction, title }) => {
   };
   return await interaction.editReply({ embeds: [embed], components: [] });
 };
+/**
+ * Helper to send an error message regarding missing bot permissions
+ */
 const sendMissingAllPermissionsError = async ({ interaction, title }) => {
   const embed = {
     title,


### PR DESCRIPTION
Not merging this, just gonna close after. Only want to have a paper trail here along with notion. This came about me testing out the status scheduler from #92. I was surprised that it took around 6 seconds for one cycle to finish then quickly realised that it's due to all the awaits we were doing. In total for a status with arenas and br selected, there'll be 2 fetches for the webhooks, 2 deletes and then 2 creates. Not to mention there's a database query at the start and end of the cycles.

This was going to be a huge problem if we don't solve it now. One of the reasons we've switched to webhooks because normal messaging would not only get us rate limited, it'll also take hella long for every guild to receive their updates. Fortunately after spiking, it looks like we're able to cut down time quite a bit. A lot of it is definitely from removing unnecessary awaits and just letting requests fire without caring about the response. But the one crazy thing from this spike is that we've found ourselves come full circle. 

Started this status feature with editing messages, realised we were going to get rate limited real fast then so used create + deleting messages, realised that wasn't enough to bypass rate limiting so switched to webhooks, and now somehow is going to use edits through webhooks cuz it's the best user experience + time intensive.

Only caveat with it is that I still have no idea if this is sustainable in a large scale. Especially when editing stuff is the most resource extensive. We might have to revisit this infrastructure wise down the road. An alternative is to continue with create + delete but separating the scheduler into multiple processes so each one will send requests to webhooks for a portion of the total guilds we support. This might be the most stable but I really want to risk seeing if edits can make it happen

More comprehensive reading here: https://shizuka.notion.site/Spike-on-Status-Time-Taken-0c26284152f04a169c546fe7b582a658