### PR TITLE
Add prompt to use status in map commands

### DIFF
--- a/commands/maps/arenas/index.js
+++ b/commands/maps/arenas/index.js
@@ -5,6 +5,7 @@ const {
   generateErrorEmbed,
   generatePubsEmbed,
   generateRankedEmbed,
+  codeBlock,
 } = require('../../../helpers');
 const { v4: uuidv4 } = require('uuid');
 const { sendMixpanelEvent } = require('../../../analytics');
@@ -37,10 +38,16 @@ module.exports = {
         case 'arenas_pubs':
           data = await getArenasPubs();
           embed = generatePubsEmbed(data, 'Arenas');
+          embed.description = `Try out my new feature to get automatic map updates! More details on ${codeBlock(
+            '/status help'
+          )}`;
           break;
         case 'arenas_ranked':
           data = await getArenasRanked();
           embed = generateRankedEmbed(data, 'Arenas');
+          embed.description = `Try out my new feature to get automatic map updates! More details on ${codeBlock(
+            '/status help'
+          )}`;
           break;
       }
       await interaction.editReply({ embeds: [embed] });

--- a/commands/maps/arenas/index.js
+++ b/commands/maps/arenas/index.js
@@ -30,6 +30,13 @@ module.exports = {
    * which is editing the reply with the relevant information after the promise resolves
    **/
   async execute({ nessie, interaction, mixpanel }) {
+    /**
+     * Temporary database query to check if there's an existing status in the guild
+     * This is so we can conditionally show the status prompt to lessen visual clutter
+     * One could argue this isn't necessary; especially when we're only going to have the prompt till end of August
+     * I don't really have any counter arguments lmao but I'm keeping it in
+     * TODO: Remove this after Aug 31 2022
+     */
     await getStatus(
       interaction.guildId,
       async (status) => {

--- a/commands/maps/battleRoyale/index.js
+++ b/commands/maps/battleRoyale/index.js
@@ -30,6 +30,13 @@ module.exports = {
    * which is editing the reply with the relevant information after the promise resolves
    **/
   async execute({ nessie, interaction, mixpanel }) {
+    /**
+     * Temporary database query to check if there's an existing status in the guild
+     * This is so we can conditionally show the status prompt to lessen visual clutter
+     * One could argue this isn't necessary; especially when we're only going to have the prompt till end of August
+     * I don't really have any counter arguments lmao but I'm keeping it in
+     * TODO: Remove this after Aug 31 2022
+     */
     await getStatus(
       interaction.guildId,
       async (status) => {

--- a/commands/maps/battleRoyale/index.js
+++ b/commands/maps/battleRoyale/index.js
@@ -5,6 +5,7 @@ const {
   generateErrorEmbed,
   generateRankedEmbed,
   generatePubsEmbed,
+  codeBlock,
 } = require('../../../helpers');
 const { v4: uuidv4 } = require('uuid');
 const { sendMixpanelEvent } = require('../../../analytics');
@@ -37,10 +38,16 @@ module.exports = {
         case 'br_pubs':
           data = await getBattleRoyalePubs();
           embed = generatePubsEmbed(data);
+          embed.description = `Try out my new feature to get automatic map updates! More details on ${codeBlock(
+            '/status help'
+          )}`;
           break;
         case 'br_ranked':
           data = await getBattleRoyaleRanked();
           embed = generateRankedEmbed(data);
+          embed.description = `Try out my new feature to get automatic map updates! More details on ${codeBlock(
+            '/status help'
+          )}`;
           break;
       }
       await interaction.editReply({ embeds: [embed] });

--- a/commands/maps/battleRoyale/index.js
+++ b/commands/maps/battleRoyale/index.js
@@ -9,6 +9,7 @@ const {
 } = require('../../../helpers');
 const { v4: uuidv4 } = require('uuid');
 const { sendMixpanelEvent } = require('../../../analytics');
+const { getStatus } = require('../../../database/handler');
 
 module.exports = {
   data: new SlashCommandBuilder()
@@ -29,43 +30,59 @@ module.exports = {
    * which is editing the reply with the relevant information after the promise resolves
    **/
   async execute({ nessie, interaction, mixpanel }) {
-    let data;
-    let embed;
-    try {
-      await interaction.deferReply();
-      const optionMode = interaction.options.getString('mode');
-      switch (optionMode) {
-        case 'br_pubs':
-          data = await getBattleRoyalePubs();
-          embed = generatePubsEmbed(data);
-          embed.description = `Try out my new feature to get automatic map updates! More details on ${codeBlock(
-            '/status help'
-          )}`;
-          break;
-        case 'br_ranked':
-          data = await getBattleRoyaleRanked();
-          embed = generateRankedEmbed(data);
-          embed.description = `Try out my new feature to get automatic map updates! More details on ${codeBlock(
-            '/status help'
-          )}`;
-          break;
+    await getStatus(
+      interaction.guildId,
+      async (status) => {
+        let data;
+        let embed;
+        try {
+          await interaction.deferReply();
+          const optionMode = interaction.options.getString('mode');
+          switch (optionMode) {
+            case 'br_pubs':
+              data = await getBattleRoyalePubs();
+              embed = generatePubsEmbed(data);
+              if (!status) {
+                embed.description = `Try out my new feature to get automatic map updates! More details on ${codeBlock(
+                  '/status help'
+                )}`;
+              }
+              break;
+            case 'br_ranked':
+              data = await getBattleRoyaleRanked();
+              embed = generateRankedEmbed(data);
+              if (!status) {
+                embed.description = `Try out my new feature to get automatic map updates! More details on ${codeBlock(
+                  '/status help'
+                )}`;
+              }
+              break;
+          }
+          await interaction.editReply({ embeds: [embed] });
+          sendMixpanelEvent(
+            interaction.user,
+            interaction.channel,
+            interaction.guild,
+            'br',
+            mixpanel,
+            optionMode,
+            true
+          );
+        } catch (error) {
+          const uuid = uuidv4();
+          const type = 'Battle Royale';
+          const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
+          await interaction.editReply({ embeds: errorEmbed });
+          await sendErrorLog({ nessie, error, interaction, type, uuid });
+        }
+      },
+      async (error) => {
+        const uuid = uuidv4();
+        const type = 'Getting Status in Database (Battle Royale)';
+        const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
+        interaction.editReply({ embeds: errorEmbed });
+        await sendErrorLog({ nessie, error, interaction, type, uuid });
       }
-      await interaction.editReply({ embeds: [embed] });
-      sendMixpanelEvent(
-        interaction.user,
-        interaction.channel,
-        interaction.guild,
-        'br',
-        mixpanel,
-        optionMode,
-        true
-      );
-    } catch (error) {
-      const uuid = uuidv4();
-      const type = 'Battle Royale';
-      const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
-      await interaction.editReply({ embeds: errorEmbed });
-      await sendErrorLog({ nessie, error, interaction, type, uuid });
-    }
+    );
   },
 };

--- a/helpers.js
+++ b/helpers.js
@@ -227,6 +227,42 @@ const sendErrorLog = async ({ nessie, error, message, interaction, type, uuid, p
     ? await errorChannel.send({ embeds: [embed], content: '<@183444648360935424>' })
     : await errorChannel.send({ embeds: [embed] });
 };
+/**
+ * Handler for errors concerning status cycles
+ * Same as above, only difference is the embed content
+ */
+const sendStatusErrorLog = async ({ nessie, uuid, error, status }) => {
+  const errorChannel = nessie.channels.cache.get('938441853542465548');
+  const errorGuild = nessie.guilds.cache.get(status.guild_id);
+  const errorEmbed = {
+    title: 'Error | Status Scheduler Cycle',
+    color: 16711680,
+    description: `uuid: ${uuid}\nError: ${codeBlock(error.message)}`,
+    fields: [
+      {
+        name: 'Status ID',
+        value: status.uuid,
+      },
+      {
+        name: 'Guild',
+        value: errorGuild ? errorGuild.name : '-',
+      },
+      {
+        name: 'Created By',
+        value: status.created_by,
+      },
+      {
+        name: 'Game Modes',
+        value: status.game_mode_selected,
+      },
+      {
+        name: 'Timestamp',
+        value: format(new Date(), 'dd MMM yyyy, h:mm:ss a'),
+      },
+    ],
+  };
+  await errorChannel.send({ embeds: [errorEmbed], content: '<@183444648360935424>' });
+};
 const generateAnnouncementMessage = (prefix) => {
   return (
     '```diff\n' +
@@ -398,38 +434,6 @@ const sendMissingAllPermissionsError = async ({ interaction, title }) => {
     color: 16711680,
   };
   return await interaction.editReply({ embeds: [embed], components: [] });
-};
-const sendStatusErrorLog = async ({ nessie, uuid, error, status }) => {
-  const errorChannel = nessie.channels.cache.get('938441853542465548');
-  const errorGuild = nessie.guilds.cache.get(status.guild_id);
-  const errorEmbed = {
-    title: 'Error | Status Scheduler Cycle',
-    color: 16711680,
-    description: `uuid: ${uuid}\nError: ${codeBlock(error.message)}`,
-    fields: [
-      {
-        name: 'Status ID',
-        value: status.uuid,
-      },
-      {
-        name: 'Guild',
-        value: errorGuild ? errorGuild.name : '-',
-      },
-      {
-        name: 'Created By',
-        value: status.created_by,
-      },
-      {
-        name: 'Game Modes',
-        value: status.game_mode_selected,
-      },
-      {
-        name: 'Timestamp',
-        value: format(new Date(), 'dd MMM yyyy, h:mm:ss a'),
-      },
-    ],
-  };
-  await errorChannel.send({ embeds: [errorEmbed], content: '<@183444648360935424>' });
 };
 //---------
 module.exports = {


### PR DESCRIPTION
#### Context
With the release of status just around the corner, we should at least try to set it up for success. Adoption is our main priority and letting people know about the new feature is our first step. This pr at least tries to do that without being overly pushy. We'll only show the prompts in map commands if there's no existing status in the guild

<img width="438" alt="image" src="https://user-images.githubusercontent.com/42207245/179312287-6cf54ab6-3204-46b3-88ba-c71f1584a739.png">
<img width="441" alt="image" src="https://user-images.githubusercontent.com/42207245/179312255-88cc5250-3727-4fdf-bfb8-adb32596d583.png">

#### Change
- Show status prompt for br and arenas commands
- Only show prompt if no existing status