### PR TITLE
Delete status when bot leaves server

### DIFF
--- a/database/handler.js
+++ b/database/handler.js
@@ -102,12 +102,17 @@ exports.removeServerDataFromNessie = (nessie, guild) => {
         if (err) {
           console.log(err);
         }
-        client.query('COMMIT', (err) => {
+        client.query('DELETE FROM Status WHERE guild_id = ($1)', [guild.id.toString()], (err) => {
           if (err) {
             console.log(err);
           }
-          sendGuildUpdateNotification(nessie, guild, 'leave');
-          done();
+          client.query('COMMIT', (err) => {
+            if (err) {
+              console.log(err);
+            }
+            sendGuildUpdateNotification(nessie, guild, 'leave');
+            done();
+          });
         });
       });
     });


### PR DESCRIPTION
#### Context
Previously when Nessie gets removed from a server, we only delete their data from our guild table. Now that we have a new status table, we should also delete those. If not, we'll get errors during the status cycles concerning webhooks and channels to not exist. Technically we can just let this be as we have handling for these types of errors that'll delete the status automatically but best to jsut add this to close the loop

#### Change
- Delete status when bot leaves server