### PR TITLE
Release/2023 07 13

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,30 @@
+# v2.0.4 (Thu Jul 13 2023)
+
+#### 🧪 Tests
+
+- Add workflow for jests [#161](https://github.com/vexuas/nessie/pull/161) ([@vexuas](https://github.com/vexuas))
+- Add jest tests [#160](https://github.com/vexuas/nessie/pull/160) ([@vexuas](https://github.com/vexuas))
+
+#### 🔧 Tweaks
+
+- Only have game status for prod [#164](https://github.com/vexuas/nessie/pull/164) ([@vexuas](https://github.com/vexuas))
+- Add current map remaining time to game status [#163](https://github.com/vexuas/nessie/pull/163) ([@vexuas](https://github.com/vexuas))
+
+#### 🏠 Internal
+
+- Release/2023 07 05 [#159](https://github.com/vexuas/nessie/pull/159) ([@vexuas](https://github.com/vexuas))
+
+#### 🔩 Dependency Updates
+
+- Bump semver from 6.3.0 to 6.3.1 [#162](https://github.com/vexuas/nessie/pull/162) ([@dependabot[bot]](https://github.com/dependabot[bot]))
+
+#### Authors: 2
+
+- [@dependabot[bot]](https://github.com/dependabot[bot])
+- Gabriel R ([@vexuas](https://github.com/vexuas))
+
+---
+
 # v2.0.3 (Wed Jul 05 2023)
 
 #### 🔧 Tweaks

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nessie",
-  "version": "2.0.3",
+  "version": "2.0.4",
   "description": "Apex Legends Map Rotation Discord Bot",
   "license": "MIT",
   "scripts": {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const BOT_VERSION = "2.0.3";export const BOT_UPDATED_AT = "05-Jul-2023"
+export const BOT_VERSION = "2.0.4";export const BOT_UPDATED_AT = "13-Jul-2023"


### PR DESCRIPTION
# v2.0.4 (Thu Jul 13 2023)

#### 🧪 Tests

- Add workflow for jests [#161](https://github.com/vexuas/nessie/pull/161) ([@vexuas](https://github.com/vexuas))
- Add jest tests [#160](https://github.com/vexuas/nessie/pull/160) ([@vexuas](https://github.com/vexuas))

#### 🔧 Tweaks

- Only have game status for prod [#164](https://github.com/vexuas/nessie/pull/164) ([@vexuas](https://github.com/vexuas))
- Add current map remaining time to game status [#163](https://github.com/vexuas/nessie/pull/163) ([@vexuas](https://github.com/vexuas))

#### 🏠 Internal

- Release/2023 07 05 [#159](https://github.com/vexuas/nessie/pull/159) ([@vexuas](https://github.com/vexuas))

#### 🔩 Dependency Updates

- Bump semver from 6.3.0 to 6.3.1 [#162](https://github.com/vexuas/nessie/pull/162) ([@dependabot[bot]](https://github.com/dependabot[bot]))

#### Authors: 2

- [@dependabot[bot]](https://github.com/dependabot[bot])
- Gabriel R ([@vexuas](https://github.com/vexuas))

---
