### PR TITLE
Delete status when bot leaves guild

### DIFF
--- a/src/events/guildDelete/index.ts
+++ b/src/events/guildDelete/index.ts
@@ -1,5 +1,5 @@
 import { DATABASE_CONFIG, GUILD_NOTIFICATION_WEBHOOK_URL } from '../../config/environment';
-import { deleteGuild } from '../../services/database';
+import { deleteGuild, deleteStatus } from '../../services/database';
 import { EventModule } from '../events';
 import { isEmpty } from 'lodash';
 import { sendErrorLog, serverNotificationEmbed } from '../../utils/helpers';
@@ -9,7 +9,10 @@ import { nessieLogo } from '../../utils/constants';
 export default function ({ app }: EventModule) {
   app.on('guildDelete', async (guild: Guild) => {
     try {
-      DATABASE_CONFIG && (await deleteGuild(guild));
+      if (DATABASE_CONFIG) {
+        await deleteGuild(guild);
+        await deleteStatus(guild.id);
+      }
       if (GUILD_NOTIFICATION_WEBHOOK_URL && !isEmpty(GUILD_NOTIFICATION_WEBHOOK_URL)) {
         const embed = await serverNotificationEmbed({ app, guild, type: 'leave' });
         const notificationWebhook = new WebhookClient({ url: GUILD_NOTIFICATION_WEBHOOK_URL });

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -217,7 +217,7 @@ export async function deleteStatus(guildId: string): Promise<StatusRecord | unde
       const getStatusQuery = 'SELECT * FROM Status WHERE guild_id = ($1)';
       const status: QueryResult<StatusRecord> = await client.query(getStatusQuery, [guildId]);
       const deleteStatusQuery = 'DELETE FROM Status WHERE guild_id = ($1)';
-      await client.query(deleteStatusQuery, [guildId]);
+      status.rows.length > 0 && (await client.query(deleteStatusQuery, [guildId]));
       await client.query('COMMIT');
       return status.rows.length > 0 ? status.rows[0] : null;
     } catch (error) {

--- a/src/services/database.ts
+++ b/src/services/database.ts
@@ -1,5 +1,6 @@
 import { Collection, Guild } from 'discord.js';
 import { Pool, QueryResult } from 'pg';
+import { sendErrorLog } from '../utils/helpers';
 const { DATABASE_CONFIG } = require('../config/environment');
 
 const pool = DATABASE_CONFIG ? new Pool(DATABASE_CONFIG) : null;
@@ -42,7 +43,7 @@ export async function createGuildTable() {
       await client.query('COMMIT');
     } catch (error) {
       await client.query('ROLLBACK');
-      console.log(error); //TODO: Add error handling
+      sendErrorLog({ error });
     } finally {
       client.release();
     }
@@ -59,7 +60,7 @@ export async function getGuilds(): Promise<QueryResult<GuildRecord> | undefined>
       return allGuilds;
     } catch (error) {
       await client.query('ROLLBACK');
-      console.log(error); //TODO: Add error handling
+      sendErrorLog({ error });
     } finally {
       client.release();
     }
@@ -76,7 +77,7 @@ export async function populateGuilds(existingGuilds: Collection<string, Guild>) 
       }
     });
   } catch (error) {
-    console.log(error); //TODO: Add error handling
+    sendErrorLog({ error });
   }
 }
 export async function insertNewGuild(newGuild: Guild) {
@@ -98,7 +99,7 @@ export async function insertNewGuild(newGuild: Guild) {
       await client.query('COMMIT');
     } catch (error) {
       await client.query('ROLLBACK');
-      console.log(error); //TODO: Add error handling
+      sendErrorLog({ error });
     } finally {
       client.release();
     }
@@ -115,7 +116,7 @@ export async function deleteGuild(existingGuild: Guild) {
       await client.query('COMMIT');
     } catch (error) {
       await client.query('ROLLBACK');
-      console.log(error); //TODO: Add error handling
+      sendErrorLog({ error });
     } finally {
       client.release();
     }
@@ -133,7 +134,7 @@ export async function createStatusTable() {
       await client.query('COMMIT');
     } catch (error) {
       await client.query('ROLLBACK');
-      console.log(error); //TODO: Add error handling
+      sendErrorLog({ error });
     } finally {
       client.release();
     }
@@ -168,7 +169,7 @@ export async function insertNewStatus(status: any) {
       await client.query('COMMIT');
     } catch (error) {
       await client.query('ROLLBACK');
-      console.log(error); //TODO: Add error handling
+      sendErrorLog({ error });
     } finally {
       client.release();
     }
@@ -185,7 +186,7 @@ export async function getStatus(guildId: string): Promise<StatusRecord | undefin
       return status.rows.length > 0 ? status.rows[0] : null;
     } catch (error) {
       await client.query('ROLLBACK');
-      console.log(error); //TODO: Add error handling
+      sendErrorLog({ error });
     } finally {
       client.release();
     }
@@ -202,7 +203,7 @@ export async function getAllStatus(): Promise<StatusRecord[] | undefined> {
       return allStatus.rows;
     } catch (error) {
       await client.query('ROLLBACK');
-      console.log(error); //TODO: Add error handling
+      sendErrorLog({ error });
     } finally {
       client.release();
     }
@@ -222,7 +223,7 @@ export async function deleteStatus(guildId: string): Promise<StatusRecord | unde
       return status.rows.length > 0 ? status.rows[0] : null;
     } catch (error) {
       await client.query('ROLLBACK');
-      console.log(error); //TODO: Add error handling
+      sendErrorLog({ error });
     } finally {
       client.release();
     }


### PR DESCRIPTION
#### Context
Got an error last night that coincided with a server removing nessie. Took a look and apparently I forgot to re-add the status deletion when nessie is removed from a server. I've added it back now with some guardrails.

Noticed I haven't added any error handling for the database handlers so sneaked in that change too

![image](https://github.com/vexuas/nessie/assets/42207245/edd4e733-59b0-4075-b22b-1d9a4c6d224d)

#### Change
- Delete status on guildDelete
- Only delete status if status exists
- Add error handling for database handlers