### PR TITLE
Add mixpanel tracking to status

### DIFF
--- a/analytics.js
+++ b/analytics.js
@@ -12,10 +12,9 @@ const sendMixpanelEvent = ({
   client,
   arguments,
   isApplicationCommand,
+  customEventName,
 }) => {
-  const eventToSend = !subcommand
-    ? `Use ${command} command`
-    : `Use ${command} ${subcommand} command`; //Name of event; string interpolated with command as best to write an event as an action a user is doing
+  const eventName = !subcommand ? `Use ${command} command` : `Use ${command} ${subcommand} command`; //Name of event; string interpolated with command as best to write an event as an action a user is doing
   /**
    * Creates and updates a user profile
    * Sets properties everytime event is called and overrides if they're different
@@ -33,7 +32,7 @@ const sendMixpanelEvent = ({
      * Added relevant properties along with event such as user, channel and guild
      * Important to always send `distinct_id` as mixpanel-nodejs uses this as its unique identifier
      */
-    client.track(eventToSend, {
+    client.track(customEventName ? customEventName : eventName, {
       distinct_id: user.id,
       user: user.tag,
       user_name: user.username,

--- a/analytics.js
+++ b/analytics.js
@@ -13,6 +13,7 @@ const sendMixpanelEvent = ({
   arguments,
   isApplicationCommand,
   customEventName,
+  properties,
 }) => {
   const eventName = !subcommand ? `Use ${command} command` : `Use ${command} ${subcommand} command`; //Name of event; string interpolated with command as best to write an event as an action a user is doing
   /**
@@ -44,6 +45,7 @@ const sendMixpanelEvent = ({
       subcommand: subcommand ? subcommand : 'none',
       arguments: arguments ? arguments : 'none',
       isApplicationCommand: isApplicationCommand, //undefined if command is a prefix command
+      ...properties,
     });
     /**
      * Sets a user profile properties only once

--- a/analytics.js
+++ b/analytics.js
@@ -3,16 +3,19 @@
  * Learning from past mistakes so adding this pre-launch
  * For reference: https://developer.mixpanel.com/docs/nodejs
  */
-const sendMixpanelEvent = (
+const sendMixpanelEvent = ({
   user,
   channel,
   guild,
   command,
+  subcommand,
   client,
   arguments,
-  isApplicationCommand
-) => {
-  const eventToSend = `Use ${command} command`; //Name of event; string interpolated with command as best to write an event as an action a user is doing
+  isApplicationCommand,
+}) => {
+  const eventToSend = !subcommand
+    ? `Use ${command} command`
+    : `Use ${command} ${subcommand} command`; //Name of event; string interpolated with command as best to write an event as an action a user is doing
   /**
    * Creates and updates a user profile
    * Sets properties everytime event is called and overrides if they're different
@@ -39,6 +42,7 @@ const sendMixpanelEvent = (
       guild: guild.name,
       guild_id: guild.id,
       command: command,
+      subcommand: subcommand ? subcommand : 'none',
       arguments: arguments ? arguments : 'none',
       isApplicationCommand: isApplicationCommand, //undefined if command is a prefix command
     });

--- a/commands/maps/arenas/index.js
+++ b/commands/maps/arenas/index.js
@@ -66,15 +66,6 @@ module.exports = {
               break;
           }
           await interaction.editReply({ embeds: [embed] });
-          sendMixpanelEvent(
-            interaction.user,
-            interaction.channel,
-            interaction.guild,
-            'arenas',
-            mixpanel,
-            optionMode,
-            true
-          );
         } catch (error) {
           const uuid = uuidv4();
           const type = 'Arenas';

--- a/commands/maps/battleRoyale/index.js
+++ b/commands/maps/battleRoyale/index.js
@@ -66,15 +66,6 @@ module.exports = {
               break;
           }
           await interaction.editReply({ embeds: [embed] });
-          sendMixpanelEvent(
-            interaction.user,
-            interaction.channel,
-            interaction.guild,
-            'br',
-            mixpanel,
-            optionMode,
-            true
-          );
         } catch (error) {
           const uuid = uuidv4();
           const type = 'Battle Royale';

--- a/commands/maps/control/index.js
+++ b/commands/maps/control/index.js
@@ -28,15 +28,6 @@ module.exports = {
           break;
       }
       await interaction.editReply({ embeds: [embed] });
-      sendMixpanelEvent(
-        interaction.user,
-        interaction.channel,
-        interaction.guild,
-        'control',
-        mixpanel,
-        optionMode,
-        true
-      );
     } catch (error) {
       /**
        * Special error handling here instead of using the error helper

--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -313,6 +313,12 @@ const _cancelStatusStart = async ({ interaction, nessie, mixpanel }) => {
 const createStatus = async ({ interaction, nessie, mixpanel }) => {
   const isBattleRoyaleSelected = interaction.customId.includes('battle_royale');
   const isArenasSelected = interaction.customId.includes('arenas');
+  const gameModeSelected =
+    isBattleRoyaleSelected && isArenasSelected
+      ? 'All'
+      : isBattleRoyaleSelected
+      ? 'Battle Royale'
+      : 'Arenas';
   const embedLoadingChannels = {
     description: `Loading Status Channels...`,
     color: 16776960,
@@ -414,12 +420,7 @@ const createStatus = async ({ interaction, nessie, mixpanel }) => {
       battleRoyaleWebhookToken: statusBattleRoyaleWebhook ? statusBattleRoyaleWebhook.token : null,
       arenasWebhookToken: statusArenasWebhook ? statusArenasWebhook.token : null,
       originalChannelId: interaction.channelId,
-      gameModeSelected:
-        isBattleRoyaleSelected && isArenasSelected
-          ? 'All'
-          : isBattleRoyaleSelected
-          ? 'Battle Royale'
-          : 'Arenas',
+      gameModeSelected,
       createdBy: interaction.user.tag,
       createdAt: format(new Date(), 'dd MMM yyyy, h:mm a'),
     };
@@ -487,6 +488,9 @@ const createStatus = async ({ interaction, nessie, mixpanel }) => {
       guild: interaction.guild,
       client: mixpanel,
       customEventName: 'Click status start confirm button',
+      properties: {
+        game_mode_selected: gameModeSelected,
+      },
     });
   }
 };

--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -218,11 +218,10 @@ const sendStartInteraction = async ({ interaction, nessie }) => {
  * Handler for when a user selects any of the options in the Game Mode dropdown
  * Will edit and show the second step of the status start wizard: Confirm Status
  */
-const goToConfirmStatus = async ({ interaction, nessie }) => {
+const goToConfirmStatus = async ({ interaction, nessie, mixpanel }) => {
   const { embed, row } = generateConfirmStatusMessage({ interaction });
   try {
     await interaction.deferUpdate();
-
     await interaction.message.edit({ embeds: [embed], components: [row] });
   } catch (error) {
     const uuid = uuidv4();
@@ -230,6 +229,14 @@ const goToConfirmStatus = async ({ interaction, nessie }) => {
     const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
     await interaction.editReply({ embeds: errorEmbed, components: [] });
     await sendErrorLog({ nessie, error, interaction, type, uuid });
+  } finally {
+    sendMixpanelEvent({
+      user: interaction.user,
+      channel: interaction.channel,
+      guild: interaction.guild,
+      client: mixpanel,
+      customEventName: 'Click status start gamemode select menu',
+    });
   }
 };
 /**

--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -23,6 +23,7 @@ const {
   deleteStatus,
 } = require('../../../../database/handler');
 const Scheduler = require('../../../../scheduler');
+const { sendMixpanelEvent } = require('../../../../analytics');
 /**
  * Handler for generating the UI for Game Mode Selection Step as well as Confirm Status step below
  * This is separated from the interaction handlers as we want to be able to reuse them when the user goes back and forth through the steps
@@ -235,7 +236,7 @@ const goToConfirmStatus = async ({ interaction, nessie }) => {
  * Handler for when a user clicks the Back button in Confirm Status Step
  * Will edit and show the first step of the status start wizard: Confirm Status
  */
-const goBackToGameModeSelection = async ({ interaction, nessie }) => {
+const goBackToGameModeSelection = async ({ interaction, nessie, mixpanel }) => {
   const { embed, row } = generateGameModeSelectionMessage();
   try {
     await interaction.deferUpdate();
@@ -246,6 +247,14 @@ const goBackToGameModeSelection = async ({ interaction, nessie }) => {
     const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
     await interaction.editReply({ embeds: errorEmbed, components: [] });
     await sendErrorLog({ nessie, error, interaction, type, uuid });
+  } finally {
+    sendMixpanelEvent({
+      user: interaction.user,
+      channel: interaction.channel,
+      guild: interaction.guild,
+      client: mixpanel,
+      customEventName: 'Click status start back button',
+    });
   }
 };
 /**
@@ -254,7 +263,7 @@ const goBackToGameModeSelection = async ({ interaction, nessie }) => {
  * Prepended an underscore as there's a function in announcement with the same name
  * TODO: Clean up the code there eventually
  */
-const _cancelStatusStart = async ({ interaction, nessie }) => {
+const _cancelStatusStart = async ({ interaction, nessie, mixpanel }) => {
   const embed = {
     description: 'Cancelled automatic map status config',
     color: 16711680,
@@ -268,6 +277,14 @@ const _cancelStatusStart = async ({ interaction, nessie }) => {
     const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
     await interaction.editReply({ embeds: errorEmbed, components: [] });
     await sendErrorLog({ nessie, error, interaction, type, uuid });
+  } finally {
+    sendMixpanelEvent({
+      user: interaction.user,
+      channel: interaction.channel,
+      guild: interaction.guild,
+      client: mixpanel,
+      customEventName: 'Click status start cancel button',
+    });
   }
 };
 /**
@@ -286,7 +303,7 @@ const _cancelStatusStart = async ({ interaction, nessie }) => {
  * TODO: Save status data in our database
  * TODO: Maybe separate ui and wiring up to respective files/folders for better readability
  */
-const createStatus = async ({ interaction, nessie }) => {
+const createStatus = async ({ interaction, nessie, mixpanel }) => {
   const isBattleRoyaleSelected = interaction.customId.includes('battle_royale');
   const isArenasSelected = interaction.customId.includes('arenas');
   const embedLoadingChannels = {
@@ -456,6 +473,14 @@ const createStatus = async ({ interaction, nessie }) => {
     const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
     await interaction.editReply({ embeds: errorEmbed, components: [] });
     await sendErrorLog({ nessie, error, interaction, type, uuid });
+  } finally {
+    sendMixpanelEvent({
+      user: interaction.user,
+      channel: interaction.channel,
+      guild: interaction.guild,
+      client: mixpanel,
+      customEventName: 'Click status start confirm button',
+    });
   }
 };
 /**

--- a/events.js
+++ b/events.js
@@ -108,8 +108,6 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
     if (!interaction.inGuild()) return; //Only respond in server channels or if it's an actual command
 
     if (interaction.isCommand()) {
-      console.log(interaction.options);
-      console.log(interaction.options.data);
       const { commandName, options } = interaction;
       const usedOption = options.data[0];
       const isArgument = usedOption && usedOption.type === 'STRING';
@@ -153,6 +151,14 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
           color: 16711680,
         };
         await interaction.deferReply({ ephemeral: true });
+        sendMixpanelEvent({
+          user: interaction.user,
+          channel: interaction.channel,
+          guild: interaction.guild,
+          client: mixpanel,
+          arguments: interaction.customId,
+          customEventName: 'Click Wrong User Button',
+        });
         return interaction.editReply({ embeds: [wrongUserEmbed] });
       }
       switch (interaction.customId) {
@@ -179,6 +185,14 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
           color: 16711680,
         };
         await interaction.deferReply({ ephemeral: true });
+        sendMixpanelEvent({
+          user: interaction.user,
+          channel: interaction.channel,
+          guild: interaction.guild,
+          client: mixpanel,
+          arguments: interaction.customId,
+          customEventName: 'Click Wrong User Select Menu',
+        });
         return interaction.editReply({ embeds: [wrongUserEmbed] });
       }
       switch (interaction.customId) {

--- a/events.js
+++ b/events.js
@@ -115,10 +115,10 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
       await appCommands[commandName].execute({ interaction, nessie, mixpanel });
       /**
        * Send event information to mixpanel for application commands
-       * This is for general commands that do not require arguments
-       * We can't do this here as we can only get the options within the command execution itself
-       * Hence, we have a separate handler for these commands in their own files instead of here
-       * TODO: Refactor conditional in the future, probably a better way to check since this isn't scalable
+       * This is called here so we don't have to repeatadly call them in tn their respective command handlers
+       * The sendMixpanelEvent handler is defaulted to send events as commands/subcommands
+       * For other interactions, we have to call them in their own handlers
+       * TODO: Cleanup analytics code; right now the handler is super smart but sacrifices readability
        */
       sendMixpanelEvent({
         user: interaction.user,

--- a/events.js
+++ b/events.js
@@ -197,7 +197,7 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
       }
       switch (interaction.customId) {
         case 'statusStart__gameModeDropdown':
-          return goToConfirmStatus({ interaction, nessie });
+          return goToConfirmStatus({ interaction, nessie, mixpanel });
       }
     }
   });

--- a/events.js
+++ b/events.js
@@ -157,22 +157,22 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
           guild: interaction.guild,
           client: mixpanel,
           arguments: interaction.customId,
-          customEventName: 'Click Wrong User Button',
+          customEventName: 'Click wrong user button',
         });
         return interaction.editReply({ embeds: [wrongUserEmbed] });
       }
       switch (interaction.customId) {
         case 'statusStart__backButton':
-          return goBackToGameModeSelection({ interaction, nessie });
+          return goBackToGameModeSelection({ interaction, nessie, mixpanel });
         case 'statusStart__cancelButton':
-          return _cancelStatusStart({ interaction, nessie });
+          return _cancelStatusStart({ interaction, nessie, mixpanel });
         case 'statusStop__cancelButton':
-          return _cancelStatusStop({ interaction, nessie });
+          return _cancelStatusStop({ interaction, nessie, mixpanel });
         case 'statusStop__stopButton':
-          return deleteGuildStatus({ interaction, nessie });
+          return deleteGuildStatus({ interaction, nessie, mixpanel });
         default:
           if (interaction.customId.includes('statusStart__confirmButton')) {
-            return createStatus({ interaction, nessie });
+            return createStatus({ interaction, nessie, mixpanel });
           }
       }
     }
@@ -191,7 +191,7 @@ exports.registerEventHandlers = ({ nessie, mixpanel }) => {
           guild: interaction.guild,
           client: mixpanel,
           arguments: interaction.customId,
-          customEventName: 'Click Wrong User Select Menu',
+          customEventName: 'Click wrong user select menu',
         });
         return interaction.editReply({ embeds: [wrongUserEmbed] });
       }

--- a/nessie.js
+++ b/nessie.js
@@ -26,7 +26,9 @@ let mixpanel;
  */
 const initialize = async () => {
   await nessie.login(token);
-  mixpanel = Mixpanel.init(checkIfInDevelopment(nessie) ? lochnessMixpanel : nessieMixpanel); //Checks if client is initialising as the development bot
+  mixpanel = Mixpanel.init(checkIfInDevelopment(nessie) ? lochnessMixpanel : nessieMixpanel, {
+    debug: true,
+  }); //Checks if client is initialising as the development bot
   !checkIfInDevelopment(nessie) && AutoPoster(topggToken, nessie); //Check if this is a one time thing per reboot or it actually auto posts when stats change
   registerEventHandlers({ nessie, mixpanel });
 };

--- a/nessie.js
+++ b/nessie.js
@@ -26,9 +26,7 @@ let mixpanel;
  */
 const initialize = async () => {
   await nessie.login(token);
-  mixpanel = Mixpanel.init(checkIfInDevelopment(nessie) ? lochnessMixpanel : nessieMixpanel, {
-    debug: true,
-  }); //Checks if client is initialising as the development bot
+  mixpanel = Mixpanel.init(checkIfInDevelopment(nessie) ? lochnessMixpanel : nessieMixpanel); //Checks if client is initialising as the development bot
   !checkIfInDevelopment(nessie) && AutoPoster(topggToken, nessie); //Check if this is a one time thing per reboot or it actually auto posts when stats change
   registerEventHandlers({ nessie, mixpanel });
 };


### PR DESCRIPTION
#### Context
Pretty straightforward implementation for tracking the new status events. Though main difference is now we're also tracking elements (buttons, select menus) instead of only commands. Might have to revisit our analytics handler sometime down the future, currently it's smart but sacrifices readability

![image](https://user-images.githubusercontent.com/42207245/179392944-a91fcca6-7c95-46eb-97fd-3ce4c710d53e.png)

#### Change
- Refactor mixpanel handler to support subcommand and arguments
- Pass down customName to event handler
- Add tracking to wrong user interacting with elements
- Add tracking to buttons and select menus