### PR TITLE
Add wrong user ephemeral handler

### DIFF
--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -214,6 +214,7 @@ const goToConfirmStatus = async ({ interaction, nessie }) => {
   const { embed, row } = generateConfirmStatusMessage({ interaction });
   try {
     await interaction.deferUpdate();
+
     await interaction.message.edit({ embeds: [embed], components: [row] });
   } catch (error) {
     const uuid = uuidv4();

--- a/events.js
+++ b/events.js
@@ -13,6 +13,7 @@ const {
   sendGuildUpdateNotification,
   checkIfInDevelopment,
   sendErrorLog,
+  codeBlock,
 } = require('./helpers');
 const { REST } = require('@discordjs/rest');
 const { Routes } = require('discord-api-types/v9');
@@ -29,7 +30,6 @@ const {
   cancelStatusStop,
   createStatusChannels,
   deleteStatusChannels,
-  initialiseStatusScheduler,
   restartStatus,
   cancelStatusRestart,
 } = require('./commands/admin/announcement');
@@ -144,6 +144,16 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
      * Will still have to check the customId for each of the buttons here though
      */
     if (interaction.isButton()) {
+      if (interaction.user.id !== interaction.message.interaction.user.id) {
+        const wrongUserEmbed = {
+          description: `Oops looks like that interaction wasn't meant for you! Nessie can only properly interact with your own commands.\n\nTo check what Nessie can do, type ${codeBlock(
+            '/help'
+          )}!`,
+          color: 16711680,
+        };
+        await interaction.deferReply({ ephemeral: true });
+        return interaction.editReply({ embeds: [wrongUserEmbed] });
+      }
       switch (interaction.customId) {
         case 'announcementStart__startButton':
           return createStatusChannels({ interaction, nessie });
@@ -178,6 +188,16 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
       }
     }
     if (interaction.isSelectMenu()) {
+      if (interaction.user.id !== interaction.message.interaction.user.id) {
+        const wrongUserEmbed = {
+          description: `Oops looks like that interaction wasn't meant for you! Nessie can only properly interact with your own commands.\n\nTo check what Nessie can do, type ${codeBlock(
+            '/help'
+          )}!`,
+          color: 16711680,
+        };
+        await interaction.deferReply({ ephemeral: true });
+        return interaction.editReply({ embeds: [wrongUserEmbed] });
+      }
       switch (interaction.customId) {
         case 'statusStart__gameModeDropdown':
           return goToConfirmStatus({ interaction, nessie });

--- a/events.js
+++ b/events.js
@@ -144,6 +144,11 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
      * Will still have to check the customId for each of the buttons here though
      */
     if (interaction.isButton()) {
+      /**
+       * Fancy handling of when the wrong user tries to use someone else's interactions
+       * Fortunately discord has the original interaction attached to the current one's payload which makes this straightforward
+       * We'll send the wrong user an ephemeral reply indicating that they can only use their own commands
+       */
       if (interaction.user.id !== interaction.message.interaction.user.id) {
         const wrongUserEmbed = {
           description: `Oops looks like that interaction wasn't meant for you! Nessie can only properly interact with your own commands.\n\nTo check what Nessie can do, type ${codeBlock(


### PR DESCRIPTION
#### Design
https://www.figma.com/file/Zw83AgLQpObLpPlSoeEWjq/Automatic-Status-Prototype?node-id=151%3A10320

#### Context
Small fancy change to send an ephemeral reply whenever a different user tries to use someone else's interactions

![image](https://user-images.githubusercontent.com/42207245/179062710-a2485713-deb4-4063-9c32-7e7c7f866cb5.png)

#### Change
- Send ephemeral reply if wrong user interaction