### PR TITLE
Release/2023 07 14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# v2.0.5 (Fri Jul 14 2023)
+
+#### 🔧 Tweaks
+
+- Dont ping if internal error [#166](https://github.com/vexuas/nessie/pull/166) ([@vexuas](https://github.com/vexuas))
+
+#### 🏠 Internal
+
+- Release/2023 07 13 [#165](https://github.com/vexuas/nessie/pull/165) ([@vexuas](https://github.com/vexuas))
+
+#### Authors: 1
+
+- Gabriel R ([@vexuas](https://github.com/vexuas))
+
+---
+
 # v2.0.4 (Thu Jul 13 2023)
 
 #### 🧪 Tests

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nessie",
-  "version": "2.0.4",
+  "version": "2.0.5",
   "description": "Apex Legends Map Rotation Discord Bot",
   "license": "MIT",
   "scripts": {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const BOT_VERSION = "2.0.4";export const BOT_UPDATED_AT = "13-Jul-2023"
+export const BOT_VERSION = "2.0.5";export const BOT_UPDATED_AT = "14-Jul-2023"


### PR DESCRIPTION
# v2.0.5 (Fri Jul 14 2023)

#### 🔧 Tweaks

- Dont ping if internal error [#166](https://github.com/vexuas/nessie/pull/166) ([@vexuas](https://github.com/vexuas))

#### 🏠 Internal

- Release/2023 07 13 [#165](https://github.com/vexuas/nessie/pull/165) ([@vexuas](https://github.com/vexuas))

#### Authors: 1

- Gabriel R ([@vexuas](https://github.com/vexuas))
