### PR TITLE
Lower status interval to 5 minutes

### DIFF
--- a/src/commands/about/index.ts
+++ b/src/commands/about/index.ts
@@ -9,7 +9,7 @@ import { nessieLogo } from '../../utils/constants';
 export const generateAboutEmbed = (app?: Client): APIEmbed => {
   const embed = {
     title: 'Info',
-    description: `Hi there! I’m Nessie and I provide an easy way to get status updates of Map Rotations in Apex Legends! Hope that you can find me useful (◕ᴗ◕✿)\n\nTry out my new beta feature: **Automatic Map Updates**! To check out what it is, use \`/status help\`!\n\nAll my data is extracted from the great works of ${hyperlink(
+    description: `Hi there! I’m Nessie and I provide an easy way to get status updates of Map Rotations in Apex Legends! Hope that you can find me useful (◕ᴗ◕✿)\n\nTry out my cool feature: **Automatic Map Updates**! To check out what it is, use \`/status help\`!\n\nAll my data is extracted from the great works of ${hyperlink(
       'Apex Legends API',
       'https://apexlegendsapi.com'
     )}. Go support them too, it’s a cool project!`,

--- a/src/commands/status/help/index.ts
+++ b/src/commands/status/help/index.ts
@@ -38,7 +38,7 @@ export const sendHelpInteraction = async ({
         'Category Channel'
       )}\n• ${inlineCode('Text Channel')}\n• ${inlineCode(
         'Webhook'
-      )}\nUpdates will then be sent in these channels **every 15 minutes**\n\n`,
+      )}\nUpdates will then be sent in these channels **every 5 minutes**\n\n`,
       color: 3447003,
     };
     const embedPermissions = {

--- a/src/commands/status/start/index.ts
+++ b/src/commands/status/start/index.ts
@@ -470,7 +470,7 @@ export const createStatus = async ({
 };
 /**
  * Handler in charge in updating map data in the relevant status channels
- * Uses the Scheduler class to create a cron job that fires every 10th second of every 15 minutes (0:5:10, 0:10:10, 0:15:10, etc)
+ * Uses the Scheduler class to create a cron job that fires every 10th second of every 5 minutes (0:5:10, 0:10:10, 0:15:10, etc)
  * When the cron job is executed, we then:
  * - Call the getAllStatus handler to get every existing status in our database
  * - Upon finishing the query, we then call the API for the current rotation data
@@ -485,7 +485,7 @@ export const createStatus = async ({
  * More detailed explanation here: https://shizuka.notion.site/Spike-on-Status-Time-Taken-0c26284152f04a169c546fe7b582a658
  */
 export const scheduleStatus = (nessie: Client) => {
-  return new Scheduler('5 */15 * * * *', async () => {
+  return new Scheduler('5 */5 * * * *', async () => {
     errorNotification.count = 0;
     errorNotification.message = '';
     const startTime = Date.now();

--- a/src/commands/status/start/index.ts
+++ b/src/commands/status/start/index.ts
@@ -144,7 +144,7 @@ const generateConfirmStatusMessage = ({
       'Apex Legends Map Status'
     )}\n${
       isBattleRoyaleSelected ? `• ${inlineCode('#apex-battle-royale')}\n` : ''
-    }• Webhook for each text channel\n\nUpdates get sent to these channels **every 15 minutes**`,
+    }• Webhook for each text channel\n\nUpdates get sent to these channels **every 5 minutes**`,
     color: 3447003,
   };
   return {
@@ -164,7 +164,7 @@ const generateBattleRoyaleStatusEmbeds = (data: MapRotationAPIObject) => {
   const battleRoyaleRankedEmbed = generateRankedEmbed(data.ranked);
   const informationEmbed = {
     description:
-      '**Updates occur every 15 minutes**. This feature is currently in beta! For feedback, bug reports or news updates, feel free to visit the [support server](https://discord.gg/FyxVrAbRAd)!',
+      '**Updates occur every 5 minutes**. This feature is currently in beta! For feedback, bug reports or news updates, feel free to visit the [support server](https://discord.gg/FyxVrAbRAd)!',
     color: 3447003,
     timestamp: new Date(Date.now()).toISOString(),
     footer: {
@@ -184,7 +184,7 @@ const generateArenasStatusEmbeds = (data: MapRotationAPIObject) => {
   const arenasRankedEmbed = generateRankedEmbed(data.arenasRanked, 'Arenas');
   const informationEmbed = {
     description:
-      '**Updates occur every 15 minutes**. This feature is currently in beta! For feedback, bug reports or news updates, feel free to visit the [support server](https://discord.gg/FyxVrAbRAd)!',
+      '**Updates occur every 5 minutes**. This feature is currently in beta! For feedback, bug reports or news updates, feel free to visit the [support server](https://discord.gg/FyxVrAbRAd)!',
     color: 3447003,
     timestamp: new Date(Date.now()).toISOString(),
     footer: {

--- a/src/commands/status/start/index.ts
+++ b/src/commands/status/start/index.ts
@@ -163,8 +163,7 @@ const generateBattleRoyaleStatusEmbeds = (data: MapRotationAPIObject) => {
   const battleRoyalePubsEmbed = generatePubsEmbed(data.battle_royale);
   const battleRoyaleRankedEmbed = generateRankedEmbed(data.ranked);
   const informationEmbed = {
-    description:
-      '**Updates occur every 5 minutes**. This feature is currently in beta! For feedback, bug reports or news updates, feel free to visit the [support server](https://discord.gg/FyxVrAbRAd)!',
+    description: '**Updates occur every 5 minutes**',
     color: 3447003,
     timestamp: new Date(Date.now()).toISOString(),
     footer: {
@@ -183,8 +182,7 @@ const generateArenasStatusEmbeds = (data: MapRotationAPIObject) => {
   const arenasPubsEmbed = generatePubsEmbed(data.arenas, 'Arenas');
   const arenasRankedEmbed = generateRankedEmbed(data.arenasRanked, 'Arenas');
   const informationEmbed = {
-    description:
-      '**Updates occur every 5 minutes**. This feature is currently in beta! For feedback, bug reports or news updates, feel free to visit the [support server](https://discord.gg/FyxVrAbRAd)!',
+    description: '**Updates occur every 5 minutes**',
     color: 3447003,
     timestamp: new Date(Date.now()).toISOString(),
     footer: {
@@ -518,8 +516,7 @@ export const scheduleStatus = (nessie: Client) => {
       const uuid = uuidV4();
       const errorEmbed: APIEmbed[] = [
         {
-          description:
-            '**Updates occur every 15 minutes**. This feature is currently in beta! For feedback, bug reports or news updates, feel free to visit the [support server](https://discord.gg/FyxVrAbRAd)!',
+          description: '**Updates occur every 5 minutes**',
           color: 3447003,
           timestamp: new Date(Date.now()).toISOString(),
           footer: {


### PR DESCRIPTION
#### Context
I made the status updates every 15 minutes before since I was hesitant on getting rate limited. I did do some extensive testing before and webhooks within a server have their own rate limits so this wasn't really an issue. I'm putting it down to 5 minutes for now and monitor it. If it's good enough, maybe every minute can be an option

![image](https://github.com/vexuas/nessie/assets/42207245/820ec74a-d156-441a-af8c-d42216951a09)

#### Change
- Make cron interval every 5 minutes
- Remove beta description
