### PR TITLE
Update status copies

### DIFF
--- a/commands/hub/about/index.js
+++ b/commands/hub/about/index.js
@@ -6,7 +6,7 @@ const { version } = require('../../../package.json');
 const sendAboutEmbed = async ({ nessie, interaction }) => {
   const embed = {
     title: 'About',
-    description: `Hi there! I’m Nessie and I provide an easy way to get status updates of Map Rotations in Apex Legends! Hope that you can find me useful (◕ᴗ◕✿)\n\nTry out my cool beta feature: **Automatic Map Updates using News Channels**! To check out what it is, use \`/status\`!\n\nAll my data is extracted from the great works of [https://apexlegendsapi.com/](https://apexlegendsapi.com/). Go support them too, it’s a cool project!\n\nFor the latest news, check out \`/updates\`!`,
+    description: `Hi there! I’m Nessie and I provide an easy way to get status updates of Map Rotations in Apex Legends! Hope that you can find me useful (◕ᴗ◕✿)\n\nTry out my new beta feature: **Automatic Map Updates**! To check out what it is, use \`/status help\`!\n\nAll my data is extracted from the great works of [https://apexlegendsapi.com/](https://apexlegendsapi.com/). Go support them too, it’s a cool project!\n\nFor the latest news, check out \`/updates\`!`,
     color: 3447003,
     thumbnail: {
       url: nessieLogo,

--- a/commands/hub/invite/index.js
+++ b/commands/hub/invite/index.js
@@ -6,7 +6,7 @@ module.exports = {
     .setDescription('Generates an invite link for Nessie'),
   async execute({ interaction }) {
     const embed = {
-      description: `<@${interaction.user.id}> | [Add me to your servers! (◕ᴗ◕✿)](https://discord.com/api/oauth2/authorize?client_id=889135055430111252&permissions=3088&scope=applications.commands%20bot)`,
+      description: `<@${interaction.user.id}> | [Add me to your servers! (◕ᴗ◕✿)](https://discord.com/api/oauth2/authorize?client_id=889135055430111252&permissions=536874000&scope=applications.commands%20bot)`,
       color: 3447003,
     };
     return await interaction.reply({ embeds: [embed] });

--- a/commands/maps/status/help/index.js
+++ b/commands/maps/status/help/index.js
@@ -4,6 +4,7 @@ const {
   sendErrorLog,
   checkMissingBotPermissions,
   checkIfAdminUser,
+  codeBlock,
 } = require('../../../../helpers');
 
 /**
@@ -19,10 +20,18 @@ const sendHelpInteraction = async ({ interaction, nessie }) => {
   const isAdminUser = checkIfAdminUser(interaction);
 
   try {
-    const embedData = {
-      title: 'Status | Help',
-      description:
-        "• Explain the status command does\n• Explain what it'll create; channels, webhooks\n• Explain necessary user permissions; admin\n• Explain bot permissions; whatever nessie needs to operate",
+    const embedInformation = {
+      title: 'Information',
+      description: `This command will send automatic updates of Apex Legends Map Rotations. You will be able to choose which game modes, *Battle Royale or/and Arenas*, to get updates for both pubs and ranked.\n\nDepending on what you choose, Nessie will create a set of:\n• ${codeBlock(
+        'Category Channel'
+      )}\n• ${codeBlock('Text Channel(s)')}\n• ${codeBlock(
+        'Webhook(s)'
+      )}\nUpdates will then be sent in these channels **every 15 minutes**\n\n`,
+      color: 3447003,
+    };
+    const embedPermissions = {
+      title: 'Permissions',
+      description: `Nessie requires certain permissions to properly create automatic updates. See the checklist below for the full list.`,
       fields: [
         {
           name: 'User Permissions',
@@ -42,7 +51,13 @@ const sendHelpInteraction = async ({ interaction, nessie }) => {
       color: 3447003,
     };
 
-    return await interaction.editReply({ embeds: [embedData] });
+    return await interaction.editReply({
+      embeds: [
+        { title: 'Status | Help', description: '', color: 3447003 },
+        embedInformation,
+        embedPermissions,
+      ],
+    });
   } catch (error) {
     const uuid = uuidv4();
     const type = 'Status Help';

--- a/commands/maps/status/help/index.js
+++ b/commands/maps/status/help/index.js
@@ -51,7 +51,11 @@ const sendHelpInteraction = async ({ interaction, nessie }) => {
             hasAdmin || hasSendMessages ? '✅' : '❌'
           } Send Messages\n\n${
             !isAdminUser || hasMissingPermissions
-              ? 'Looks like there are missing permissions. Make sure to add the above permissions to be able to create automatic map updates!'
+              ? `Looks like there are missing permissions. Make sure to add the above permissions to be able to use automatic map updates!${
+                  isAdminUser
+                    ? `\nYou can refresh Nessie's permissions by reinviting using this [link](https://discord.com/api/oauth2/authorize?client_id=889135055430111252&permissions=536874000&scope=applications.commands%20bot)`
+                    : ''
+                }`
               : 'Looks like everything is set, use `/status start` to get started!'
           }`,
         },

--- a/commands/maps/status/help/index.js
+++ b/commands/maps/status/help/index.js
@@ -15,8 +15,14 @@ const {
  * Shows a success/warning at the end if any of the permissions are missing
  */
 const sendHelpInteraction = async ({ interaction, nessie }) => {
-  const { hasAdmin, hasManageChannels, hasManageWebhooks, hasSendMessages, hasMissingPermissions } =
-    checkMissingBotPermissions(interaction);
+  const {
+    hasAdmin,
+    hasManageChannels,
+    hasManageWebhooks,
+    hasViewChannel,
+    hasSendMessages,
+    hasMissingPermissions,
+  } = checkMissingBotPermissions(interaction);
   const isAdminUser = checkIfAdminUser(interaction);
 
   try {
@@ -41,7 +47,9 @@ const sendHelpInteraction = async ({ interaction, nessie }) => {
           name: 'Bot Permissions',
           value: `${hasAdmin || hasManageChannels ? '✅' : '❌'} Manage Channels\n${
             hasAdmin || hasManageWebhooks ? '✅' : '❌'
-          } Manage Webhooks\n${hasAdmin || hasSendMessages ? '✅' : '❌'} Send Messages\n\n${
+          } Manage Webhooks\n${hasAdmin || hasViewChannel ? '✅' : '❌'} View Channels\n${
+            hasAdmin || hasSendMessages ? '✅' : '❌'
+          } Send Messages\n\n${
             !isAdminUser || hasMissingPermissions
               ? 'Looks like there are missing permissions. Make sure to add the above permissions to be able to create automatic map updates!'
               : 'Looks like everything is set, use `/status start` to get started!'

--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -512,7 +512,7 @@ const createStatus = async ({ interaction, nessie, mixpanel }) => {
  */
 const scheduleStatus = (nessie) => {
   return new Scheduler(
-    '5 */15 * * * *',
+    '5 */1 * * * *',
     async () => {
       getAllStatus(async (allStatus, client) => {
         const startTime = Date.now();

--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -97,17 +97,10 @@ const generateConfirmStatusMessage = ({ interaction }) => {
   const confirmButtonId = `statusStart__confirmButton${modeLength > 0 ? '?' : ''}${
     isBattleRoyaleSelected ? 'battle_royale' : ''
   }${modeLength > 1 ? '&' : ''}${isArenasSelected ? 'arenas' : ''}`; //Full selection: statusStart__confirmButton?battle_royale&arenas;
+  const selectionText = `${isBattleRoyaleSelected ? '*Battle Royale*' : ''} ${
+    modeLength > 1 ? 'and' : ''
+  } ${isArenasSelected ? '*Arenas*' : ''}`;
 
-  //TODO: Cleanup the selected game mode display below
-  const mapOptions = {
-    gameModeDropdown__battleRoyaleValue: 'Battle Royale',
-    gameModeDropdown__arenasValue: 'Arenas',
-  };
-
-  let selectedValues = '';
-  interaction.values.forEach((value, index) => {
-    selectedValues += `${index > 0 ? ', ' : ''}${mapOptions[value]}`;
-  });
   const row = new MessageActionRow()
     .addComponents(
       new MessageButton()
@@ -126,7 +119,11 @@ const generateConfirmStatusMessage = ({ interaction }) => {
     );
   const embed = {
     title: 'Step 2 | Status Confirmation',
-    description: `Selected ${selectedValues}\n\n• Show selected game modes\n• Explain what channels + webhooks will be created based on selection\n• By confirming below, Nessie will create yada yada yada`,
+    description: `You've selected ${selectionText}!\n\nBy confirming below, Nessie will create a new category channel, ${modeLength} text-channels and ${modeLength} webhooks for the automatic map updates:\n• ${codeBlock(
+      'Apex Legends Map Status'
+    )}\n${isBattleRoyaleSelected ? `• ${codeBlock('#apex-battle-royale')}\n` : ''}${
+      isArenasSelected ? `• ${codeBlock('#apex-arenas')}\n` : ''
+    }• Webhook for each text channel\n\nUpdates get sent to these channels **every 15 minutes**`,
     color: 3447003,
   };
   return {

--- a/helpers.js
+++ b/helpers.js
@@ -388,17 +388,19 @@ const generateRankedEmbed = (data, type = 'Battle Royale') => {
 const checkMissingBotPermissions = (interaction) => {
   const hasAdmin = interaction.guild.me.permissions.has('ADMINISTRATOR');
   const hasManageChannels = interaction.guild.me.permissions.has('MANAGE_CHANNELS', false);
+  const hasViewChannel = interaction.guild.me.permissions.has('VIEW_CHANNEL', false);
   const hasManageWebhooks = interaction.guild.me.permissions.has('MANAGE_WEBHOOKS', false);
   const hasSendMessages = interaction.guild.me.permissions.has('SEND_MESSAGES', false);
 
   const hasMissingPermissions =
-    (!hasManageChannels || !hasManageWebhooks || !hasSendMessages) && !hasAdmin; //Overrides missing permissions if nessie has Admin
+    (!hasManageChannels || !hasViewChannel || !hasManageWebhooks || !hasSendMessages) && !hasAdmin; //Overrides missing permissions if nessie has Admin
 
   return {
     hasAdmin,
     hasManageChannels,
     hasManageWebhooks,
     hasSendMessages,
+    hasViewChannel,
     hasMissingPermissions,
   };
 };
@@ -408,7 +410,7 @@ const checkIfAdminUser = (interaction) => {
 const sendMissingBotPermissionsError = async ({ interaction, title }) => {
   const embed = {
     title,
-    description: `Oops looks like Nessie is missing some permissions D:\n\nThese bot permissions are required to create automatic map updates:\n• Manage Channels\n• Manage Webhooks\n• Send Messages\n\nFor more details, use ${codeBlock(
+    description: `Oops looks like Nessie is missing some permissions D:\n\nThese bot permissions are required to create/stop automatic map updates:\n• Manage Channels\n• Manage Webhooks\n• View Channels\n• Send Messages\n\nFor more details, use ${codeBlock(
       '/status help'
     )}`,
     color: 16711680,
@@ -418,7 +420,7 @@ const sendMissingBotPermissionsError = async ({ interaction, title }) => {
 const sendOnlyAdminError = async ({ interaction, title }) => {
   const embed = {
     title,
-    description: `Oops only Admins can create automatic map updates D:\n\nRequired User Permissions:\n• Administrator\n\nFor more details, use ${codeBlock(
+    description: `Oops only Admins can create/stop automatic map updates D:\n\nRequired User Permissions:\n• Administrator\n\nFor more details, use ${codeBlock(
       '/status help'
     )}`,
     color: 16711680,
@@ -428,7 +430,7 @@ const sendOnlyAdminError = async ({ interaction, title }) => {
 const sendMissingAllPermissionsError = async ({ interaction, title }) => {
   const embed = {
     title,
-    description: `Oops looks there are some issues to resolve before you're able to create automatic map updates D:\n\nRequired Bot Permissions\n• Manage Channels\n• Manage Webhooks\n• Send Messages\n\nRequired User Permissions:\n• Administrator\n\nFor more details, use ${codeBlock(
+    description: `Oops looks there are some issues to resolve before you're able to create automatic map updates D:\n\nRequired Bot Permissions\n• Manage Channels\n• Manage Webhooks\n• View Channels\n• Send Messages\n\nRequired User Permissions:\n• Administrator\n\nFor more details, use ${codeBlock(
       '/status help'
     )}`,
     color: 16711680,


### PR DESCRIPTION
#### Context
Last change before releasing status in the next couple of days. Mostly copy updates for the status commands. Added the `VIEW_CHANNEL` permission as required though since apparently discord would be enforcing this in a couple of weeks. I don't think nessie needs this tbh but I'll require it just in case. Weird tho, read messages + view channel is combined as a permission scope, we might need to update the invite link if this gets affected in September

<img width="490" alt="image" src="https://user-images.githubusercontent.com/42207245/179417581-3292c799-43ea-4f74-86b7-765d6814482f.png">
<img width="482" alt="image" src="https://user-images.githubusercontent.com/42207245/179417604-879be890-6716-4110-aeb9-3945d3ad3bce.png">
<img width="478" alt="image" src="https://user-images.githubusercontent.com/42207245/179417590-705d3f12-b394-4b37-af3b-4d3b7898f949.png">

#### Change
- Update embed content of status commands
- Add updated invite link to footer of status help
- Update invite links
- Update about copy