### PR TITLE
Simplify error status cycle notifications

### DIFF
--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -517,6 +517,8 @@ const scheduleStatus = (nessie) => {
   return new Scheduler(
     '5 */15 * * * *',
     async () => {
+      errorNotification.count = 0;
+      errorNotification.message = '';
       getAllStatus(async (allStatus, client) => {
         const startTime = Date.now();
         try {

--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -557,12 +557,13 @@ const scheduleStatus = (nessie) => {
               },
             },
           ].concat(await generateErrorEmbed(error, uuid, nessie));
-          allStatus.forEach(async (status) => {
+          allStatus.forEach(async (status, index) => {
             await handleStatusCycle({
               nessie,
               status,
               brStatusEmbeds: errorEmbed,
               arenasStatusEmbeds: errorEmbed,
+              index,
             });
           });
           await sendErrorLog({ nessie, error, type, uuid, ping: true });
@@ -660,8 +661,11 @@ const handleStatusCycle = async ({
       await statusLogChannel.send({ embeds: [statusLogEmbed] });
     }
   } catch (error) {
+    errorNotification.count = errorNotification + 1;
+    errorNotification.message = error;
     const uuid = uuidv4();
-    await sendStatusErrorLog({ nessie, uuid, error, status });
+    errorNotification.count < 3 && (await sendStatusErrorLog({ nessie, uuid, error, status }));
+
     if (error.message === 'Unknown Message' || error.message === 'Unknown Webhook') {
       deleteStatus(status.guild_id, async (status) => {
         try {

--- a/commands/maps/status/start/index.js
+++ b/commands/maps/status/start/index.js
@@ -24,6 +24,11 @@ const {
 } = require('../../../../database/handler');
 const Scheduler = require('../../../../scheduler');
 const { sendMixpanelEvent } = require('../../../../analytics');
+
+const errorNotification = {
+  count: 0,
+  message: '',
+};
 /**
  * Handler for generating the UI for Game Mode Selection Step as well as Confirm Status step below
  * This is separated from the interaction handlers as we want to be able to reuse them when the user goes back and forth through the steps


### PR DESCRIPTION
#### Context
Previously I set up error notifcations for the status cycle as sending 1 message per guild affected to a log channel. This was fine in the beginning but I've been made aware of the issues this presented recently when I got insanely spammed close to a hundred times in multiple instances. To prevent this and potential API abuse, this pr implements a simple system where only a max of 3 individual error messages are sent per cycle and send a summary at the end of a cycle

<img width="501" alt="image" src="https://user-images.githubusercontent.com/42207245/212970934-e9cf7206-d23b-46bf-8597-c6dcc8ed26d8.png">

#### Change
- Create global error notification object
- Only send individual status error notification at a max of 3 messages
- Send error summary at end of cycle
