### PR TITLE
Add limited time event command

### DIFF
--- a/adapters.js
+++ b/adapters.js
@@ -93,6 +93,13 @@ exports.getControlPubs = async () => {
   console.log(data);
   return data;
 };
+exports.getLimitedTimeEvent = async () => {
+  const data = await axios.get(url).then((response) => {
+    return response.data.ltm;
+  });
+  console.log(data);
+  return data;
+};
 exports.getRotationData = async () => {
   const data = await axios.get(url).then((response) => {
     return response.data;

--- a/commands.js
+++ b/commands.js
@@ -13,7 +13,8 @@ exports.getApplicationCommands = () => {
     // Maps
     br: require('./commands/maps/battleRoyale'),
     arenas: require('./commands/maps/arenas'),
-    control: require('./commands/maps/control'),
+    // control: require('./commands/maps/control'),
+    ltm: require('./commands/maps/ltm'),
     status: require('./commands/maps/status'),
     //Admin
     announcement: require('./commands/admin/announcement'),

--- a/commands/maps/ltm/index.js
+++ b/commands/maps/ltm/index.js
@@ -1,0 +1,24 @@
+const { SlashCommandBuilder } = require('@discordjs/builders');
+const { v4: uuidv4 } = require('uuid');
+const { getLimitedTimeEvent } = require('../../../adapters');
+const { generateErrorEmbed, generatePubsEmbed } = require('../../../helpers');
+
+module.exports = {
+  data: new SlashCommandBuilder()
+    .setName('ltm')
+    .setDescription('Shows current limited event map rotation'),
+  async execute({ nessie, interaction }) {
+    try {
+      await interaction.deferReply();
+      const data = await getLimitedTimeEvent();
+      const embed = generatePubsEmbed(data, data.current.eventName);
+      interaction.editReply({ embeds: [embed] });
+    } catch (error) {
+      const uuid = uuidv4();
+      const type = 'Limited Time Event';
+      const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
+      await interaction.editReply({ embeds: errorEmbed });
+      await sendErrorLog({ nessie, error, interaction, type, uuid });
+    }
+  },
+};

--- a/commands/maps/ltm/index.js
+++ b/commands/maps/ltm/index.js
@@ -31,6 +31,12 @@ const generateLimitedTimeEventEmbed = (data) => {
   };
   return embedData;
 };
+/**
+ * Handler for limited time events
+ * Tbh I'm not so sure what I want to do with this currently
+ * Since it's definitely not scalable to be updating and releasing everytime an event ends
+ * Maybe make it so that it'll always exist as a command and return a specific error if there's no ltm?
+ */
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('ltm')

--- a/commands/maps/ltm/index.js
+++ b/commands/maps/ltm/index.js
@@ -1,8 +1,36 @@
 const { SlashCommandBuilder } = require('@discordjs/builders');
 const { v4: uuidv4 } = require('uuid');
 const { getLimitedTimeEvent } = require('../../../adapters');
-const { generateErrorEmbed, generatePubsEmbed } = require('../../../helpers');
+const { generateErrorEmbed, getMapUrl, getCountdown, sendErrorLog } = require('../../../helpers');
 
+const generateLimitedTimeEventEmbed = (data) => {
+  const embedData = {
+    title: data.current.eventName,
+    description: '',
+    color: 15105570,
+    image: {
+      url:
+        getMapUrl(data.current.code).length > 0 ? getMapUrl(data.current.code) : data.current.asset,
+    },
+    timestamp: Date.now() + data.current.remainingSecs * 1000,
+    footer: {
+      text: `Next Map: ${data.next.map}`,
+    },
+    fields: [
+      {
+        name: 'Current map',
+        value: '```fix\n\n' + data.current.map + '```',
+        inline: true,
+      },
+      {
+        name: 'Time left',
+        value: '```xl\n\n' + getCountdown(data.current.remainingTimer) + '```',
+        inline: true,
+      },
+    ],
+  };
+  return embedData;
+};
 module.exports = {
   data: new SlashCommandBuilder()
     .setName('ltm')
@@ -11,8 +39,8 @@ module.exports = {
     try {
       await interaction.deferReply();
       const data = await getLimitedTimeEvent();
-      const embed = generatePubsEmbed(data, data.current.eventName);
-      interaction.editReply({ embeds: [embed] });
+      const embed = generateLimitedTimeEventEmbed(data);
+      await interaction.editReply({ embeds: [embed] });
     } catch (error) {
       const uuid = uuidv4();
       const type = 'Limited Time Event';


### PR DESCRIPTION
#### Context
Was about to release before I noticed the control command was throwing errors. Apparently it's been gone for a couple of days and replaced with a new limited time event: Armed and Dangerous. It was getting annoying and definitely not scalable having to always add/remove control so adding this new `ltm` command which will show the current limited time event rotation

Not really sure yet what I'll do with this to make it feasible; the command will still error if there's no event currently. Maybe  show a specific error if it happens? Gonna tackle that when it does start failing lol

<img width="412" alt="image" src="https://user-images.githubusercontent.com/42207245/180231780-ba4c0d15-10c6-412a-8490-eec17a10fb90.png">

#### Change
- Remove control
- Create limited time event command