### PR TITLE
Replace development status to map status

### DIFF
--- a/src/events/ready/index.ts
+++ b/src/events/ready/index.ts
@@ -39,6 +39,7 @@ const registerApplicationCommands = async (commands?: AppCommand[]) => {
  * That being said since status already has a cron job at the 5th sec of the hour, I'm setting this up at the 10th sec
  */
 const scheduleSetCurrentMapGameStatus = (app: Client) => {
+  //Making this a different schedule for dev/prod instances. Just a couple of seconds off each other to not get rate limited by the API
   const gameStatusSchedule = ENV === 'dev' ? '7 */1 * * * *' : '10 */1 * * * *';
   return new Scheduler(gameStatusSchedule, async () => {
     try {

--- a/src/events/ready/index.ts
+++ b/src/events/ready/index.ts
@@ -39,7 +39,8 @@ const registerApplicationCommands = async (commands?: AppCommand[]) => {
  * That being said since status already has a cron job at the 5th sec of the hour, I'm setting this up at the 10th sec
  */
 const scheduleSetCurrentMapGameStatus = (app: Client) => {
-  return new Scheduler('10 */1 * * * *', async () => {
+  const gameStatusSchedule = ENV === 'dev' ? '7 */1 * * * *' : '10 */1 * * * *';
+  return new Scheduler(gameStatusSchedule, async () => {
     try {
       if (!app.user) return;
       const data = await getBattleRoyalePubs();
@@ -66,12 +67,8 @@ export default function ({ app, appCommands }: EventModule) {
       const statusSchedule = scheduleStatus(app);
       statusSchedule.start();
 
-      if (ENV === 'dev') {
-        app.user && app.user.setActivity('Nessie Development');
-      } else {
-        const mapGameStatusSchedule = scheduleSetCurrentMapGameStatus(app);
-        mapGameStatusSchedule.start();
-      }
+      const mapGameStatusSchedule = scheduleSetCurrentMapGameStatus(app);
+      mapGameStatusSchedule.start();
     } catch (error) {
       sendErrorLog({ error });
     }


### PR DESCRIPTION
#### Context
I initially made this change in #164 since I was going to get ratelimited by the API if I had nessie and the development bot up at the same time. However I didn't account for when a new project gets initialised. New projects would always have the `Nessie Development` game status as by default it uses `ENV` as dev.

I removed this functionality and just have the map status always on regardless of instance. I did make it so that the schedule is a couple of seconds off for dev/prod instances. Mostly for me tho since I don't want to get ratelimited heh

![image](https://github.com/vexuas/nessie/assets/42207245/40d43390-3cab-440f-933c-dd56b6bf7c28)

#### Change
- Separate schedule for dev and prod instances
