### PR TITLE
Add current map remaining time to game status

### DIFF
--- a/src/events/ready/index.ts
+++ b/src/events/ready/index.ts
@@ -1,10 +1,10 @@
-import { REST, Routes, TextChannel } from 'discord.js';
+import { REST, Routes } from 'discord.js';
 import { AppCommand } from '../../commands/commands';
 import { scheduleStatus } from '../../commands/status/start';
 import { BOT_ID, BOT_TOKEN, DATABASE_CONFIG, ENV, GUILD_ID } from '../../config/environment';
 import { getBattleRoyalePubs } from '../../services/adapters';
 import { createGuildTable, createStatusTable, populateGuilds } from '../../services/database';
-import { sendBootNotification, sendErrorLog, sendHealthLog } from '../../utils/helpers';
+import { sendBootNotification, sendErrorLog } from '../../utils/helpers';
 import { EventModule } from '../events';
 
 const rest = new REST({ version: '9' }).setToken(BOT_TOKEN);
@@ -32,9 +32,8 @@ const registerApplicationCommands = async (commands?: AppCommand[]) => {
   }
 };
 
-const setCurrentMapStatus = (data: any, channel: any, nessie: any) => {
+const setCurrentMapStatus = (data: any, nessie: any) => {
   const fiveSecondsBuffer = 5000;
-  let currentBrPubsData = data;
   let currentTimer = data.current.remainingSecs * 1000 + fiveSecondsBuffer;
   const intervalRequest = async () => {
     try {
@@ -45,11 +44,8 @@ const setCurrentMapStatus = (data: any, channel: any, nessie: any) => {
        * Not sure why this is happening so just adding a notification when this happens again
        * Don't really want to add extra code for now, if it happens again then i'll fix it
        */
-      const isAccurate = currentBrPubsData.next.code === updatedBrPubsData.current.code;
-      currentBrPubsData = updatedBrPubsData;
       currentTimer = updatedBrPubsData.current.remainingSecs * 1000 + fiveSecondsBuffer;
       nessie.user.setActivity(updatedBrPubsData.current.map);
-      sendHealthLog(updatedBrPubsData, channel, isAccurate);
       setTimeout(intervalRequest, currentTimer);
     } catch (error) {
       sendErrorLog({ error });
@@ -69,12 +65,9 @@ export default function ({ app, appCommands }: EventModule) {
       }
       await sendBootNotification(app);
 
-      //TODO: See if we even need the health log
-      const logChannel = app.channels.cache.get('899620845436141609') as TextChannel | undefined;
       const brPubsData = await getBattleRoyalePubs();
       app.user && app.user.setActivity(brPubsData.current.map);
-      sendHealthLog(brPubsData, logChannel, true);
-      setCurrentMapStatus(brPubsData, logChannel, app);
+      setCurrentMapStatus(brPubsData, app);
 
       const statusSchedule = scheduleStatus(app);
       statusSchedule.start();

--- a/src/events/ready/index.ts
+++ b/src/events/ready/index.ts
@@ -32,6 +32,12 @@ const registerApplicationCommands = async (commands?: AppCommand[]) => {
     sendErrorLog({ error });
   }
 };
+/**
+ * Uses a cron job to set the current map and its remaining time as a game status for Nessie
+ * Thought of caching the current data but opted to just request for the data everytime the job triggers
+ * The API is free(for now) and rate limits are at 1req/s so this should be fine
+ * That being said since status already has a cron job at the 5th sec of the hour, I'm setting this up at the 10th sec
+ */
 const scheduleSetCurrentMapGameStatus = (app: Client) => {
   return new Scheduler('10 */1 * * * *', async () => {
     try {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -12,7 +12,6 @@ import {
   PermissionFlagsBits,
   ButtonInteraction,
   GuildMember,
-  TextChannel,
 } from 'discord.js';
 import {
   BOOT_NOTIFICATION_CHANNEL_ID,
@@ -32,60 +31,7 @@ import {
 } from '../schemas/mapRotation';
 import { Mixpanel } from 'mixpanel';
 import { sendAnalyticsEvent } from '../services/analytics';
-//----------
-/**
- * Function to send health status so that I can monitor how the status update for br pub maps is doing
- * @data - br data object
- * @channel - log channel in Nessie's Canyon (#health: 899620845436141609)
- * @isAccurate - whether the data received is up-to-date
- * TODO: Revisit if this is necessary
- */
-export const sendHealthLog = (
-  data: MapRotationBattleRoyaleSchema,
-  channel: TextChannel | undefined,
-  isAccurate: boolean
-) => {
-  const utcStart = new Date(data.current.readableDate_start);
-  const sgtStart = new Date(utcStart.getTime() + 28800000);
-  const utcEnd = new Date(data.current.readableDate_end);
-  const sgtEnd = new Date(utcEnd.getTime() + 28800000);
 
-  const embed = {
-    title: 'Nessie | Status Health Log',
-    description: 'Requested data from API',
-    color: isAccurate ? 3066993 : 16776960,
-    thumbnail: {
-      url: nessieLogo,
-    },
-    fields: [
-      {
-        name: 'Current Map',
-        value: `${inlineCode(data.current.map)} - ${inlineCode(format(sgtStart, 'hh:mm:ss aa'))}`,
-      },
-      {
-        name: 'Next Map',
-        value: `${inlineCode(data.next.map)} - ${inlineCode(format(sgtEnd, 'hh:mm:ss aa'))}`,
-      },
-      {
-        name: 'Time left',
-        value: inlineCode(`${data.current.remainingTimer} | ${data.current.remainingSecs} secs`),
-      },
-      {
-        name: 'Requested At',
-        value: inlineCode(format(new Date(), 'hh:mm:ss aa, dd MMM yyyy')),
-      },
-      {
-        name: 'Accurate',
-        value: isAccurate ? 'Yes' : 'No',
-      },
-    ],
-  };
-  if (!channel) return;
-  isAccurate
-    ? channel.send({ embeds: [embed] })
-    : channel.send({ content: '<@183444648360935424>', embeds: [embed] });
-};
-//----------
 export const serverNotificationEmbed = async ({
   app,
   guild,


### PR DESCRIPTION
#### Context
We're already showing the current map as a game status for nessie. However it was just the map but not the remaining time it has. My reasoning behind this then was that people can just set up an automatic status. Don't really have strong feelings for it anymore so adding this as well

Previous implementation was more efficient in data retrieval as it only hits the API once the current map ends. I opted to create a cron job every minute for this new implementation since it's the easiest. This is fine for now as the API is free and we're not hitting any rate limits with this

![image](https://github.com/vexuas/nessie/assets/42207245/3c721de1-1f4a-43e5-8a19-5d07a05c5539)

#### Change
- Remove health log
- Create scheduler for map game status
