### PR TITLE
Add information for Missing Access error

### DIFF
--- a/helpers.js
+++ b/helpers.js
@@ -158,8 +158,13 @@ const generateErrorEmbed = async (error, uuid, nessie) => {
     errorMessage.lastIndexOf(']') - 3
   );
 
+  const missingAccessAlert =
+    'Oops looks like Nessie has missing access! This sometimes happens in servers where there are permission overwrites for default roles. An example of these are `View Channel` and `Send Messages` permissions that might not be enabled by default for new users/bots.\n\nTo grant access and use automatic map status, enable the `View Channels` and `Send Messages` permissions for Nessie through Server Settings -> Roles';
+
   const embed = {
-    description: `${errorAlert}\n\nError: ${
+    description: `${
+      error.message.includes('Missing Access') ? missingAccessAlert : errorAlert
+    }\n\nError: ${
       error.message ? codeBlock(error.message) : codeBlock('Unexpected Error')
     }\nError ID: ${codeBlock(
       uuid


### PR DESCRIPTION
#### Context
This error has always haunted me ever since the status feature was first released. Essentially this error happens when there are permission overwrites that causes implicit permissions to be disabled. An example of this from the discordjs guides:
> One possible scenario causing this: the channel has permission overwrites for the default role to grant SendMessages so everyone who can see the channel can also write in it, but at the same time has an overwrite to deny ViewChannel to make it only accessible to a subset of members.

So far I've evaded the issue of trying to solve this since frankly, I have no idea how to fix this on my end and that the errors weren't popping up a lot. For the cases that did, I relied on users to jsut figure it out or come to the support server to get explanations. 

I've seen a significant number of these errors recently however and I don't think I can avoid this any longer. I still don't know how to properly fix this but we can at least let the users know why the error is happening. I added some context and instructions on fixing it whenever this error gets thrown

![image](https://user-images.githubusercontent.com/42207245/232542140-081265ca-1250-45fd-9dec-9d26e3dde49b.png)

#### Change
- Add error information

#### Considerations
Don't think this solves #118 but it's a good bandaid for now. Will look into this deeper when migrating to typescript/v2