### PR TITLE
Add logging for status

### DIFF
--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -419,6 +419,7 @@ const createStatus = async ({ interaction, nessie }) => {
           : null;
 
         await interaction.message.edit({ embeds: [embedSuccess], components: [] });
+        //Sends status creation log after everything is done
         const statusLogChannel = nessie.channels.cache.get('976863441526595644');
         const statusLogEmbed = {
           title: 'New Status Created',
@@ -580,6 +581,11 @@ const handleStatusCycle = async ({
         embeds: arenasStatusEmbeds,
       });
     }
+    /**
+     * Logs health of status after the last guild gets done
+     * This is placed here instead of finally as somehow the latter gets fired even before the loop ends
+     * Added time fields so we can monitor how long a cycle finishes
+     */
     if (index === totalCount - 1) {
       const endTime = Date.now();
       const statusLogChannel = nessie.channels.cache.get('976863441526595644');

--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -419,6 +419,27 @@ const createStatus = async ({ interaction, nessie }) => {
           : null;
 
         await interaction.message.edit({ embeds: [embedSuccess], components: [] });
+        const statusLogChannel = nessie.channels.cache.get('976863441526595644');
+        const statusLogEmbed = {
+          title: 'New Status Created',
+          color: 3066993,
+          fields: [
+            {
+              name: 'Guild',
+              value: interaction.guild.name,
+            },
+            {
+              name: 'Game Modes',
+              value:
+                isBattleRoyaleSelected && isArenasSelected
+                  ? 'All'
+                  : isBattleRoyaleSelected
+                  ? 'Battle Royale'
+                  : 'Arenas',
+            },
+          ],
+        };
+        await statusLogChannel.send({ embeds: [statusLogEmbed] });
       },
       async (error) => {
         const uuid = uuidv4();

--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -15,7 +15,7 @@ const {
 } = require('../../../../helpers');
 const { getRotationData } = require('../../../../adapters');
 const { nessieLogo } = require('../../../../constants');
-const { format } = require('date-fns');
+const { format, differenceInSeconds, differenceInMilliseconds } = require('date-fns');
 const {
   insertNewStatus,
   getStatus,
@@ -454,16 +454,25 @@ const createStatus = async ({ interaction, nessie }) => {
  */
 const scheduleStatus = (nessie) => {
   return new Scheduler(
-    '10 */15 * * * *',
+    '5 */15 * * * *',
     async () => {
       getAllStatus(async (allStatus, client) => {
+        const startTime = Date.now();
         try {
           if (allStatus) {
             const rotationData = await getRotationData();
             const brStatusEmbeds = generateBattleRoyaleStatusEmbeds(rotationData);
             const arenasStatusEmbeds = generateArenasStatusEmbeds(rotationData);
-            allStatus.forEach(async (status) => {
-              await handleStatusCycle({ nessie, status, brStatusEmbeds, arenasStatusEmbeds });
+            allStatus.forEach(async (status, index) => {
+              await handleStatusCycle({
+                nessie,
+                status,
+                index,
+                startTime,
+                totalCount: allStatus.length,
+                brStatusEmbeds,
+                arenasStatusEmbeds,
+              });
             });
           }
         } catch (error) {
@@ -518,7 +527,15 @@ const scheduleStatus = (nessie) => {
  * But I felt like that might just open more possibilities of the user to make an error
  * Finally opted to just delete the status entirely if these errors happen and let the guild know about it
  */
-const handleStatusCycle = async ({ nessie, status, brStatusEmbeds, arenasStatusEmbeds }) => {
+const handleStatusCycle = async ({
+  nessie,
+  status,
+  index,
+  startTime,
+  totalCount,
+  brStatusEmbeds,
+  arenasStatusEmbeds,
+}) => {
   try {
     const brWebhook =
       status.br_webhook_id &&
@@ -541,6 +558,40 @@ const handleStatusCycle = async ({ nessie, status, brStatusEmbeds, arenasStatusE
       await arenasWebhook.editMessage(status.arenas_message_id, {
         embeds: arenasStatusEmbeds,
       });
+    }
+    if (index === totalCount - 1) {
+      const endTime = Date.now();
+      const statusLogChannel = nessie.channels.cache.get('976863441526595644');
+      const statusLogEmbed = {
+        title: 'Nessie | Auto Map Status Log',
+        description: 'Successfully finished status cycle',
+        color: 3066993,
+        fields: [
+          {
+            name: 'Status Count',
+            value: codeBlock(totalCount),
+            inline: true,
+          },
+          {
+            name: 'Start Time',
+            value: codeBlock(format(startTime, 'dd MMM yyyy, h:mm:ss a')),
+          },
+          {
+            name: 'End Time',
+            value: codeBlock(format(endTime, 'dd MMM yyyy, h:mm:ss a')),
+          },
+          {
+            name: 'Time Taken',
+            value: codeBlock(
+              `${differenceInSeconds(endTime, startTime)} seconds | ${differenceInMilliseconds(
+                endTime,
+                startTime
+              )} milliseconds`
+            ),
+          },
+        ],
+      };
+      await statusLogChannel.send({ embeds: [statusLogEmbed] });
     }
   } catch (error) {
     const uuid = uuidv4();

--- a/commands/maps/status/stop/index.js
+++ b/commands/maps/status/stop/index.js
@@ -133,6 +133,18 @@ const deleteGuildStatus = async ({ interaction, nessie }) => {
             color: 3066993,
           };
           await interaction.message.edit({ embeds: [embedSuccess], components: [] });
+          const statusLogChannel = nessie.channels.cache.get('976863441526595644');
+          const statusLogEmbed = {
+            title: 'Status Deleted',
+            color: 16711680,
+            fields: [
+              {
+                name: 'Guild',
+                value: interaction.guild.name,
+              },
+            ],
+          };
+          await statusLogChannel.send({ embeds: [statusLogEmbed] });
         }
       } catch (error) {
         const uuid = uuidv4();

--- a/commands/maps/status/stop/index.js
+++ b/commands/maps/status/stop/index.js
@@ -133,6 +133,7 @@ const deleteGuildStatus = async ({ interaction, nessie }) => {
             color: 3066993,
           };
           await interaction.message.edit({ embeds: [embedSuccess], components: [] });
+          //Sends status deletion log after everything is done
           const statusLogChannel = nessie.channels.cache.get('976863441526595644');
           const statusLogEmbed = {
             title: 'Status Deleted',


### PR DESCRIPTION
#### Context
Logging for when a status cycle finishes, a new status is created and a status gets deleted. Useful so we can monitor if there's adoption and also the time taken for a cycle to finish

![image](https://user-images.githubusercontent.com/42207245/179305240-b91ad72c-bc79-4653-a3eb-cae640201c70.png)
![image](https://user-images.githubusercontent.com/42207245/179305257-9a801ca7-ade2-41a9-9e3b-1f73c968627a.png)
![image](https://user-images.githubusercontent.com/42207245/179305264-b462867f-0950-4da8-99f6-e3bb7c6aae56.png)

#### Change
- Log status health once a cycle finishes
- Logging for status creation and deletion