### PR TITLE
Ignore internal server errors

### DIFF
--- a/src/commands/status/start/index.ts
+++ b/src/commands/status/start/index.ts
@@ -634,6 +634,7 @@ const handleStatusCycle = async ({
       statusLogChannel && (await statusLogChannel.send({ embeds: [statusLogEmbed] }));
     }
   } catch (error: any) {
+    if (error.message === 'Internal Server Error') return;
     /**
      * Previously we sent an error notification to a channel whenever a status errors within a cycle
      * This was fine in the beginning so that I can be notified relatively fast


### PR DESCRIPTION
#### Context
Got a bunch of internal server errors from some guilds today. This error originates from discord itself so there's really nothing we can do about it. Don't really want to get spammed by these error logs so ignoring them

#### Change
- Ignore internal server errors in status cycle

#### Considerations
Pretty scuffed way of doing this, I'll have to think of a more proper way to ignore these when I get the time