### PR TITLE
Only have game status for prod

### DIFF
--- a/src/events/ready/index.ts
+++ b/src/events/ready/index.ts
@@ -66,11 +66,11 @@ export default function ({ app, appCommands }: EventModule) {
       const statusSchedule = scheduleStatus(app);
       statusSchedule.start();
 
-      if (ENV === 'prod') {
+      if (ENV === 'dev') {
+        app.user && app.user.setActivity('Nessie Development');
+      } else {
         const mapGameStatusSchedule = scheduleSetCurrentMapGameStatus(app);
         mapGameStatusSchedule.start();
-      } else {
-        app.user && app.user.setActivity('Nessie Development');
       }
     } catch (error) {
       sendErrorLog({ error });

--- a/src/events/ready/index.ts
+++ b/src/events/ready/index.ts
@@ -69,6 +69,8 @@ export default function ({ app, appCommands }: EventModule) {
       if (ENV === 'prod') {
         const mapGameStatusSchedule = scheduleSetCurrentMapGameStatus(app);
         mapGameStatusSchedule.start();
+      } else {
+        app.user && app.user.setActivity('Nessie Development');
       }
     } catch (error) {
       sendErrorLog({ error });

--- a/src/events/ready/index.ts
+++ b/src/events/ready/index.ts
@@ -66,8 +66,10 @@ export default function ({ app, appCommands }: EventModule) {
       const statusSchedule = scheduleStatus(app);
       statusSchedule.start();
 
-      const mapGameStatusSchedule = scheduleSetCurrentMapGameStatus(app);
-      mapGameStatusSchedule.start();
+      if (ENV === 'prod') {
+        const mapGameStatusSchedule = scheduleSetCurrentMapGameStatus(app);
+        mapGameStatusSchedule.start();
+      }
     } catch (error) {
       sendErrorLog({ error });
     }


### PR DESCRIPTION
#### Context
Realised that if the game status is up in prod, we'll probably get rate limited if I have the test bot booted up at the same time. We only use one API key to access the api since the owner doesn't like giving away more than one for each user. To avoid this, the game status only works in prod now

It was bothering me that the test bot doesn't have any game status so added one that shows it's developing nessie lol

![image](https://github.com/vexuas/nessie/assets/42207245/7f36a966-6894-4664-b5db-6d87be1929d0)

#### Change
- Only start schedule for prod
- Add dev status
