### PR TITLE
Revamp status flow

### DIFF
--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -435,19 +435,14 @@ const createStatus = async ({ interaction, nessie }) => {
  * - Call the getAllStatus handler to get every existing status in our database
  * - Upon finishing the query, we then call the API for the current rotation data
  * - If there are no existing statuses, we don't do anything
- * - If there are, we then get all relevant webhooks of the guild for each status
- * - We then delete the old rotation message and then send a new message with updated data
- * - Finally we update our database of the current change in status
+ * - If there are, we then edit the relevant status messages
  *
- * RED ALERT
- * Currently for one guild cycle, this takes at least 6 seconds to finish with both arenas + br status active
- * This is because of our usage with awaits on getting webhooks, deleting and creating messages
- * This is not good cuz we'll find ourselves back to where we started pre-webhooks where it'll take forever for all guilds to get their status updated
- * Fortunately we can do away with fetching webhooks by storing tokens and opting for non-blocking deleting
- * However the big issue here is the creation of new rotation messages. We have to wait for those to finish so we know the message id to delete next cycle
- * There's gotta be a solution out there. Right now the best one I can think of is scrapping deleting and just sending the new message
- * This will definitely be the best case scenario time-wise as we don't care about storing data in expense of UX
- * Oh well, looks like there's one final boss to slay smh
+ * Opted to use edits now to lessen runtime of each status cyle through guilds
+ * Initially wanted to just edit without waiting for the response for peak speed
+ * But realised we at least want to do error handling if it does fail
+ * This definitely affects runtime quite a bit but does make our cycles more stable
+ * Might have to revisit this in the near future when we're supporting a lot of guilds
+ * More detailed explanation here: https://shizuka.notion.site/Spike-on-Status-Time-Taken-0c26284152f04a169c546fe7b582a658
  */
 const scheduleStatus = (nessie) => {
   return new Scheduler(

--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -297,6 +297,11 @@ const createStatus = async ({ interaction, nessie }) => {
     const rotationData = await getRotationData();
     const statusBattleRoyaleEmbed = generateBattleRoyaleStatusEmbeds(rotationData);
     const statusArenasEmbed = generateArenasStatusEmbeds(rotationData);
+    /**
+     * Gets the @everyone role of the guild
+     * Important so w can't prevent non-admin users from sending any messages in status channels
+     */
+    const everyoneRole = interaction.guild.roles.cache.find((role) => role.name === '@everyone');
 
     const statusCategory = await interaction.guild.channels.create('Apex Legends Map Status', {
       type: 'GUILD_CATEGORY',
@@ -306,12 +311,24 @@ const createStatus = async ({ interaction, nessie }) => {
       (await interaction.guild.channels.create('apex-battle-royale', {
         parent: statusCategory,
         type: 'GUILD_TEXT',
+        permissionOverwrites: [
+          {
+            id: everyoneRole.id,
+            deny: ['SEND_MESSAGES'],
+          },
+        ],
       }));
     const statusArenasChannel =
       isArenasSelected &&
       (await interaction.guild.channels.create('apex-arenas', {
         parent: statusCategory,
         type: 'GUILD_TEXT',
+        permissionOverwrites: [
+          {
+            id: everyoneRole.id,
+            deny: ['SEND_MESSAGES'],
+          },
+        ],
       }));
 
     //Since webhooks take way longer to create than channels, adding another loading state here

--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -362,6 +362,8 @@ const createStatus = async ({ interaction, nessie }) => {
       arenasMessageId: statusArenasMessage ? statusArenasMessage.id : null,
       battleRoyaleWebhookId: statusBattleRoyaleWebhook ? statusBattleRoyaleWebhook.id : null,
       arenasWebhookId: statusArenasWebhook ? statusArenasWebhook.id : null,
+      battleRoyaleWebhookToken: statusBattleRoyaleWebhook ? statusBattleRoyaleWebhook.token : null,
+      arenasWebhookToken: statusArenasWebhook ? statusArenasWebhook.token : null,
       originalChannelId: interaction.channelId,
       gameModeSelected:
         isBattleRoyaleSelected && isArenasSelected
@@ -432,7 +434,7 @@ const createStatus = async ({ interaction, nessie }) => {
  */
 const scheduleStatus = (nessie) => {
   return new Scheduler(
-    '10 */15 * * * *',
+    '10 15 * * * *',
     async () => {
       getAllStatus(async (allStatus, client) => {
         try {

--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -137,7 +137,7 @@ const generateBattleRoyaleStatusEmbeds = (data) => {
   const battleRoyaleRankedEmbed = generateRankedEmbed(data.ranked);
   const informationEmbed = {
     description:
-      '**Updates occur every 15 minutes**. This is a temporary feature while a more refined solution is being worked on to get automatic map updates directly in your servers. For feedback, bug reports or news update, feel free visit the [support server](https://discord.gg/FyxVrAbRAd)!',
+      '**Updates occur every 15 minutes**. This feature is currently in beta! For feedback, bug reports or news updates, feel free to visit the [support server](https://discord.gg/FyxVrAbRAd)!',
     color: 3447003,
     timestamp: Date.now(),
     footer: {
@@ -156,7 +156,7 @@ const generateArenasStatusEmbeds = (data) => {
   const arenasRankedEmbed = generateRankedEmbed(data.arenasRanked, 'Arenas');
   const informationEmbed = {
     description:
-      '**Updates occur every 15 minutes**. This is a temporary feature while a more refined solution is being worked on to get automatic map updates directly in your servers. For feedback, bug reports or news update, feel free visit the [support server](https://discord.gg/FyxVrAbRAd)!',
+      '**Updates occur every 15 minutes**. This feature is currently in beta! For feedback, bug reports or news updates, feel free to visit the [support server](https://discord.gg/FyxVrAbRAd)!',
     color: 3447003,
     timestamp: Date.now(),
     footer: {

--- a/database/handler.js
+++ b/database/handler.js
@@ -123,7 +123,7 @@ exports.createStatusTable = () => {
   this.pool.connect((err, client, done) => {
     client.query('BEGIN', (err) => {
       client.query(
-        'CREATE TABLE IF NOT EXISTS Status(uuid TEXT NOT NULL PRIMARY KEY, guild_id TEXT NOT NULL, category_channel_id TEXT, br_channel_id TEXT, arenas_channel_id TEXT, br_message_id TEXT, arenas_message_id TEXT, br_webhook_id TEXT, arenas_webhook_id TEXT, original_channel_id TEXT NOT NULL, game_mode_selected TEXT NOT NULL, created_by TEXT NOT NULL, created_at TEXT NOT NULL)'
+        'CREATE TABLE IF NOT EXISTS Status(uuid TEXT NOT NULL PRIMARY KEY, guild_id TEXT NOT NULL, category_channel_id TEXT, br_channel_id TEXT, arenas_channel_id TEXT, br_message_id TEXT, arenas_message_id TEXT, br_webhook_id TEXT, arenas_webhook_id TEXT, br_webhook_token TEXT, arenas_webhook_token TEXT, original_channel_id TEXT NOT NULL, game_mode_selected TEXT NOT NULL, created_by TEXT NOT NULL, created_at TEXT NOT NULL)'
       );
       client.query('COMMIT', (err) => {
         done();
@@ -143,7 +143,7 @@ exports.insertNewStatus = async (status, onSuccess, onError) => {
   this.pool.connect((err, client, done) => {
     client.query('BEGIN', (err) => {
       client.query(
-        'INSERT INTO Status (uuid, guild_id, category_channel_id, br_channel_id, arenas_channel_id, br_message_id, arenas_message_id, br_webhook_id, arenas_webhook_id, original_channel_id, game_mode_selected, created_by, created_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13)',
+        'INSERT INTO Status (uuid, guild_id, category_channel_id, br_channel_id, arenas_channel_id, br_message_id, arenas_message_id, br_webhook_id, arenas_webhook_id, br_webhook_token, arenas_webhook_token, original_channel_id, game_mode_selected, created_by, created_at) VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11, $12, $13, $14, $15)',
         [
           status.uuid,
           status.guildId,
@@ -154,6 +154,8 @@ exports.insertNewStatus = async (status, onSuccess, onError) => {
           status.arenasMessageId,
           status.battleRoyaleWebhookId,
           status.arenasWebhookId,
+          status.battleRoyaleWebhookToken,
+          status.arenasWebhookToken,
           status.originalChannelId,
           status.gameModeSelected,
           status.createdBy,


### PR DESCRIPTION
#### Context
Continuing from #94, this pr revamps the status flow to mainly use edits instead of deleting old messages and creating new ones. Was initially going to just send edits with no care of responses as this is peak runtime. But I don't think it'll be a good idea to forgo proper error handling in the off chance something goes wrong in a cycle. This does unfortunately mean we're going to sacrifice some time to wait for responses to finish but I think this is fine for stability. It'll be a good learning experience eventually when we revisit optimising our processes

<img width="510" alt="image" src="https://user-images.githubusercontent.com/42207245/179038850-a8e98821-8973-4a45-af63-0e1aa09d5a64.png">

#### Change
- Add token to status table
- Edit status message instead of deleting and creating
- Update information embed for status message
- Create status channels with permission overrides