### PR TITLE
Error handling for status cycle errors

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -399,6 +399,38 @@ const sendMissingAllPermissionsError = async ({ interaction, title }) => {
   };
   return await interaction.editReply({ embeds: [embed], components: [] });
 };
+const sendStatusErrorLog = async ({ nessie, uuid, error, status }) => {
+  const errorChannel = nessie.channels.cache.get('938441853542465548');
+  const errorGuild = nessie.guilds.cache.get(status.guild_id);
+  const errorEmbed = {
+    title: 'Error | Status Scheduler Cycle',
+    color: 16711680,
+    description: `uuid: ${uuid}\nError: ${codeBlock(error.message)}`,
+    fields: [
+      {
+        name: 'Status ID',
+        value: status.uuid,
+      },
+      {
+        name: 'Guild',
+        value: errorGuild ? errorGuild.name : '-',
+      },
+      {
+        name: 'Created By',
+        value: status.created_by,
+      },
+      {
+        name: 'Game Modes',
+        value: status.game_mode_selected,
+      },
+      {
+        name: 'Timestamp',
+        value: format(new Date(), 'dd MMM yyyy, h:mm:ss a'),
+      },
+    ],
+  };
+  await errorChannel.send({ embeds: [errorEmbed], content: '<@183444648360935424>' });
+};
 //---------
 module.exports = {
   checkIfInDevelopment,
@@ -418,4 +450,5 @@ module.exports = {
   sendMissingBotPermissionsError,
   sendOnlyAdminError,
   sendMissingAllPermissionsError,
+  sendStatusErrorLog,
 };


### PR DESCRIPTION
#### Context
Special handling for errors that happen during status update cycles. Specifically when Nessie is unable to find the message, channels or webhooks associated to the guild status. This is most likely due to users deleting these in their guilds.  

I don't really want to listen for channel/message deletes as that would mean more database queries hence more monetary expenses. The next best thing is we'll handle it during the 15 minute cycles and I've opted to just delete the whole status of the guild whenever Nessie throws this error and then notify the guild in the original channel it was initially set that the status was stopped and explains why they shouldn't manually delete these important objects

![image](https://user-images.githubusercontent.com/42207245/179293183-b5a633ea-d0c2-47fb-be3b-90669ae73bf8.png)
<img width="489" alt="image" src="https://user-images.githubusercontent.com/42207245/179293213-febe6453-9add-4084-9620-6f6bf38159e2.png">
<img width="324" alt="image" src="https://user-images.githubusercontent.com/42207245/179293275-01792e33-a965-4e66-80ee-b64de501521b.png">
<img width="313" alt="image" src="https://user-images.githubusercontent.com/42207245/179293315-07c1cd28-bd1d-4228-8fd3-0b4cbfacdae4.png">

#### Change
- Send error log when a status update fails
- Delete status if nessie fails to find status webhook or message
- Show error embed instead of rotation data if API fails