### PR TITLE
Refactor error handling

### DIFF
--- a/src/App.ts
+++ b/src/App.ts
@@ -4,15 +4,20 @@ import AutoPoster from 'topgg-autoposter';
 import { BOT_TOKEN, MIXPANEL_ID, TOP_GG_TOKEN } from './config/environment';
 import { registerEventHandlers } from './events/events';
 import { isEmpty } from 'lodash';
+import { sendErrorLog } from './utils/helpers';
 
 const nessie = new Client({
   intents: [Intents.FLAGS.GUILDS, Intents.FLAGS.GUILD_MESSAGES, Intents.FLAGS.GUILD_MESSAGE_TYPING],
 });
 
 const initialize = async () => {
-  await nessie.login(BOT_TOKEN);
-  const mixpanel = MIXPANEL_ID && !isEmpty(MIXPANEL_ID) ? Mixpanel.init(MIXPANEL_ID) : null;
-  TOP_GG_TOKEN && !isEmpty(TOP_GG_TOKEN) && AutoPoster(TOP_GG_TOKEN, nessie);
-  registerEventHandlers({ nessie, mixpanel });
+  try {
+    await nessie.login(BOT_TOKEN);
+    const mixpanel = MIXPANEL_ID && !isEmpty(MIXPANEL_ID) ? Mixpanel.init(MIXPANEL_ID) : null;
+    TOP_GG_TOKEN && !isEmpty(TOP_GG_TOKEN) && AutoPoster(TOP_GG_TOKEN, nessie);
+    registerEventHandlers({ nessie, mixpanel });
+  } catch (error) {
+    sendErrorLog({ error });
+  }
 };
 initialize();

