### PR TITLE
Update status help layout

### DIFF
--- a/src/commands/status/help/index.ts
+++ b/src/commands/status/help/index.ts
@@ -4,7 +4,9 @@ import {
   ChatInputCommandInteraction,
   inlineCode,
   StringSelectMenuBuilder,
+  StringSelectMenuInteraction,
 } from 'discord.js';
+import { isEmpty } from 'lodash';
 import {
   checkIfUserHasManageServer,
   checkMissingBotPermissions,
@@ -38,40 +40,7 @@ const generateStatusHelpRow = (defaultValue: 'information' | 'setup' | 'permissi
   );
   return row;
 };
-const generateInformationSelectionMessage = () => {
-  const row = generateStatusHelpRow('information');
-  const embed: APIEmbed = {
-    description: 'Add information description here',
-    color: 3447003,
-  };
-  return {
-    embed,
-    row,
-  };
-};
-// const generateSetupSelectionMessage = () => {
-//   const row = generateStatusHelpRow('setup');
-//   const embed: APIEmbed = {
-//     description: 'Add setup description here',
-//     color: 3447003,
-//   };
-//   return {
-//     embed,
-//     row,
-//   };
-// };
-// const generatePermissionsSelectionMessage = () => {
-//   const row = generateStatusHelpRow('permissions');
-//   const embed: APIEmbed = {
-//     description: 'Add permissions description here',
-//     color: 3447003,
-//   };
-//   return {
-//     embed,
-//     row,
-//   };
-// };
-export const sendInformationInteraction = async ({
+export const sendStatusHelpInformationInteraction = async ({
   interaction,
   subCommand,
 }: {
@@ -79,13 +48,85 @@ export const sendInformationInteraction = async ({
   subCommand: string;
 }) => {
   try {
-    const { row } = generateInformationSelectionMessage();
+    const row = generateStatusHelpRow('information');
+    const embed: APIEmbed = {
+      description: 'Add information description here',
+      color: 3447003,
+    };
 
-    await interaction.editReply({ components: [row], content: 'something' });
+    await interaction.editReply({ embeds: [embed], components: [row] });
   } catch (error) {
     sendErrorLog({ error, interaction, subCommand });
   }
 };
+export const showStatusHelpMessage = async ({
+  interaction,
+}: {
+  interaction: StringSelectMenuInteraction;
+}) => {
+  const value = !isEmpty(interaction.values) ? interaction.values[0] : null;
+
+  switch (value) {
+    case 'sectionDropdown__informationValue':
+      await showStatusHelpInformation({ interaction });
+      break;
+    case 'sectionDropdown__setupValue':
+      await showStatusHelpSetup({ interaction });
+      break;
+    case 'sectionDropdown__permissionsValue':
+      await showStatusHelpPermissions({ interaction });
+      break;
+  }
+};
+export const showStatusHelpInformation = async ({
+  interaction,
+}: {
+  interaction: StringSelectMenuInteraction;
+}) => {
+  const row = generateStatusHelpRow('information');
+  const embed: APIEmbed = {
+    description: 'Add information description here',
+    color: 3447003,
+  };
+  try {
+    await interaction.message.edit({ embeds: [embed], components: [row] });
+  } catch (error) {
+    sendErrorLog({ error, interaction });
+  }
+};
+export const showStatusHelpSetup = async ({
+  interaction,
+}: {
+  interaction: StringSelectMenuInteraction;
+}) => {
+  const row = generateStatusHelpRow('setup');
+  const embed: APIEmbed = {
+    description: 'Add setup description here',
+    color: 3447003,
+  };
+  try {
+    await interaction.message.edit({ embeds: [embed], components: [row] });
+  } catch (error) {
+    sendErrorLog({ error, interaction });
+  }
+};
+export const showStatusHelpPermissions = async ({
+  interaction,
+}: {
+  interaction: StringSelectMenuInteraction;
+}) => {
+  const row = generateStatusHelpRow('permissions');
+  const embed: APIEmbed = {
+    description: 'Add permissions description here',
+    color: 3447003,
+  };
+  try {
+    await interaction.message.edit({ embeds: [embed], components: [row] });
+  } catch (error) {
+    sendErrorLog({ error, interaction });
+  }
+};
+
 /**
  * Handler for when a user initiates the /status help command
  * Displays information of status command, explains what it does and permissions it needs

--- a/src/commands/status/help/index.ts
+++ b/src/commands/status/help/index.ts
@@ -1,6 +1,7 @@
 import {
   ActionRowBuilder,
   APIEmbed,
+  bold,
   ChatInputCommandInteraction,
   inlineCode,
   StringSelectMenuBuilder,
@@ -14,6 +15,14 @@ import {
   sendErrorLog,
 } from '../../../utils/helpers';
 
+const informationDescription = `This command will send automatic updates of Apex Legends Map Rotations. Currently Nessie supports\n• ${bold(
+  'Battle Royale Pubs'
+)}\n• ${bold('Battle Royale Ranked')}\n• ${bold(
+  'Mixtape modes'
+)}\n\n Automatic updates occur every ${bold(
+  '5'
+)} minutes.\n\nNessie also offers the option to get notified when a particular map starts.`;
+
 const generateStatusHelpRow = (defaultValue: 'information' | 'setup' | 'permissions') => {
   const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
     new StringSelectMenuBuilder()
@@ -25,16 +34,19 @@ const generateStatusHelpRow = (defaultValue: 'information' | 'setup' | 'permissi
           label: 'Information',
           value: 'sectionDropdown__informationValue',
           default: defaultValue === 'information',
+          emoji: { name: 'ℹ️' },
         },
         {
           label: 'Setup',
           value: 'sectionDropdown__setupValue',
           default: defaultValue === 'setup',
+          emoji: { name: '🛠️' },
         },
         {
           label: 'Permissions',
           value: 'sectionDropdown__permissionsValue',
           default: defaultValue === 'permissions',
+          emoji: { name: '⚙️' },
         },
       ])
   );
@@ -50,7 +62,7 @@ export const sendStatusHelpInformationInteraction = async ({
   try {
     const row = generateStatusHelpRow('information');
     const embed: APIEmbed = {
-      description: 'Add information description here',
+      description: informationDescription,
       color: 3447003,
     };
 
@@ -85,7 +97,7 @@ export const showStatusHelpInformation = async ({
 }) => {
   const row = generateStatusHelpRow('information');
   const embed: APIEmbed = {
-    description: 'Add information description here',
+    description: informationDescription,
     color: 3447003,
   };
   try {

--- a/src/commands/status/help/index.ts
+++ b/src/commands/status/help/index.ts
@@ -3,7 +3,6 @@ import {
   APIEmbed,
   bold,
   ChatInputCommandInteraction,
-  inlineCode,
   StringSelectMenuBuilder,
   StringSelectMenuInteraction,
 } from 'discord.js';
@@ -11,15 +10,10 @@ import { isEmpty } from 'lodash';
 import {
   checkIfUserHasManageServer,
   checkMissingBotPermissions,
-  getEmbedColor,
   sendErrorLog,
 } from '../../../utils/helpers';
 
-const informationDescription = `This command will send automatic updates of Apex Legends Map Rotations. Currently Nessie supports\n• ${bold(
-  'Battle Royale Pubs'
-)}\n• ${bold('Battle Royale Ranked')}\n• ${bold(
-  'Mixtape modes'
-)}\n\n Automatic updates occur every ${bold(
+const informationDescription = `This command will send automatic updates of Apex Legends Map Rotations. Currently Nessie supports:\n• Battle Royale Pubs\n• Battle Royale Ranked\n• Mixtape modes\n\n Automatic updates occur every ${bold(
   '5'
 )} minutes.\n\nNessie also offers the option to get notified when a particular map starts.`;
 
@@ -37,16 +31,16 @@ const generateStatusHelpRow = (defaultValue: 'information' | 'setup' | 'permissi
           emoji: { name: 'ℹ️' },
         },
         {
-          label: 'Setup',
-          value: 'sectionDropdown__setupValue',
-          default: defaultValue === 'setup',
-          emoji: { name: '🛠️' },
-        },
-        {
           label: 'Permissions',
           value: 'sectionDropdown__permissionsValue',
           default: defaultValue === 'permissions',
           emoji: { name: '⚙️' },
+        },
+        {
+          label: 'Setup',
+          value: 'sectionDropdown__setupValue',
+          default: defaultValue === 'setup',
+          emoji: { name: '🛠️' },
         },
       ])
   );
@@ -127,32 +121,6 @@ export const showStatusHelpPermissions = async ({
 }: {
   interaction: StringSelectMenuInteraction;
 }) => {
-  const row = generateStatusHelpRow('permissions');
-  const embed: APIEmbed = {
-    description: 'Add permissions description here',
-    color: 3447003,
-  };
-  try {
-    await interaction.message.edit({ embeds: [embed], components: [row] });
-  } catch (error) {
-    sendErrorLog({ error, interaction });
-  }
-};
-
-/**
- * Handler for when a user initiates the /status help command
- * Displays information of status command, explains what it does and permissions it needs
- * Feeling a bit wacky so added a dynamic checklist of required permissions
- * Will either show a tick or mark if the permission is missing
- * Shows a success/warning at the end if any of the permissions are missing
- */
-export const sendHelpInteraction = async ({
-  interaction,
-  subCommand,
-}: {
-  interaction: ChatInputCommandInteraction;
-  subCommand: string;
-}) => {
   const {
     hasAdmin,
     hasManageChannels,
@@ -163,52 +131,36 @@ export const sendHelpInteraction = async ({
   } = checkMissingBotPermissions(interaction);
   const isManageServerUser = checkIfUserHasManageServer(interaction);
 
+  const row = generateStatusHelpRow('permissions');
+  const embed: APIEmbed = {
+    description: `Nessie requires certain permissions to properly create automatic updates. See the checklist below for the full list.`,
+    fields: [
+      {
+        name: 'User Permissions',
+        value: `${isManageServerUser ? '✅' : '❌'} Manage Server`,
+      },
+      {
+        name: 'Bot Permissions',
+        value: `${hasAdmin || hasManageChannels ? '✅' : '❌'} Manage Channels\n${
+          hasAdmin || hasManageWebhooks ? '✅' : '❌'
+        } Manage Webhooks\n${hasAdmin || hasViewChannel ? '✅' : '❌'} View Channels\n${
+          hasAdmin || hasSendMessages ? '✅' : '❌'
+        } Send Messages\n\n${
+          !isManageServerUser || hasMissingPermissions
+            ? `Looks like there are missing permissions. Make sure to add the above permissions to be able to use automatic map updates!${
+                isManageServerUser
+                  ? `\nYou can refresh Nessie's permissions by reinviting using this [link](https://discord.com/api/oauth2/authorize?client_id=889135055430111252&permissions=536874000&scope=applications.commands%20bot)`
+                  : ''
+              }`
+            : 'Looks like everything is set, use `/status start` to get started!'
+        }`,
+      },
+    ],
+    color: 3447003,
+  };
   try {
-    const embedInformation = {
-      title: 'Information',
-      description: `This command will send automatic updates of Apex Legends Map Rotations. Since Arenas are no longer in the game, you will only be able to choose the *Battle Royale* game mode to get updates for both pubs and ranked.\n\nAfter choosing, Nessie will create a set of:\n• ${inlineCode(
-        'Category Channel'
-      )}\n• ${inlineCode('Text Channel')}\n• ${inlineCode(
-        'Webhook'
-      )}\nUpdates will then be sent in these channels **every 5 minutes**\n\n`,
-      color: 3447003,
-    };
-    const embedPermissions = {
-      title: 'Permissions',
-      description: `Nessie requires certain permissions to properly create automatic updates. See the checklist below for the full list.`,
-      fields: [
-        {
-          name: 'User Permissions',
-          value: `${isManageServerUser ? '✅' : '❌'} Manage Server`,
-        },
-        {
-          name: 'Bot Permissions',
-          value: `${hasAdmin || hasManageChannels ? '✅' : '❌'} Manage Channels\n${
-            hasAdmin || hasManageWebhooks ? '✅' : '❌'
-          } Manage Webhooks\n${hasAdmin || hasViewChannel ? '✅' : '❌'} View Channels\n${
-            hasAdmin || hasSendMessages ? '✅' : '❌'
-          } Send Messages\n\n${
-            !isManageServerUser || hasMissingPermissions
-              ? `Looks like there are missing permissions. Make sure to add the above permissions to be able to use automatic map updates!${
-                  isManageServerUser
-                    ? `\nYou can refresh Nessie's permissions by reinviting using this [link](https://discord.com/api/oauth2/authorize?client_id=889135055430111252&permissions=536874000&scope=applications.commands%20bot)`
-                    : ''
-                }`
-              : 'Looks like everything is set, use `/status start` to get started!'
-          }`,
-        },
-      ],
-      color: 3447003,
-    };
-
-    await interaction.editReply({
-      embeds: [
-        { title: 'Status | Help', description: '', color: getEmbedColor() },
-        embedInformation,
-        embedPermissions,
-      ],
-    });
+    await interaction.message.edit({ embeds: [embed], components: [row] });
   } catch (error) {
-    sendErrorLog({ error, interaction, subCommand });
+    sendErrorLog({ error, interaction });
   }
 };

--- a/src/commands/status/help/index.ts
+++ b/src/commands/status/help/index.ts
@@ -3,6 +3,7 @@ import {
   APIEmbed,
   bold,
   ChatInputCommandInteraction,
+  inlineCode,
   StringSelectMenuBuilder,
   StringSelectMenuInteraction,
 } from 'discord.js';
@@ -107,7 +108,13 @@ export const showStatusHelpSetup = async ({
 }) => {
   const row = generateStatusHelpRow('setup');
   const embed: APIEmbed = {
-    description: 'Add setup description here',
+    description: `To start an automatic map status, use ${inlineCode(
+      '/status start'
+    )}\n\nUpon choosing your game modes, Nessie will create a set of:\n• ${inlineCode(
+      'Category Channel'
+    )}\n• ${inlineCode('Text Channel')}\n• ${inlineCode(
+      'Webhook'
+    )}\n\nUpdates will then be sent in these channels ${bold('every 5 minutes')}`,
     color: 3447003,
   };
   try {

--- a/src/commands/status/help/index.ts
+++ b/src/commands/status/help/index.ts
@@ -1,4 +1,10 @@
-import { ChatInputCommandInteraction, inlineCode } from 'discord.js';
+import {
+  ActionRowBuilder,
+  APIEmbed,
+  ChatInputCommandInteraction,
+  inlineCode,
+  StringSelectMenuBuilder,
+} from 'discord.js';
 import {
   checkIfUserHasManageServer,
   checkMissingBotPermissions,
@@ -6,6 +12,80 @@ import {
   sendErrorLog,
 } from '../../../utils/helpers';
 
+const generateStatusHelpRow = (defaultValue: 'information' | 'setup' | 'permissions') => {
+  const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
+    new StringSelectMenuBuilder()
+      .setCustomId('statusHelp__sectionDropdown')
+      .setMinValues(1)
+      .setMaxValues(1)
+      .addOptions([
+        {
+          label: 'Information',
+          value: 'sectionDropdown__informationValue',
+          default: defaultValue === 'information',
+        },
+        {
+          label: 'Setup',
+          value: 'sectionDropdown__setupValue',
+          default: defaultValue === 'setup',
+        },
+        {
+          label: 'Permissions',
+          value: 'sectionDropdown__permissionsValue',
+          default: defaultValue === 'permissions',
+        },
+      ])
+  );
+  return row;
+};
+const generateInformationSelectionMessage = () => {
+  const row = generateStatusHelpRow('information');
+  const embed: APIEmbed = {
+    description: 'Add information description here',
+    color: 3447003,
+  };
+  return {
+    embed,
+    row,
+  };
+};
+// const generateSetupSelectionMessage = () => {
+//   const row = generateStatusHelpRow('setup');
+//   const embed: APIEmbed = {
+//     description: 'Add setup description here',
+//     color: 3447003,
+//   };
+//   return {
+//     embed,
+//     row,
+//   };
+// };
+// const generatePermissionsSelectionMessage = () => {
+//   const row = generateStatusHelpRow('permissions');
+//   const embed: APIEmbed = {
+//     description: 'Add permissions description here',
+//     color: 3447003,
+//   };
+//   return {
+//     embed,
+//     row,
+//   };
+// };
+export const sendInformationInteraction = async ({
+  interaction,
+  subCommand,
+}: {
+  interaction: ChatInputCommandInteraction;
+  subCommand: string;
+}) => {
+  try {
+    const { row } = generateInformationSelectionMessage();
+
+    await interaction.editReply({ components: [row], content: 'something' });
+  } catch (error) {
+    sendErrorLog({ error, interaction, subCommand });
+  }
+};
 /**
  * Handler for when a user initiates the /status help command
  * Displays information of status command, explains what it does and permissions it needs

--- a/src/commands/status/help/index.ts
+++ b/src/commands/status/help/index.ts
@@ -107,6 +107,7 @@ export const showStatusHelpSetup = async ({
   interaction: StringSelectMenuInteraction;
 }) => {
   const row = generateStatusHelpRow('setup');
+  // TODO: Add created roles after wiring up
   const embed: APIEmbed = {
     description: `To start an automatic map status, use ${inlineCode(
       '/status start'

--- a/src/commands/status/index.ts
+++ b/src/commands/status/index.ts
@@ -1,6 +1,6 @@
 import { SlashCommandBuilder } from 'discord.js';
 import { AppCommand, AppCommandOptions } from '../commands';
-import { sendHelpInteraction } from './help';
+import { sendInformationInteraction } from './help';
 import { sendStartInteraction } from './start';
 import { sendStopInteraction } from './stop';
 
@@ -25,7 +25,8 @@ export default {
     await interaction.deferReply();
     switch (subCommand) {
       case 'help':
-        return sendHelpInteraction({ interaction, subCommand });
+        return sendInformationInteraction({ interaction, subCommand });
+      // return sendHelpInteraction({ interaction, subCommand });
       case 'start':
         return sendStartInteraction({ interaction, subCommand });
       case 'stop':

--- a/src/commands/status/index.ts
+++ b/src/commands/status/index.ts
@@ -1,6 +1,6 @@
 import { SlashCommandBuilder } from 'discord.js';
 import { AppCommand, AppCommandOptions } from '../commands';
-import { sendInformationInteraction } from './help';
+import { sendStatusHelpInformationInteraction } from './help';
 import { sendStartInteraction } from './start';
 import { sendStopInteraction } from './stop';
 
@@ -25,7 +25,7 @@ export default {
     await interaction.deferReply();
     switch (subCommand) {
       case 'help':
-        return sendInformationInteraction({ interaction, subCommand });
+        return sendStatusHelpInformationInteraction({ interaction, subCommand });
       // return sendHelpInteraction({ interaction, subCommand });
       case 'start':
         return sendStartInteraction({ interaction, subCommand });

--- a/src/commands/status/start/index.ts
+++ b/src/commands/status/start/index.ts
@@ -235,7 +235,6 @@ export const goToConfirmStatus = async ({
 }) => {
   const { embed, row } = generateConfirmStatusMessage({ interaction });
   try {
-    await interaction.deferUpdate();
     await interaction.message.edit({ embeds: [embed], components: [row] });
   } catch (error) {
     sendErrorLog({ error, interaction, customTitle: 'Status Start Confirm Error' });

--- a/src/events/interactionCreate/index.ts
+++ b/src/events/interactionCreate/index.ts
@@ -1,4 +1,5 @@
 import { StringSelectMenuInteraction, ApplicationCommandOptionType } from 'discord.js';
+import { showStatusHelpMessage } from '../../commands/status/help';
 import {
   createStatus,
   goBackToGameModeSelection,
@@ -67,11 +68,17 @@ export default function ({ app, mixpanel, appCommands }: EventModule) {
         }
       }
       if (interaction.isAnySelectMenu()) {
+        await interaction.deferUpdate();
         switch (interaction.customId) {
           case 'statusStart__gameModeDropdown':
-            goToConfirmStatus({
+            await goToConfirmStatus({
               interaction: interaction as StringSelectMenuInteraction,
               mixpanel,
+            });
+            break;
+          case 'statusHelp__sectionDropdown':
+            await showStatusHelpMessage({
+              interaction: interaction as StringSelectMenuInteraction,
             });
             break;
         }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -12,6 +12,7 @@ import {
   PermissionFlagsBits,
   ButtonInteraction,
   GuildMember,
+  StringSelectMenuInteraction,
 } from 'discord.js';
 import {
   BOOT_NOTIFICATION_CHANNEL_ID,
@@ -386,7 +387,9 @@ export const generateRankedEmbed = (
   return embedData;
 };
 //TODO: Refactor this someday
-export const checkMissingBotPermissions = (interaction: ChatInputCommandInteraction) => {
+export const checkMissingBotPermissions = (
+  interaction: ChatInputCommandInteraction | StringSelectMenuInteraction
+) => {
   const { guild } = interaction;
 
   const hasAdmin =
@@ -422,7 +425,9 @@ export const checkMissingBotPermissions = (interaction: ChatInputCommandInteract
     hasMissingPermissions,
   };
 };
-export const checkIfUserHasManageServer = (interaction: ChatInputCommandInteraction) => {
+export const checkIfUserHasManageServer = (
+  interaction: ChatInputCommandInteraction | StringSelectMenuInteraction
+) => {
   return (
     interaction.member &&
     interaction.member instanceof GuildMember &&


### PR DESCRIPTION
#### Context
In preparation of the Map Alerts development, this updates how we're showing `/status help` as the previous layout would be congested once we add more information.

I'd have to flesh this out more eventually since tbh my copy skills aren't the best

<img width="603" alt="image" src="https://github.com/vexuas/nessie/assets/42207245/73ecb3e7-a8bf-4e96-9056-cf155dd3b4c3">

<img width="650" alt="image" src="https://github.com/vexuas/nessie/assets/42207245/88252fca-94b4-40dd-8232-edc1b0befa7f">

<img width="468" alt="image" src="https://github.com/vexuas/nessie/assets/42207245/e95734d2-4fbd-4c24-91da-81aa4ba9a8bc">

#### Change
- Create information interaction
- Create handlers for showing help embeds
- Update section descriptions
