### PR TITLE
Release/2022 01 18

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# v1.10.3 (Wed Jan 18 2023)
+
+#### 🐛 Bug Fix
+
+- Simplify error status cycle notifications [#113](https://github.com/vexuas/nessie/pull/113) ([@vexuas](https://github.com/vexuas))
+- Add template [#112](https://github.com/vexuas/nessie/pull/112) ([@vexuas](https://github.com/vexuas))
+- Add image for broken moon [#111](https://github.com/vexuas/nessie/pull/111) ([@vexuas](https://github.com/vexuas))
+
+#### 🏠 Internal
+
+- Release/2022 07 25 [#110](https://github.com/vexuas/nessie/pull/110) ([@vexuas](https://github.com/vexuas))
+
+#### Authors: 1
+
+- Gabriel R ([@vexuas](https://github.com/vexuas))
+
+---
+
 # v1.10.2 (Mon Jul 25 2022)
 
 #### 🐛 Bug Fix

--- a/commands/hub/about/index.js
+++ b/commands/hub/about/index.js
@@ -34,7 +34,7 @@ const sendAboutEmbed = async ({ nessie, interaction }) => {
       },
       {
         name: 'Last Update',
-        value: '25-July-2022',
+        value: '18-Jan-2023',
         inline: true,
       },
       {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nessie",
-  "version": "1.10.2",
+  "version": "1.10.3",
   "description": "Apex Legends Map Rotation Discord Bot",
   "scripts": {
     "auto:version": "yarn version --`auto version`"


### PR DESCRIPTION
# v1.10.3 (Wed Jan 18 2023)

#### 🐛 Bug Fix

- Simplify error status cycle notifications [#113](https://github.com/vexuas/nessie/pull/113) ([@vexuas](https://github.com/vexuas))
- Add template [#112](https://github.com/vexuas/nessie/pull/112) ([@vexuas](https://github.com/vexuas))
- Add image for broken moon [#111](https://github.com/vexuas/nessie/pull/111) ([@vexuas](https://github.com/vexuas))

#### 🏠 Internal

- Release/2022 07 25 [#110](https://github.com/vexuas/nessie/pull/110) ([@vexuas](https://github.com/vexuas))

#### Authors: 1

- Gabriel R ([@vexuas](https://github.com/vexuas))

---
