### PR TITLE
Add basic guides to setting up self-hosted automatic map status

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,29 @@ Nessie uses Discord's Slash Commands `/`:
 ## Setting Up Automatic Map Status
 Gonna add a detailed guide here someday but use `status help` for now! It's probably straightforward enough. Probably.
 
-Cool links regarding the status command:
+For self-hosted projects, you are required to set up a [PostgreSQL](https://www.postgresql.org/) database to make the automatic updates work. Without the database, it will create the relevant channels, webhooks and the initial status message but the functionality stops there. I should probably also set up some guides for that but here are a couple of links to get you started with it for now:
+- Windows: https://www.postgresqltutorial.com/postgresql-getting-started/install-postgresql/
+- Mac: https://postgresapp.com/
+- Linux: https://www.postgresqltutorial.com/postgresql-getting-started/install-postgresql-linux/
+
+After setting up the database, you would need to fill in the environment variable `DATABASE_CONFIG` with your database credentials. The typing for this is generally
+```ts
+type DatabaseConfig = {
+  database: string;
+  host: string;
+  user: string;
+  port: number;
+  password: string;
+  ssl: {
+    rejectUnauthorized: boolean;
+  };
+};
+```
+A more detailed breakdown of this can be found through the [node-postgres package](https://node-postgres.com/)
+
+With these done, give `status start` a whirl and the automatic updates *should* be working now
+
+Some cool links regarding the status command:
 - [Design Prototypes](https://www.figma.com/file/Zw83AgLQpObLpPlSoeEWjq/Automatic-Status-Prototype?node-id=144%3A4675)
 - [Adventures in Discord's Rate Limits](https://shizuka.notion.site/Adventures-in-Discord-s-Rate-Limits-4ef7fa20481f4e3b8a388d9cdb1021e7)
 - [Spike on Time Taken for Status Cycles](https://shizuka.notion.site/Spike-on-Status-Time-Taken-0c26284152f04a169c546fe7b582a658)

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "nessie",
   "version": "2.0.5",
-  "description": "Apex Legends Map Rotation Discord Bot",
   "license": "MIT",
+  "description": "Apex Legends Map Rotation Discord Bot",
   "scripts": {
     "config:init": "yarn config:file && yarn config:bot && yarn config:als && yarn config:env && yarn config:notification && yarn config:database && yarn config:product && yarn config:topgg",
     "config:file": "mkdir src/config && touch src/config/environment.ts",


### PR DESCRIPTION
#### Context
There's no guide at all for self-hosted projects utilising the automatic map status feature. Rather a key element is not visible which is hooking up a postgres database for the project. The setup of the status will take you all the way to the initial map message but after that, it will not update without a db.

I'm not really that keen in having a step-by-step guide to set up a postgres database so I just ended up linking a couple of guides for it lol.

Also idk why github doesn't show the MIT license when I have it in the package json. Kinda weird.

#### Change
- Update readme
- Update license
