### PR TITLE
Dont ping if internal error

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -248,7 +248,7 @@ export const sendStatusErrorLog = async ({
   if (ERROR_NOTIFICATION_WEBHOOK_URL && !isEmpty(ERROR_NOTIFICATION_WEBHOOK_URL)) {
     const notificationWebhook = new WebhookClient({ url: ERROR_NOTIFICATION_WEBHOOK_URL });
     await notificationWebhook.send({
-      content: '<@183444648360935424>',
+      content: error.message === 'Internal Server Error' ? '' : '<@183444648360935424>',
       embeds: [errorEmbed],
       username: 'Nessie Error Notification',
       avatarURL: nessieLogo,


### PR DESCRIPTION
#### Context
I woke up today to 50 pings from my error logs lol. Apparently an `Internal Server Error` is being thrown by a specific guild since 5am and still ongoing at this point. Internal errors mean this is an issue from Discord's side so we can't really do anything about it until they figure it out on their end. It is odd that it's only from one server, not sure what happened there.

In any case, this is a temporary fix since I don't really want to get pinged by these so removing that functionality for it. I might want to silence these types of errors overall but for now I want to monitor how long this is going to take. If it's still ongoing for like a day or two, I'll have to take a closer look on what's going on.

![image](https://github.com/vexuas/nessie/assets/42207245/f2e870f9-5378-4a9c-a01a-c0866bf87239)

#### Change
- Dont ping if internal error is thrown

