### PR TITLE
Remove arenas from status setup

### DIFF
--- a/src/commands/status/help/index.ts
+++ b/src/commands/status/help/index.ts
@@ -34,10 +34,10 @@ export const sendHelpInteraction = async ({
   try {
     const embedInformation = {
       title: 'Information',
-      description: `This command will send automatic updates of Apex Legends Map Rotations. You will be able to choose which game modes, *Battle Royale or/and Arenas*, to get updates for both pubs and ranked.\n\nDepending on what you choose, Nessie will create a set of:\n• ${inlineCode(
+      description: `This command will send automatic updates of Apex Legends Map Rotations. Since Arenas are no longer in the game, you will only be able to choose the *Battle Royale* game mode to get updates for both pubs and ranked.\n\nAfter choosing, Nessie will create a set of:\n• ${inlineCode(
         'Category Channel'
-      )}\n• ${inlineCode('Text Channel(s)')}\n• ${inlineCode(
-        'Webhook(s)'
+      )}\n• ${inlineCode('Text Channel')}\n• ${inlineCode(
+        'Webhook'
       )}\nUpdates will then be sent in these channels **every 15 minutes**\n\n`,
       color: 3447003,
     };

--- a/src/commands/status/start/index.ts
+++ b/src/commands/status/start/index.ts
@@ -86,7 +86,9 @@ const generateGameModeSelectionMessage = (status?: StatusRecord | null) => {
       title: 'Status | Start',
       description: `There's currently an existing automated map status active in:${
         status.br_channel_id ? `\n• <#${status.br_channel_id}>` : ''
-      }\n\nCreated at ${status.created_at} by ${status.created_by}`,
+      }${status.arenas_channel_id ? `\n• <#${status.arenas_channel_id}>` : ''}\n\nCreated at ${
+        status.created_at
+      } by ${status.created_by}`,
       color: 3447003,
     };
   }

--- a/src/commands/status/stop/index.ts
+++ b/src/commands/status/stop/index.ts
@@ -124,6 +124,7 @@ export const _cancelStatusStop = async ({
  * - Edits initial message with a success message
  *
  * We don't need to delete the webhooks as they'll be automatically deleted along with its channels
+ * TODO: Remove arenas code once we cleanup arenas in our database
  */
 export const deleteGuildStatus = async ({
   interaction,


### PR DESCRIPTION
#### Context
Arenas are no longer in the game so there's really no reason to let users be able to select arenas when setting up statuses. I'm not exactly sure when the API will remove arenas support but it's probably best we start cleaning up arenas code. There could be a possibility that it'll come back but we can tackle that again when it does.

I was initially thinking of cleaning up arenas statuses from discord servers along with this change too. Tho after checking the data, I was pretty surprised like 25% of the active statuses in production have arenas in them. Gonna keep the active arenas in the database for now and just prevent new ones from getting created

![image](https://github.com/vexuas/nessie/assets/42207245/7eff03e7-65f2-4c99-b722-97ec376429ea)
![image](https://github.com/vexuas/nessie/assets/42207245/f4c037db-f4c1-4779-9c57-888323f33c0e)
![image](https://github.com/vexuas/nessie/assets/42207245/17a9efbc-db96-4f41-a597-71386c91cd9b)

#### Change
- Remove arenas from status help description
- Remove arenas from status setup