--- a/src/commands/arenas/index.ts
+++ b/src/commands/arenas/index.ts
@@ -1,11 +1,6 @@
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { getArenasPubs, getArenasRanked } from '../../services/adapters';
-import {
-  generateErrorEmbed,
-  generatePubsEmbed,
-  generateRankedEmbed,
-  sendErrorLog,
-} from '../../utils/helpers';
+import { generatePubsEmbed, generateRankedEmbed, sendErrorLog } from '../../utils/helpers';
 import { AppCommand, AppCommandOptions } from '../commands';
 
 export default {

--- a/src/commands/arenas/index.ts
+++ b/src/commands/arenas/index.ts
@@ -7,7 +7,6 @@ import {
   sendErrorLog,
 } from '../../utils/helpers';
 import { AppCommand, AppCommandOptions } from '../commands';
-import { v4 as uuidV4 } from 'uuid';
 
 export default {
   commandType: 'Maps',
@@ -22,7 +21,7 @@ export default {
         .addChoice('pubs', 'arenas_pubs')
         .addChoice('ranked', 'arenas_ranked')
     ),
-  async execute({ interaction, app }: AppCommandOptions) {
+  async execute({ interaction }: AppCommandOptions) {
     let data;
     let embed;
     try {
@@ -49,11 +48,7 @@ export default {
       //   true
       // );
     } catch (error) {
-      const uuid = uuidV4();
-      const type = 'Arenas';
-      const errorEmbed = await generateErrorEmbed(error, uuid, app);
-      await interaction.editReply({ embeds: errorEmbed });
-      await sendErrorLog({ nessie: app, error, type, interaction, uuid });
+      sendErrorLog({ error, interaction });
     }
   },
 } as AppCommand;

--- a/src/commands/arenas/index.ts
+++ b/src/commands/arenas/index.ts
@@ -19,9 +19,9 @@ export default {
   async execute({ interaction }: AppCommandOptions) {
     let data;
     let embed;
+    const optionMode = interaction.options.getString('mode');
     try {
       await interaction.deferReply();
-      const optionMode = interaction.options.getString('mode');
       switch (optionMode) {
         case 'arenas_pubs':
           data = await getArenasPubs();
@@ -43,7 +43,7 @@ export default {
       //   true
       // );
     } catch (error) {
-      sendErrorLog({ error, interaction });
+      sendErrorLog({ error, interaction, option: optionMode });
     }
   },
 } as AppCommand;

--- a/src/commands/battleRoyale/index.ts
+++ b/src/commands/battleRoyale/index.ts
@@ -1,13 +1,7 @@
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { getBattleRoyalePubs, getBattleRoyaleRanked } from '../../services/adapters';
-import {
-  generateErrorEmbed,
-  generatePubsEmbed,
-  generateRankedEmbed,
-  sendErrorLog,
-} from '../../utils/helpers';
+import { generatePubsEmbed, generateRankedEmbed, sendErrorLog } from '../../utils/helpers';
 import { AppCommand, AppCommandOptions } from '../commands';
-import { v4 as uuidV4 } from 'uuid';
 
 export default {
   commandType: 'Maps',
@@ -22,7 +16,7 @@ export default {
         .addChoice('pubs', 'br_pubs')
         .addChoice('ranked', 'br_ranked')
     ),
-  async execute({ interaction, app }: AppCommandOptions) {
+  async execute({ interaction }: AppCommandOptions) {
     let data;
     let embed;
     try {
@@ -49,11 +43,7 @@ export default {
       //   true
       // );
     } catch (error) {
-      const uuid = uuidV4();
-      const type = 'Battle Royale';
-      const errorEmbed = await generateErrorEmbed(error, uuid, app);
-      await interaction.editReply({ embeds: errorEmbed });
-      await sendErrorLog({ nessie: app, error, interaction, type, uuid });
+      sendErrorLog({ error, interaction });
     }
   },
 } as AppCommand;

--- a/src/commands/battleRoyale/index.ts
+++ b/src/commands/battleRoyale/index.ts
@@ -19,9 +19,9 @@ export default {
   async execute({ interaction }: AppCommandOptions) {
     let data;
     let embed;
+    const optionMode = interaction.options.getString('mode');
     try {
       await interaction.deferReply();
-      const optionMode = interaction.options.getString('mode');
       switch (optionMode) {
         case 'br_pubs':
           data = await getBattleRoyalePubs();
@@ -43,7 +43,7 @@ export default {
       //   true
       // );
     } catch (error) {
-      sendErrorLog({ error, interaction });
+      sendErrorLog({ error, interaction, option: optionMode });
     }
   },
 } as AppCommand;

--- a/src/commands/ltm/index.ts
+++ b/src/commands/ltm/index.ts
@@ -38,18 +38,14 @@ export default {
   data: new SlashCommandBuilder()
     .setName('ltm')
     .setDescription('Shows current limited time mode map rotation'),
-  async execute({ app, interaction }: AppCommandOptions) {
+  async execute({ interaction }: AppCommandOptions) {
     try {
       await interaction.deferReply();
       const data = await getLimitedTimeEvent();
       const embed = generateLimitedTimeEventEmbed(data);
       await interaction.editReply({ embeds: [embed] });
     } catch (error) {
-      const uuid = uuidV4();
-      const type = 'Limited Time Event';
-      const errorEmbed = await generateErrorEmbed(error, uuid, app);
-      await interaction.editReply({ embeds: errorEmbed });
-      await sendErrorLog({ nessie: app, error, interaction, type, uuid });
+      sendErrorLog({ error, interaction });
     }
   },
 } as AppCommand;

--- a/src/commands/ltm/index.ts
+++ b/src/commands/ltm/index.ts
@@ -1,8 +1,7 @@
 import { SlashCommandBuilder } from '@discordjs/builders';
 import { getLimitedTimeEvent } from '../../services/adapters';
-import { generateErrorEmbed, getCountdown, getMapUrl, sendErrorLog } from '../../utils/helpers';
+import { getCountdown, getMapUrl, sendErrorLog } from '../../utils/helpers';
 import { AppCommand, AppCommandOptions } from '../commands';
-import { v4 as uuidV4 } from 'uuid';
 
 //TODO: Add typing after upgrading to djs v14
 export const generateLimitedTimeEventEmbed = (data: any) => {

--- a/src/commands/status/help/index.ts
+++ b/src/commands/status/help/index.ts
@@ -72,10 +72,6 @@ export const sendHelpInteraction = async ({ interaction, app }: any) => {
       ],
     });
   } catch (error) {
-    const uuid = uuidV4();
-    const type = 'Status Help';
-    const errorEmbed = await generateErrorEmbed(error, uuid, app);
-    await interaction.editReply({ embeds: errorEmbed });
-    await sendErrorLog({ nessie: app, error, interaction, type, uuid });
+    sendErrorLog({ error, interaction });
   }
 };

--- a/src/commands/status/help/index.ts
+++ b/src/commands/status/help/index.ts
@@ -1,7 +1,9 @@
+import { CommandInteraction } from 'discord.js';
 import {
   checkIfUserHasManageServer,
   checkMissingBotPermissions,
   codeBlock,
+  getEmbedColor,
   sendErrorLog,
 } from '../../../utils/helpers';
 
@@ -13,7 +15,13 @@ import {
  * Will either show a tick or mark if the permission is missing
  * Shows a success/warning at the end if any of the permissions are missing
  */
-export const sendHelpInteraction = async ({ interaction }: any) => {
+export const sendHelpInteraction = async ({
+  interaction,
+  subCommand,
+}: {
+  interaction: CommandInteraction;
+  subCommand: string;
+}) => {
   const {
     hasAdmin,
     hasManageChannels,
@@ -62,14 +70,14 @@ export const sendHelpInteraction = async ({ interaction }: any) => {
       color: 3447003,
     };
 
-    return await interaction.editReply({
+    await interaction.editReply({
       embeds: [
-        { title: 'Status | Help', description: '', color: 3447003 },
+        { title: 'Status | Help', description: '', color: getEmbedColor() },
         embedInformation,
         embedPermissions,
       ],
     });
   } catch (error) {
-    sendErrorLog({ error, interaction });
+    sendErrorLog({ error, interaction, subCommand });
   }
 };

--- a/src/commands/status/help/index.ts
+++ b/src/commands/status/help/index.ts
@@ -2,10 +2,8 @@ import {
   checkIfUserHasManageServer,
   checkMissingBotPermissions,
   codeBlock,
-  generateErrorEmbed,
   sendErrorLog,
 } from '../../../utils/helpers';
-import { v4 as uuidV4 } from 'uuid';
 
 //TODO: Add typing and refactor handlers
 /**
@@ -15,7 +13,7 @@ import { v4 as uuidV4 } from 'uuid';
  * Will either show a tick or mark if the permission is missing
  * Shows a success/warning at the end if any of the permissions are missing
  */
-export const sendHelpInteraction = async ({ interaction, app }: any) => {
+export const sendHelpInteraction = async ({ interaction }: any) => {
   const {
     hasAdmin,
     hasManageChannels,

--- a/src/commands/status/index.ts
+++ b/src/commands/status/index.ts
@@ -3,8 +3,7 @@ import { AppCommand, AppCommandOptions } from '../commands';
 import { sendHelpInteraction } from './help';
 import { sendStartInteraction } from './start';
 import { sendStopInteraction } from './stop';
-import { v4 as uuidV4 } from 'uuid';
-import { generateErrorEmbed, sendErrorLog } from '../../utils/helpers';
+import { sendErrorLog } from '../../utils/helpers';
 
 export default {
   commandType: 'Automation',
@@ -35,11 +34,7 @@ export default {
           return sendStopInteraction({ interaction, nessie: app });
       }
     } catch (error) {
-      const uuid = uuidV4();
-      const type = 'Status Generic';
-      const errorEmbed = await generateErrorEmbed(error, uuid, app);
-      await interaction.editReply({ embeds: errorEmbed });
-      await sendErrorLog({ nessie: app, error, interaction, type, uuid });
+      sendErrorLog({ error, interaction });
     }
   },
 } as AppCommand;

--- a/src/commands/status/index.ts
+++ b/src/commands/status/index.ts
@@ -20,16 +20,16 @@ export default {
     .addSubcommand((subCommand) =>
       subCommand.setName('stop').setDescription('Stops existing automatic map updates')
     ),
-  async execute({ app, interaction }: AppCommandOptions) {
+  async execute({ interaction }: AppCommandOptions) {
     const subCommand = interaction.options.getSubcommand();
     await interaction.deferReply();
     switch (subCommand) {
       case 'help':
         return sendHelpInteraction({ interaction, subCommand });
       case 'start':
-        return sendStartInteraction({ interaction, nessie: app });
+        return sendStartInteraction({ interaction, subCommand });
       case 'stop':
-        return sendStopInteraction({ interaction, nessie: app });
+        return sendStopInteraction({ interaction, subCommand });
     }
   },
 } as AppCommand;

--- a/src/commands/status/index.ts
+++ b/src/commands/status/index.ts
@@ -3,7 +3,6 @@ import { AppCommand, AppCommandOptions } from '../commands';
 import { sendHelpInteraction } from './help';
 import { sendStartInteraction } from './start';
 import { sendStopInteraction } from './stop';
-import { sendErrorLog } from '../../utils/helpers';
 
 export default {
   commandType: 'Automation',
@@ -22,19 +21,15 @@ export default {
       subCommand.setName('stop').setDescription('Stops existing automatic map updates')
     ),
   async execute({ app, interaction }: AppCommandOptions) {
-    const statusOption = interaction.options.getSubcommand();
-    try {
-      await interaction.deferReply();
-      switch (statusOption) {
-        case 'help':
-          return sendHelpInteraction({ interaction, nessie: app });
-        case 'start':
-          return sendStartInteraction({ interaction, nessie: app });
-        case 'stop':
-          return sendStopInteraction({ interaction, nessie: app });
-      }
-    } catch (error) {
-      sendErrorLog({ error, interaction });
+    const subCommand = interaction.options.getSubcommand();
+    await interaction.deferReply();
+    switch (subCommand) {
+      case 'help':
+        return sendHelpInteraction({ interaction, subCommand });
+      case 'start':
+        return sendStartInteraction({ interaction, nessie: app });
+      case 'stop':
+        return sendStopInteraction({ interaction, nessie: app });
     }
   },
 } as AppCommand;

--- a/src/commands/status/start/index.ts
+++ b/src/commands/status/start/index.ts
@@ -218,7 +218,7 @@ export const goToConfirmStatus = async ({ interaction }: any) => {
     await interaction.deferUpdate();
     await interaction.message.edit({ embeds: [embed], components: [row] });
   } catch (error) {
-    sendErrorLog({ error, interaction });
+    sendErrorLog({ error, interaction, customTitle: 'Status Start Confirm Error' });
   } finally {
     // sendMixpanelEvent({
     //   user: interaction.user,
@@ -239,7 +239,7 @@ export const goBackToGameModeSelection = async ({ interaction }: any) => {
     await interaction.deferUpdate();
     await interaction.message.edit({ embeds: [embed], components: [row] });
   } catch (error) {
-    sendErrorLog({ error, interaction });
+    sendErrorLog({ error, interaction, customTitle: 'Status Start Back Error' });
   } finally {
     // sendMixpanelEvent({
     //   user: interaction.user,
@@ -265,7 +265,7 @@ export const _cancelStatusStart = async ({ interaction }: any) => {
     await interaction.deferUpdate();
     await interaction.message.edit({ embeds: [embed], components: [] });
   } catch (error) {
-    sendErrorLog({ error, interaction });
+    sendErrorLog({ error, interaction, customTitle: 'Status Start Cancel Error' });
   } finally {
     // sendMixpanelEvent({
     //   user: interaction.user,
@@ -449,7 +449,7 @@ export const createStatus = async ({ interaction, nessie }: any) => {
     };
     await statusLogChannel.send({ embeds: [statusLogEmbed] });
   } catch (error) {
-    sendErrorLog({ error, interaction });
+    sendErrorLog({ error, interaction, customTitle: 'Status Start Confirm' });
   } finally {
     // sendMixpanelEvent({
     //   user: interaction.user,

--- a/src/commands/status/start/index.ts
+++ b/src/commands/status/start/index.ts
@@ -656,7 +656,6 @@ const handleStatusCycle = async ({
       if (ERROR_NOTIFICATION_WEBHOOK_URL && !isEmpty(ERROR_NOTIFICATION_WEBHOOK_URL)) {
         const notificationWebhook = new WebhookClient({ url: ERROR_NOTIFICATION_WEBHOOK_URL });
         await notificationWebhook.send({
-          content: '<@183444648360935424>',
           embeds: [errorEmbed],
           username: 'Nessie Error Notification',
           avatarURL: nessieLogo,

--- a/src/commands/status/start/index.ts
+++ b/src/commands/status/start/index.ts
@@ -1,4 +1,10 @@
-import { MessageActionRow, MessageButton, MessageSelectMenu, WebhookClient } from 'discord.js';
+import {
+  CommandInteraction,
+  MessageActionRow,
+  MessageButton,
+  MessageSelectMenu,
+  WebhookClient,
+} from 'discord.js';
 import { deleteStatus, getAllStatus, getStatus, insertNewStatus } from '../../../services/database';
 import {
   generatePubsEmbed,
@@ -175,7 +181,13 @@ const generateArenasStatusEmbeds = (data: any) => {
  * We want to show permissions errors only when status do not exist
  * We want to show them existing status details but block them if they want to create one
  */
-export const sendStartInteraction = async ({ interaction }: any) => {
+export const sendStartInteraction = async ({
+  interaction,
+  subCommand,
+}: {
+  interaction: CommandInteraction;
+  subCommand: string;
+}) => {
   const status = await getStatus(interaction.guildId);
   const { embed, row } = generateGameModeSelectionMessage(status);
   const { hasMissingPermissions } = checkMissingBotPermissions(interaction);
@@ -193,7 +205,7 @@ export const sendStartInteraction = async ({ interaction }: any) => {
     }
     await interaction.editReply({ embeds: [embed], components: row ? [row] : [] });
   } catch (error) {
-    sendErrorLog({ error, interaction });
+    sendErrorLog({ error, interaction, subCommand });
   }
 };
 /**

--- a/src/commands/status/start/index.ts
+++ b/src/commands/status/start/index.ts
@@ -534,7 +534,7 @@ export const scheduleStatus = (nessie: any) => {
             index,
           });
         });
-      sendErrorLog({ error });
+      sendErrorLog({ error, customTitle: 'Status Scheduler Config' });
     }
   });
 };

--- a/src/commands/status/start/index.ts
+++ b/src/commands/status/start/index.ts
@@ -175,7 +175,7 @@ const generateArenasStatusEmbeds = (data: any) => {
  * We want to show permissions errors only when status do not exist
  * We want to show them existing status details but block them if they want to create one
  */
-export const sendStartInteraction = async ({ interaction, nessie }: any) => {
+export const sendStartInteraction = async ({ interaction }: any) => {
   const status = await getStatus(interaction.guildId);
   const { embed, row } = generateGameModeSelectionMessage(status);
   const { hasMissingPermissions } = checkMissingBotPermissions(interaction);
@@ -193,28 +193,20 @@ export const sendStartInteraction = async ({ interaction, nessie }: any) => {
     }
     await interaction.editReply({ embeds: [embed], components: row ? [row] : [] });
   } catch (error) {
-    const uuid = uuidV4();
-    const type = 'Status Start';
-    const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
-    await interaction.editReply({ embeds: errorEmbed });
-    await sendErrorLog({ nessie, error, interaction, type, uuid });
+    sendErrorLog({ error, interaction });
   }
 };
 /**
  * Handler for when a user selects any of the options in the Game Mode dropdown
  * Will edit and show the second step of the status start wizard: Confirm Status
  */
-export const goToConfirmStatus = async ({ interaction, nessie }: any) => {
+export const goToConfirmStatus = async ({ interaction }: any) => {
   const { embed, row } = generateConfirmStatusMessage({ interaction });
   try {
     await interaction.deferUpdate();
     await interaction.message.edit({ embeds: [embed], components: [row] });
   } catch (error) {
-    const uuid = uuidV4();
-    const type = 'Status Start Confirm';
-    const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
-    await interaction.editReply({ embeds: errorEmbed, components: [] });
-    await sendErrorLog({ nessie, error, interaction, type, uuid });
+    sendErrorLog({ error, interaction });
   } finally {
     // sendMixpanelEvent({
     //   user: interaction.user,
@@ -229,17 +221,13 @@ export const goToConfirmStatus = async ({ interaction, nessie }: any) => {
  * Handler for when a user clicks the Back button in Confirm Status Step
  * Will edit and show the first step of the status start wizard: Confirm Status
  */
-export const goBackToGameModeSelection = async ({ interaction, nessie }: any) => {
+export const goBackToGameModeSelection = async ({ interaction }: any) => {
   const { embed, row } = generateGameModeSelectionMessage();
   try {
     await interaction.deferUpdate();
     await interaction.message.edit({ embeds: [embed], components: [row] });
   } catch (error) {
-    const uuid = uuidV4();
-    const type = 'Status Start Back';
-    const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
-    await interaction.editReply({ embeds: errorEmbed, components: [] });
-    await sendErrorLog({ nessie, error, interaction, type, uuid });
+    sendErrorLog({ error, interaction });
   } finally {
     // sendMixpanelEvent({
     //   user: interaction.user,
@@ -256,7 +244,7 @@ export const goBackToGameModeSelection = async ({ interaction, nessie }: any) =>
  * Prepended an underscore as there's a function in announcement with the same name
  * TODO: Clean up the code there eventually
  */
-export const _cancelStatusStart = async ({ interaction, nessie }: any) => {
+export const _cancelStatusStart = async ({ interaction }: any) => {
   const embed = {
     description: 'Cancelled automatic map status config',
     color: 16711680,
@@ -265,11 +253,7 @@ export const _cancelStatusStart = async ({ interaction, nessie }: any) => {
     await interaction.deferUpdate();
     await interaction.message.edit({ embeds: [embed], components: [] });
   } catch (error) {
-    const uuid = uuidV4();
-    const type = 'Status Start Cancel';
-    const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
-    await interaction.editReply({ embeds: errorEmbed, components: [] });
-    await sendErrorLog({ nessie, error, interaction, type, uuid });
+    sendErrorLog({ error, interaction });
   } finally {
     // sendMixpanelEvent({
     //   user: interaction.user,
@@ -453,11 +437,7 @@ export const createStatus = async ({ interaction, nessie }: any) => {
     };
     await statusLogChannel.send({ embeds: [statusLogEmbed] });
   } catch (error) {
-    const uuid = uuidV4();
-    const type = 'Status Start Confirm';
-    const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
-    await interaction.editReply({ embeds: errorEmbed, components: [] });
-    await sendErrorLog({ nessie, error, interaction, type, uuid });
+    sendErrorLog({ error, interaction });
   } finally {
     // sendMixpanelEvent({
     //   user: interaction.user,
@@ -519,7 +499,6 @@ export const scheduleStatus = (nessie: any) => {
        * Only difference is instead of the rotation data, we're showing the information embed + an error message
        */
       const uuid = uuidV4();
-      const type = 'Status Scheduler Config';
       const errorEmbed: any = [
         {
           description:
@@ -543,7 +522,7 @@ export const scheduleStatus = (nessie: any) => {
             index,
           });
         });
-      await sendErrorLog({ nessie, error, type, uuid, ping: true });
+      sendErrorLog({ error });
     }
   });
 };

--- a/src/commands/status/stop/index.ts
+++ b/src/commands/status/stop/index.ts
@@ -85,7 +85,7 @@ export const _cancelStatusStop = async ({ interaction }: any) => {
     await interaction.deferUpdate();
     await interaction.message.edit({ embeds: [embed], components: [] });
   } catch (error) {
-    sendErrorLog({ error, interaction });
+    sendErrorLog({ error, interaction, customTitle: 'Status Stop Cancel Error' });
   } finally {
     // sendMixpanelEvent({
     //   user: interaction.user,
@@ -149,7 +149,7 @@ export const deleteGuildStatus = async ({ interaction, nessie }: any) => {
       await statusLogChannel.send({ embeds: [statusLogEmbed] });
     }
   } catch (error) {
-    sendErrorLog({ error, interaction });
+    sendErrorLog({ error, interaction, customTitle: 'Status Stop Error' });
   } finally {
     // sendMixpanelEvent({
     //   user: interaction.user,

--- a/src/commands/status/stop/index.ts
+++ b/src/commands/status/stop/index.ts
@@ -4,13 +4,11 @@ import {
   checkIfUserHasManageServer,
   checkMissingBotPermissions,
   codeBlock,
-  generateErrorEmbed,
   sendErrorLog,
   sendMissingAllPermissionsError,
   sendMissingBotPermissionsError,
   sendMissingUserPermissionError,
 } from '../../../utils/helpers';
-import { v4 as uuidV4 } from 'uuid';
 
 /**
  * Handler for when a user initiates the /status stop command

--- a/src/commands/status/stop/index.ts
+++ b/src/commands/status/stop/index.ts
@@ -68,7 +68,7 @@ export const sendStopInteraction = async ({ interaction }: any) => {
  * Handler for when a user clicks the cancel button of /status stop
  * Pretty straightforward; we just edit the initial message with a cancel message similar to the cancel start handler
  */
-export const _cancelStatusStop = async ({ interaction, nessie }: any) => {
+export const _cancelStatusStop = async ({ interaction }: any) => {
   const embed = {
     description: 'Cancelled automated map status deletion',
     color: 16711680,
@@ -77,11 +77,7 @@ export const _cancelStatusStop = async ({ interaction, nessie }: any) => {
     await interaction.deferUpdate();
     await interaction.message.edit({ embeds: [embed], components: [] });
   } catch (error) {
-    const uuid = uuidV4();
-    const type = 'Status Stop Cancel';
-    const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
-    await interaction.editReply({ embeds: errorEmbed, components: [] });
-    await sendErrorLog({ nessie, error, interaction, type, uuid });
+    sendErrorLog({ error, interaction });
   } finally {
     // sendMixpanelEvent({
     //   user: interaction.user,
@@ -145,11 +141,7 @@ export const deleteGuildStatus = async ({ interaction, nessie }: any) => {
       await statusLogChannel.send({ embeds: [statusLogEmbed] });
     }
   } catch (error) {
-    const uuid = uuidV4();
-    const type = 'Status Stop Button';
-    const errorEmbed = await generateErrorEmbed(error, uuid, nessie);
-    await interaction.message.edit({ embeds: errorEmbed, components: [] });
-    await sendErrorLog({ nessie, error, interaction, type, uuid });
+    sendErrorLog({ error, interaction });
   } finally {
     // sendMixpanelEvent({
     //   user: interaction.user,

--- a/src/events/guildCreate/index.ts
+++ b/src/events/guildCreate/index.ts
@@ -3,7 +3,7 @@ import { EventModule } from '../events';
 import { isEmpty } from 'lodash';
 import { Guild, WebhookClient } from 'discord.js';
 import { DATABASE_CONFIG, GUILD_NOTIFICATION_WEBHOOK_URL } from '../../config/environment';
-import { serverNotificationEmbed } from '../../utils/helpers';
+import { sendErrorLog, serverNotificationEmbed } from '../../utils/helpers';
 import { nessieLogo } from '../../utils/constants';
 
 export default function ({ nessie }: EventModule) {
@@ -19,8 +19,8 @@ export default function ({ nessie }: EventModule) {
           avatarURL: nessieLogo,
         });
       }
-    } catch (e) {
-      console.log(e); // Add proper handling
+    } catch (error) {
+      sendErrorLog({ error });
     }
   });
 }

--- a/src/events/guildDelete/index.ts
+++ b/src/events/guildDelete/index.ts
@@ -2,7 +2,7 @@ import { DATABASE_CONFIG, GUILD_NOTIFICATION_WEBHOOK_URL } from '../../config/en
 import { deleteGuild } from '../../services/database';
 import { EventModule } from '../events';
 import { isEmpty } from 'lodash';
-import { serverNotificationEmbed } from '../../utils/helpers';
+import { sendErrorLog, serverNotificationEmbed } from '../../utils/helpers';
 import { Guild, WebhookClient } from 'discord.js';
 import { nessieLogo } from '../../utils/constants';
 
@@ -19,8 +19,8 @@ export default function ({ nessie }: EventModule) {
           avatarURL: nessieLogo,
         });
       }
-    } catch (e) {
-      console.log(e); // Add proper handling
+    } catch (error) {
+      sendErrorLog({ error });
     }
   });
 }

--- a/src/events/interactionCreate/index.ts
+++ b/src/events/interactionCreate/index.ts
@@ -5,101 +5,105 @@ import {
   goToConfirmStatus,
 } from '../../commands/status/start';
 import { deleteGuildStatus, _cancelStatusStop } from '../../commands/status/stop';
-import { codeBlock } from '../../utils/helpers';
+import { codeBlock, sendErrorLog } from '../../utils/helpers';
 import { EventModule } from '../events';
 
 export default function ({ nessie, mixpanel, appCommands }: EventModule) {
   nessie.on('interactionCreate', async (interaction) => {
-    if (!interaction.inGuild() || !appCommands) return;
+    try {
+      if (!interaction.inGuild() || !appCommands) return;
 
-    if (interaction.isCommand()) {
-      const { commandName } = interaction;
-      const command = appCommands.find((command) => command.data.name === commandName);
-      command && (await command.execute({ interaction, app: nessie, appCommands }));
-      // mixpanel &&
-      // 	sendCommandEvent({
-      // 		user: interaction.user,
-      // 		channel: interaction.channel,
-      // 		guild: interaction.guild,
-      // 		command: commandName,
-      // 		client: mixpanel,
-      // 	});
-    }
-    /**
-     * Since components are also interactions, any user inputs from it go through this listener too
-     * This does prove to be a hassle code readability wise as the handlers for these interactions are now detached from their own files
-     * Tried to make it less ugly tho and house the implementations inside functions and call them here
-     * Will still have to check the customId for each of the buttons here though
-     */
-    if (interaction.isButton()) {
+      if (interaction.isCommand()) {
+        const { commandName } = interaction;
+        const command = appCommands.find((command) => command.data.name === commandName);
+        command && (await command.execute({ interaction, app: nessie, appCommands }));
+        // mixpanel &&
+        // 	sendCommandEvent({
+        // 		user: interaction.user,
+        // 		channel: interaction.channel,
+        // 		guild: interaction.guild,
+        // 		command: commandName,
+        // 		client: mixpanel,
+        // 	});
+      }
       /**
-       * Fancy handling of when the wrong user tries to use someone else's interactions
-       * Fortunately discord has the original interaction attached to the current one's payload which makes this straightforward
-       * We'll send the wrong user an ephemeral reply indicating that they can only use their own commands
+       * Since components are also interactions, any user inputs from it go through this listener too
+       * This does prove to be a hassle code readability wise as the handlers for these interactions are now detached from their own files
+       * Tried to make it less ugly tho and house the implementations inside functions and call them here
+       * Will still have to check the customId for each of the buttons here though
        */
-      if (
-        interaction.message.interaction &&
-        interaction.user.id !== interaction.message.interaction.user.id
-      ) {
-        const wrongUserEmbed = {
-          description: `Oops looks like that interaction wasn't meant for you! Nessie can only properly interact with your own commands.\n\nTo check what Nessie can do, type ${codeBlock(
-            '/help'
-          )}!`,
-          color: 16711680,
-        };
-        await interaction.deferReply({ ephemeral: true });
-        // sendMixpanelEvent({
-        //   user: interaction.user,
-        //   channel: interaction.channel,
-        //   guild: interaction.guild,
-        //   client: mixpanel,
-        //   arguments: interaction.customId,
-        //   customEventName: 'Click wrong user button',
-        // });
-        interaction.editReply({ embeds: [wrongUserEmbed] });
+      if (interaction.isButton()) {
+        /**
+         * Fancy handling of when the wrong user tries to use someone else's interactions
+         * Fortunately discord has the original interaction attached to the current one's payload which makes this straightforward
+         * We'll send the wrong user an ephemeral reply indicating that they can only use their own commands
+         */
+        if (
+          interaction.message.interaction &&
+          interaction.user.id !== interaction.message.interaction.user.id
+        ) {
+          const wrongUserEmbed = {
+            description: `Oops looks like that interaction wasn't meant for you! Nessie can only properly interact with your own commands.\n\nTo check what Nessie can do, type ${codeBlock(
+              '/help'
+            )}!`,
+            color: 16711680,
+          };
+          await interaction.deferReply({ ephemeral: true });
+          // sendMixpanelEvent({
+          //   user: interaction.user,
+          //   channel: interaction.channel,
+          //   guild: interaction.guild,
+          //   client: mixpanel,
+          //   arguments: interaction.customId,
+          //   customEventName: 'Click wrong user button',
+          // });
+          interaction.editReply({ embeds: [wrongUserEmbed] });
+        }
+        switch (interaction.customId) {
+          case 'statusStart__backButton':
+            goBackToGameModeSelection({ interaction, nessie, mixpanel });
+            return;
+          case 'statusStart__cancelButton':
+            _cancelStatusStart({ interaction, nessie, mixpanel });
+          case 'statusStop__cancelButton':
+            _cancelStatusStop({ interaction, nessie, mixpanel });
+          case 'statusStop__stopButton':
+            deleteGuildStatus({ interaction, nessie, mixpanel });
+          default:
+            if (interaction.customId.includes('statusStart__confirmButton')) {
+              createStatus({ interaction, nessie, mixpanel });
+            }
+        }
       }
-      switch (interaction.customId) {
-        case 'statusStart__backButton':
-          goBackToGameModeSelection({ interaction, nessie, mixpanel });
-          return;
-        case 'statusStart__cancelButton':
-          _cancelStatusStart({ interaction, nessie, mixpanel });
-        case 'statusStop__cancelButton':
-          _cancelStatusStop({ interaction, nessie, mixpanel });
-        case 'statusStop__stopButton':
-          deleteGuildStatus({ interaction, nessie, mixpanel });
-        default:
-          if (interaction.customId.includes('statusStart__confirmButton')) {
-            createStatus({ interaction, nessie, mixpanel });
-          }
+      if (interaction.isSelectMenu()) {
+        if (
+          interaction.message.interaction &&
+          interaction.user.id !== interaction.message.interaction.user.id
+        ) {
+          const wrongUserEmbed = {
+            description: `Oops looks like that interaction wasn't meant for you! Nessie can only properly interact with your own commands.\n\nTo check what Nessie can do, type ${codeBlock(
+              '/help'
+            )}!`,
+            color: 16711680,
+          };
+          await interaction.deferReply({ ephemeral: true });
+          // sendMixpanelEvent({
+          //   user: interaction.user,
+          //   channel: interaction.channel,
+          //   guild: interaction.guild,
+          //   client: mixpanel,
+          //   arguments: interaction.customId,
+          //   customEventName: 'Click wrong user select menu',
+          // });
+          interaction.editReply({ embeds: [wrongUserEmbed] });
+        }
+        switch (interaction.customId) {
+          case 'statusStart__gameModeDropdown':
+            goToConfirmStatus({ interaction, nessie, mixpanel });
+        }
       }
-    }
-    if (interaction.isSelectMenu()) {
-      if (
-        interaction.message.interaction &&
-        interaction.user.id !== interaction.message.interaction.user.id
-      ) {
-        const wrongUserEmbed = {
-          description: `Oops looks like that interaction wasn't meant for you! Nessie can only properly interact with your own commands.\n\nTo check what Nessie can do, type ${codeBlock(
-            '/help'
-          )}!`,
-          color: 16711680,
-        };
-        await interaction.deferReply({ ephemeral: true });
-        // sendMixpanelEvent({
-        //   user: interaction.user,
-        //   channel: interaction.channel,
-        //   guild: interaction.guild,
-        //   client: mixpanel,
-        //   arguments: interaction.customId,
-        //   customEventName: 'Click wrong user select menu',
-        // });
-        interaction.editReply({ embeds: [wrongUserEmbed] });
-      }
-      switch (interaction.customId) {
-        case 'statusStart__gameModeDropdown':
-          goToConfirmStatus({ interaction, nessie, mixpanel });
-      }
+    } catch (error) {
+      sendErrorLog({ error });
     }
   });
 }

--- a/src/events/rateLimit/index.ts
+++ b/src/events/rateLimit/index.ts
@@ -1,16 +1,13 @@
 import { sendErrorLog } from '../../utils/helpers';
 import { EventModule } from '../events';
-import { v4 as uuidV4 } from 'uuid';
 
 export default function ({ nessie }: EventModule) {
   nessie.on('rateLimit', async (data) => {
-    const uuid = uuidV4();
-    const type = 'Rate Limited';
     const error = {
       message: data
         ? `\n• Timeout: ${data.timeout}ms\n• Limit: ${data.limit}\n• Method: ${data.method}\n• Path: ${data.path}\n• Route: ${data.route}\n• Global: ${data.global}`
         : 'Unexpected rate limit error',
     };
-    await sendErrorLog({ nessie, error, type, uuid, ping: true });
+    sendErrorLog({ error });
   });
 }

--- a/src/events/rateLimit/index.ts
+++ b/src/events/rateLimit/index.ts
@@ -3,11 +3,15 @@ import { EventModule } from '../events';
 
 export default function ({ nessie }: EventModule) {
   nessie.on('rateLimit', async (data) => {
-    const error = {
-      message: data
-        ? `\n• Timeout: ${data.timeout}ms\n• Limit: ${data.limit}\n• Method: ${data.method}\n• Path: ${data.path}\n• Route: ${data.route}\n• Global: ${data.global}`
-        : 'Unexpected rate limit error',
-    };
-    sendErrorLog({ error });
+    try {
+      const error = {
+        message: data
+          ? `\n• Timeout: ${data.timeout}ms\n• Limit: ${data.limit}\n• Method: ${data.method}\n• Path: ${data.path}\n• Route: ${data.route}\n• Global: ${data.global}`
+          : 'Unexpected rate limit error',
+      };
+      sendErrorLog({ error });
+    } catch (error) {
+      sendErrorLog({ error });
+    }
   });
 }

--- a/src/events/ready/index.ts
+++ b/src/events/ready/index.ts
@@ -80,8 +80,8 @@ export default function ({ nessie, appCommands }: EventModule) {
 
       const statusSchedule = scheduleStatus(nessie);
       statusSchedule.start();
-    } catch (e) {
-      console.log(e); //Add proper error handling
+    } catch (error) {
+      sendErrorLog({ error });
     }
   });
 }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -425,7 +425,7 @@ export const sendMissingBotPermissionsError = async ({ interaction, title }: any
     )}`,
     color: 16711680,
   };
-  return await interaction.editReply({ embeds: [embed], components: [] });
+  await interaction.editReply({ embeds: [embed], components: [] });
 };
 export const sendMissingUserPermissionError = async ({ interaction, title }: any) => {
   const embed = {
@@ -437,7 +437,7 @@ export const sendMissingUserPermissionError = async ({ interaction, title }: any
     )}`,
     color: 16711680,
   };
-  return await interaction.editReply({ embeds: [embed], components: [] });
+  interaction.editReply({ embeds: [embed], components: [] });
 };
 export const sendMissingAllPermissionsError = async ({ interaction, title }: any) => {
   const embed = {
@@ -447,7 +447,7 @@ export const sendMissingAllPermissionsError = async ({ interaction, title }: any
     )}`,
     color: 16711680,
   };
-  return await interaction.editReply({ embeds: [embed], components: [] });
+  await interaction.editReply({ embeds: [embed], components: [] });
 };
 
 export const sendBootNotification = async (app: Client) => {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -242,7 +242,6 @@ export const sendErrorLog = async ({
  * Same as above, only difference is the embed content
  */
 export const sendStatusErrorLog = async ({ nessie, uuid, error, status }: any) => {
-  const errorChannel = nessie.channels.cache.get('938441853542465548');
   const errorGuild = nessie.guilds.cache.get(status.guild_id);
   const errorEmbed = {
     title: 'Error | Status Scheduler Cycle',
@@ -271,7 +270,15 @@ export const sendStatusErrorLog = async ({ nessie, uuid, error, status }: any) =
       },
     ],
   };
-  await errorChannel.send({ embeds: [errorEmbed], content: '<@183444648360935424>' });
+  if (ERROR_NOTIFICATION_WEBHOOK_URL && !isEmpty(ERROR_NOTIFICATION_WEBHOOK_URL)) {
+    const notificationWebhook = new WebhookClient({ url: ERROR_NOTIFICATION_WEBHOOK_URL });
+    await notificationWebhook.send({
+      content: '<@183444648360935424>',
+      embeds: [errorEmbed],
+      username: 'Nessie Error Notification',
+      avatarURL: nessieLogo,
+    });
+  }
 };
 export const generateAnnouncementMessage = (prefix: any) => {
   return (

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -159,10 +159,12 @@ export const sendErrorLog = async ({
   error,
   interaction,
   option,
+  subCommand,
 }: {
   error: any;
   interaction?: CommandInteraction;
   option?: string | null;
+  subCommand?: string;
 }) => {
   console.error(error);
   const errorID = uuidV4();
@@ -178,7 +180,11 @@ export const sendErrorLog = async ({
   if (ERROR_NOTIFICATION_WEBHOOK_URL && !isEmpty(ERROR_NOTIFICATION_WEBHOOK_URL)) {
     const interactionChannel = interaction?.channel as GuildChannel | undefined;
     const notificationEmbed: any = {
-      title: interaction ? `Error | ${capitalize(interaction.commandName)} Command` : 'Error',
+      title: interaction
+        ? `Error | ${capitalize(interaction.commandName)}${
+            subCommand ? ` ${capitalize(subCommand)}` : ''
+          } Command`
+        : 'Error',
       color: getEmbedColor('#FF0000'),
       description: `uuid: ${errorID}\nError: ${
         error.message ? error.message : 'Unexpected Error'

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -5,6 +5,7 @@ import {
   CommandInteraction,
   Guild,
   GuildChannel,
+  SelectMenuInteraction,
   WebhookClient,
 } from 'discord.js';
 import {
@@ -160,11 +161,13 @@ export const sendErrorLog = async ({
   interaction,
   option,
   subCommand,
+  customTitle,
 }: {
   error: any;
-  interaction?: CommandInteraction;
+  interaction?: CommandInteraction | SelectMenuInteraction;
   option?: string | null;
   subCommand?: string;
+  customTitle?: string;
 }) => {
   console.error(error);
   const errorID = uuidV4();
@@ -175,13 +178,15 @@ export const sendErrorLog = async ({
       }\nError ID: ${inlineCode(errorID)}`,
       color: getEmbedColor('#FF0000'),
     };
-    await interaction.editReply({ embeds: [errorEmbed] });
+    await interaction.editReply({ embeds: [errorEmbed], components: [] });
   }
   if (ERROR_NOTIFICATION_WEBHOOK_URL && !isEmpty(ERROR_NOTIFICATION_WEBHOOK_URL)) {
     const interactionChannel = interaction?.channel as GuildChannel | undefined;
     const notificationEmbed: any = {
-      title: interaction
-        ? `Error | ${capitalize(interaction.commandName)}${
+      title: customTitle
+        ? `Error | ${customTitle}`
+        : interaction
+        ? `Error | ${interaction.isCommand() ? capitalize(interaction.commandName) : ''}${
             subCommand ? ` ${capitalize(subCommand)}` : ''
           } Command`
         : 'Error',

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -158,9 +158,11 @@ export const generateErrorEmbed = async (error: any, uuid: any, nessie: any) => 
 export const sendErrorLog = async ({
   error,
   interaction,
+  option,
 }: {
   error: any;
   interaction?: CommandInteraction;
+  option?: string | null;
 }) => {
   console.error(error);
   const errorID = uuidV4();
@@ -178,7 +180,9 @@ export const sendErrorLog = async ({
     const notificationEmbed: any = {
       title: interaction ? `Error | ${capitalize(interaction.commandName)} Command` : 'Error',
       color: getEmbedColor('#FF0000'),
-      description: `uuid: ${errorID}\nError: ${error.message ? error.message : 'Unexpected Error'}`,
+      description: `uuid: ${errorID}\nError: ${
+        error.message ? error.message : 'Unexpected Error'
+      }\n${option ? `Option: ${option}` : ''}`,
       fields: interaction
         ? [
             {
@@ -217,8 +221,8 @@ export const sendErrorLog = async ({
     const notificationWebhook = new WebhookClient({ url: ERROR_NOTIFICATION_WEBHOOK_URL });
     await notificationWebhook.send({
       embeds: [notificationEmbed],
-      username: 'My App Error Notification',
-      avatarURL: '',
+      username: 'Nessie Error Notification',
+      avatarURL: nessieLogo,
     });
   }
 };


### PR DESCRIPTION
#### Context
The error handling that I normally use initially originated from Nessie; previously the only error handling I did was console logging it smh. Since then it has expanded albeit it hasn't differ that much from how it looks like here. The main difference is that it's more general and uses webhooks instead of sending messages.

Again nothing new here, just some cleanups and migrations

![image](https://github.com/vexuas/nessie/assets/42207245/c1cac4d7-e9e1-41bb-9e5c-0885687fdf76)

#### Change
- Refactor error handler
- Update existing error handling for commands, buttons and select menus
- Add error handling for event listeners
