### PR TITLE
Add image for broken moon

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -298,8 +298,10 @@ const getMapUrl = (map) => {
       return 'https://cdn.discordapp.com/attachments/896544134813319168/911631835300237332/storm_point_nessie.jpg';
     case 'storm_point_rotation':
       return 'https://cdn.discordapp.com/attachments/896544134813319168/911631835300237332/storm_point_nessie.jpg';
+    case 'broken_moon_rotation':
+      return 'https://cdn.discordapp.com/attachments/896544134813319168/1064934640739164240/broken_moon.jpg';
     default:
-      return '';
+      return null;
   }
 };
 /**


### PR DESCRIPTION
#### Context
Ayo a pr after 6months :eyes: Did take a somewhat long break from coding projects (spent way too much time playing random games orz) but now I'm back after figuring some stuff out. Will probably be spending more time coding again here and other projects I think of for this year.

Anyway this was prompted after I got spammed the other day with error logs; further investigation showed that nessie couldn't render the necessary embeds since the image url being used for broken moon was an empty string. I quickly changed the function to return as null in the meantime but this fixes it completely by adding an image url and changed the default returned value

<img width="632" alt="image" src="https://user-images.githubusercontent.com/42207245/212947956-02c68efe-b5ae-4917-91a0-837d11d28a4b.png">

<img width="590" alt="image" src="https://user-images.githubusercontent.com/42207245/212949001-457e6940-5d76-48d3-91a3-645c53b5720b.png">

#### Change
- Add image

#### Considerations
Would probably have to figure out how to refactor the `getMapUrl` function to be more scalable. It worked as it is since there are less maps but might not be the best idea to keep hardcoding map urls in the future