### PR TITLE
Change user permission for status

### DIFF
--- a/commands/maps/status/help/index.js
+++ b/commands/maps/status/help/index.js
@@ -3,8 +3,8 @@ const {
   generateErrorEmbed,
   sendErrorLog,
   checkMissingBotPermissions,
-  checkIfAdminUser,
   codeBlock,
+  checkIfUserHasManageServer,
 } = require('../../../../helpers');
 
 /**
@@ -23,7 +23,7 @@ const sendHelpInteraction = async ({ interaction, nessie }) => {
     hasSendMessages,
     hasMissingPermissions,
   } = checkMissingBotPermissions(interaction);
-  const isAdminUser = checkIfAdminUser(interaction);
+  const isManageServerUser = checkIfUserHasManageServer(interaction);
 
   try {
     const embedInformation = {
@@ -41,7 +41,7 @@ const sendHelpInteraction = async ({ interaction, nessie }) => {
       fields: [
         {
           name: 'User Permissions',
-          value: `${isAdminUser ? '✅' : '❌'} Administrator`,
+          value: `${isManageServerUser ? '✅' : '❌'} Manage Server`,
         },
         {
           name: 'Bot Permissions',
@@ -50,9 +50,9 @@ const sendHelpInteraction = async ({ interaction, nessie }) => {
           } Manage Webhooks\n${hasAdmin || hasViewChannel ? '✅' : '❌'} View Channels\n${
             hasAdmin || hasSendMessages ? '✅' : '❌'
           } Send Messages\n\n${
-            !isAdminUser || hasMissingPermissions
+            !isManageServerUser || hasMissingPermissions
               ? `Looks like there are missing permissions. Make sure to add the above permissions to be able to use automatic map updates!${
-                  isAdminUser
+                  isManageServerUser
                     ? `\nYou can refresh Nessie's permissions by reinviting using this [link](https://discord.com/api/oauth2/authorize?client_id=889135055430111252&permissions=536874000&scope=applications.commands%20bot)`
                     : ''
                 }`

--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -8,10 +8,11 @@ const {
   checkMissingBotPermissions,
   sendMissingBotPermissionsError,
   checkIfAdminUser,
-  sendOnlyAdminError,
   sendMissingAllPermissionsError,
   codeBlock,
   sendStatusErrorLog,
+  checkIfUserHasManageServer,
+  sendMissingUserPermissionError,
 } = require('../../../../helpers');
 const { getRotationData } = require('../../../../adapters');
 const { nessieLogo } = require('../../../../constants');
@@ -183,6 +184,7 @@ const sendStartInteraction = async ({ interaction, nessie }) => {
       const { embed, row } = generateGameModeSelectionMessage(status);
       const { hasMissingPermissions } = checkMissingBotPermissions(interaction);
       const isAdminUser = checkIfAdminUser(interaction);
+      const hasManageServer = checkIfUserHasManageServer(interaction);
       try {
         if (!status) {
           if (hasMissingPermissions && !isAdminUser) {
@@ -190,7 +192,8 @@ const sendStartInteraction = async ({ interaction, nessie }) => {
           } else {
             if (hasMissingPermissions)
               return sendMissingBotPermissionsError({ interaction, title: 'Status | Start' });
-            if (!isAdminUser) return sendOnlyAdminError({ interaction, title: 'Status | Start' });
+            if (!(isAdminUser || hasManageServer))
+              return sendMissingUserPermissionError({ interaction, title: 'Status | Start' });
           }
         }
         await interaction.editReply({ embeds: [embed], components: row ? [row] : [] });

--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -7,7 +7,6 @@ const {
   generateRankedEmbed,
   checkMissingBotPermissions,
   sendMissingBotPermissionsError,
-  checkIfAdminUser,
   sendMissingAllPermissionsError,
   codeBlock,
   sendStatusErrorLog,
@@ -183,16 +182,15 @@ const sendStartInteraction = async ({ interaction, nessie }) => {
     async (status) => {
       const { embed, row } = generateGameModeSelectionMessage(status);
       const { hasMissingPermissions } = checkMissingBotPermissions(interaction);
-      const isAdminUser = checkIfAdminUser(interaction);
-      const hasManageServer = checkIfUserHasManageServer(interaction);
+      const isManageServerUser = checkIfUserHasManageServer(interaction);
       try {
         if (!status) {
-          if (hasMissingPermissions && !isAdminUser) {
+          if (hasMissingPermissions && !isManageServerUser) {
             return sendMissingAllPermissionsError({ interaction, title: 'Status | Start' });
           } else {
             if (hasMissingPermissions)
               return sendMissingBotPermissionsError({ interaction, title: 'Status | Start' });
-            if (!(isAdminUser || hasManageServer))
+            if (!isManageServerUser)
               return sendMissingUserPermissionError({ interaction, title: 'Status | Start' });
           }
         }

--- a/commands/maps/status/stop/index.js
+++ b/commands/maps/status/stop/index.js
@@ -6,7 +6,8 @@ const {
   checkIfAdminUser,
   sendMissingAllPermissionsError,
   sendMissingBotPermissionsError,
-  sendOnlyAdminError,
+  checkIfUserHasManageServer,
+  sendMissingUserPermissionError,
 } = require('../../../../helpers');
 const { v4: uuidv4 } = require('uuid');
 const { MessageActionRow, MessageButton } = require('discord.js');
@@ -24,13 +25,15 @@ const sendStopInteraction = async ({ interaction, nessie }) => {
     async (status) => {
       const { hasMissingPermissions } = checkMissingBotPermissions(interaction);
       const isAdminUser = checkIfAdminUser(interaction);
+      const hasManageServer = checkIfUserHasManageServer(interaction);
       if (status) {
         if (hasMissingPermissions && !isAdminUser) {
           return sendMissingAllPermissionsError({ interaction, title: 'Status | Stop' });
         } else {
           if (hasMissingPermissions)
             return sendMissingBotPermissionsError({ interaction, title: 'Status | Stop' });
-          if (!isAdminUser) return sendOnlyAdminError({ interaction, title: 'Status | Stop' });
+          if (!(isAdminUser || hasManageServer))
+            return sendMissingUserPermissionError({ interaction, title: 'Status | Stop' });
         }
       }
       const embed = {

--- a/commands/maps/status/stop/index.js
+++ b/commands/maps/status/stop/index.js
@@ -3,7 +3,6 @@ const {
   sendErrorLog,
   codeBlock,
   checkMissingBotPermissions,
-  checkIfAdminUser,
   sendMissingAllPermissionsError,
   sendMissingBotPermissionsError,
   checkIfUserHasManageServer,
@@ -24,15 +23,14 @@ const sendStopInteraction = async ({ interaction, nessie }) => {
     interaction.guildId,
     async (status) => {
       const { hasMissingPermissions } = checkMissingBotPermissions(interaction);
-      const isAdminUser = checkIfAdminUser(interaction);
-      const hasManageServer = checkIfUserHasManageServer(interaction);
+      const isManageServerUser = checkIfUserHasManageServer(interaction);
       if (status) {
-        if (hasMissingPermissions && !isAdminUser) {
+        if (hasMissingPermissions && !isManageServerUser) {
           return sendMissingAllPermissionsError({ interaction, title: 'Status | Stop' });
         } else {
           if (hasMissingPermissions)
             return sendMissingBotPermissionsError({ interaction, title: 'Status | Stop' });
-          if (!(isAdminUser || hasManageServer))
+          if (!isManageServerUser)
             return sendMissingUserPermissionError({ interaction, title: 'Status | Stop' });
         }
       }

--- a/helpers.js
+++ b/helpers.js
@@ -407,6 +407,9 @@ const checkMissingBotPermissions = (interaction) => {
 const checkIfAdminUser = (interaction) => {
   return interaction.member.permissions.has('ADMINISTRATOR'); //Checks if user who initiated command is an Admin
 };
+const checkIfUserHasManageServer = (interaction) => {
+  return interaction.member.permissions.has('MANAGE_GUILD'); //Checks if user who initiated command has the Manage Server/Guild permission
+};
 const sendMissingBotPermissionsError = async ({ interaction, title }) => {
   const embed = {
     title,
@@ -417,10 +420,12 @@ const sendMissingBotPermissionsError = async ({ interaction, title }) => {
   };
   return await interaction.editReply({ embeds: [embed], components: [] });
 };
-const sendOnlyAdminError = async ({ interaction, title }) => {
+const sendMissingUserPermissionError = async ({ interaction, title }) => {
   const embed = {
     title,
-    description: `Oops only Admins can create/stop automatic map updates D:\n\nRequired User Permissions:\n• Administrator\n\nFor more details, use ${codeBlock(
+    description: `Oops only users with the ${codeBlock(
+      'Manage Server'
+    )} permission can create/stop automatic map updates D:\n\nRequired User Permissions:\n• Manage Server\n\nFor more details, use ${codeBlock(
       '/status help'
     )}`,
     color: 16711680,
@@ -430,7 +435,7 @@ const sendOnlyAdminError = async ({ interaction, title }) => {
 const sendMissingAllPermissionsError = async ({ interaction, title }) => {
   const embed = {
     title,
-    description: `Oops looks there are some issues to resolve before you're able to create automatic map updates D:\n\nRequired Bot Permissions\n• Manage Channels\n• Manage Webhooks\n• View Channels\n• Send Messages\n\nRequired User Permissions:\n• Administrator\n\nFor more details, use ${codeBlock(
+    description: `Oops looks there are some issues to resolve before you're able to create automatic map updates D:\n\nRequired Bot Permissions\n• Manage Channels\n• Manage Webhooks\n• View Channels\n• Send Messages\n\nRequired User Permissions:\n• Manage Server\n\nFor more details, use ${codeBlock(
       '/status help'
     )}`,
     color: 16711680,
@@ -453,8 +458,9 @@ module.exports = {
   generateRankedEmbed,
   checkMissingBotPermissions,
   checkIfAdminUser,
+  checkIfUserHasManageServer,
   sendMissingBotPermissionsError,
-  sendOnlyAdminError,
+  sendMissingUserPermissionError,
   sendMissingAllPermissionsError,
   sendStatusErrorLog,
 };


### PR DESCRIPTION
#### Context
Currently we require users to have the Administrator permission to be able to start/stop map status. Never really had a reason of setting this other than it's the highest permission a user can have; basically an admin has every permission. This is fine as we don't really want just anybody setting this up however it occured to me, we don't really need to go that far

Since users would only ever need the `Manage Server` permission to invite bots to their servers, it makes sense that we'll  only need that too for our requirements. Might make it also more accessible for larger guilds as most of them won't necessarily have a lot of admins

<img width="476" alt="image" src="https://user-images.githubusercontent.com/42207245/180647932-000512fc-9015-4c3c-aca6-72a16e31464c.png">
<img width="489" alt="image" src="https://user-images.githubusercontent.com/42207245/180647941-ce5ce36b-d681-4706-96ba-2379aba8fa85.png">


#### Change
- Create helper to check if user has manage server permission
- Update validations to check manage server instead of admin