### PR TITLE
Spike on permissions needed for Map Alerts

### DIFF
--- a/src/commands/spikeRoles/index.ts
+++ b/src/commands/spikeRoles/index.ts
@@ -1,6 +1,28 @@
-import { APIEmbed, SlashCommandBuilder } from 'discord.js';
+import {
+  ActionRowBuilder,
+  APIEmbed,
+  ButtonBuilder,
+  ButtonInteraction,
+  ButtonStyle,
+  roleMention,
+  SlashCommandBuilder,
+} from 'discord.js';
 import { checkMissingBotPermissions, getEmbedColor, sendErrorLog } from '../../utils/helpers';
 import { AppCommand, AppCommandOptions } from '../commands';
+
+export const createSpikeRole = async (interaction: ButtonInteraction) => {
+  try {
+    const { guild, channel } = interaction;
+    await interaction.deferUpdate();
+    const role = guild && (await guild.roles.create({ name: 'SpikeRole' }));
+    const embed: APIEmbed = {
+      description: `Created ${roleMention(role ? role.id : '')}`,
+    };
+    channel && (await channel.send({ embeds: [embed] }));
+  } catch (error) {
+    sendErrorLog({ interaction, error });
+  }
+};
 
 export default {
   data: new SlashCommandBuilder()
@@ -9,6 +31,12 @@ export default {
   async execute({ interaction }: AppCommandOptions) {
     try {
       await interaction.deferReply();
+      const row = new ActionRowBuilder<ButtonBuilder>().addComponents(
+        new ButtonBuilder()
+          .setLabel('Create Role')
+          .setStyle(ButtonStyle.Success)
+          .setCustomId('spikeRole__createRole')
+      );
       const {
         hasAdmin,
         hasManageChannels,
@@ -21,7 +49,7 @@ export default {
         description: `• hasAdmin: ${hasAdmin}\n• hasManageChannels: ${hasManageChannels}\n• hasManageWebhooks: ${hasManageWebhooks}\n• hasSendMessage: ${hasSendMessages}\n• hasViewChannel: ${hasViewChannel}\n• hasManageRoles: ${hasManageRoles}`,
         color: getEmbedColor(),
       };
-      await interaction.editReply({ embeds: [embed] });
+      await interaction.editReply({ embeds: [embed], components: [row] });
     } catch (error) {
       sendErrorLog({ error, interaction });
     }

--- a/src/commands/spikeRoles/index.ts
+++ b/src/commands/spikeRoles/index.ts
@@ -1,16 +1,24 @@
 import { APIEmbed, SlashCommandBuilder } from 'discord.js';
-import { getEmbedColor, sendErrorLog } from '../../utils/helpers';
+import { checkMissingBotPermissions, getEmbedColor, sendErrorLog } from '../../utils/helpers';
 import { AppCommand, AppCommandOptions } from '../commands';
 
 export default {
   data: new SlashCommandBuilder()
-    .setName('spikeRoles')
+    .setName('spikeroles')
     .setDescription('Spike roles necessary for map alerts'),
   async execute({ interaction }: AppCommandOptions) {
     try {
       await interaction.deferReply();
+      const {
+        hasAdmin,
+        hasManageChannels,
+        hasManageWebhooks,
+        hasSendMessages,
+        hasViewChannel,
+        hasManageRoles,
+      } = checkMissingBotPermissions(interaction);
       const embed: APIEmbed = {
-        description: 'Add roles here',
+        description: `• hasAdmin: ${hasAdmin}\n• hasManageChannels: ${hasManageChannels}\n• hasManageWebhooks: ${hasManageWebhooks}\n• hasSendMessage: ${hasSendMessages}\n• hasViewChannel: ${hasViewChannel}\n• hasManageRoles: ${hasManageRoles}`,
         color: getEmbedColor(),
       };
       await interaction.editReply({ embeds: [embed] });

--- a/src/commands/spikeRoles/index.ts
+++ b/src/commands/spikeRoles/index.ts
@@ -23,6 +23,22 @@ export const createSpikeRole = async (interaction: ButtonInteraction) => {
     sendErrorLog({ interaction, error });
   }
 };
+export const assignSpikeRole = async (interaction: ButtonInteraction) => {
+  try {
+    await interaction.deferUpdate();
+    const { guild, member } = interaction;
+    const role = await guild?.roles.fetch('1151576864314363976');
+
+    member &&
+      role &&
+      (await guild?.members.addRole({
+        user: member.user.id,
+        role: role.id,
+      }));
+  } catch (error) {
+    sendErrorLog({ interaction, error });
+  }
+};
 
 export default {
   data: new SlashCommandBuilder()
@@ -35,7 +51,11 @@ export default {
         new ButtonBuilder()
           .setLabel('Create Role')
           .setStyle(ButtonStyle.Success)
-          .setCustomId('spikeRole__createRole')
+          .setCustomId('spikeRole__createRole'),
+        new ButtonBuilder()
+          .setLabel('Assign Role')
+          .setStyle(ButtonStyle.Primary)
+          .setCustomId('spikeRole__assignRole')
       );
       const {
         hasAdmin,

--- a/src/commands/spikeRoles/index.ts
+++ b/src/commands/spikeRoles/index.ts
@@ -1,0 +1,21 @@
+import { APIEmbed, SlashCommandBuilder } from 'discord.js';
+import { getEmbedColor, sendErrorLog } from '../../utils/helpers';
+import { AppCommand, AppCommandOptions } from '../commands';
+
+export default {
+  data: new SlashCommandBuilder()
+    .setName('spikeRoles')
+    .setDescription('Spike roles necessary for map alerts'),
+  async execute({ interaction }: AppCommandOptions) {
+    try {
+      await interaction.deferReply();
+      const embed: APIEmbed = {
+        description: 'Add roles here',
+        color: getEmbedColor(),
+      };
+      await interaction.editReply({ embeds: [embed] });
+    } catch (error) {
+      sendErrorLog({ error, interaction });
+    }
+  },
+} as AppCommand;

--- a/src/commands/spikeRoles/index.ts
+++ b/src/commands/spikeRoles/index.ts
@@ -39,6 +39,17 @@ export const assignSpikeRole = async (interaction: ButtonInteraction) => {
     sendErrorLog({ interaction, error });
   }
 };
+export const pingSpikeRole = async (interaction: ButtonInteraction) => {
+  try {
+    await interaction.deferUpdate();
+    const { channel } = interaction;
+
+    channel &&
+      (await channel.send({ content: `${roleMention('1151576864314363976')} Map start!` }));
+  } catch (error) {
+    sendErrorLog({ interaction, error });
+  }
+};
 
 export default {
   data: new SlashCommandBuilder()
@@ -55,7 +66,11 @@ export default {
         new ButtonBuilder()
           .setLabel('Assign Role')
           .setStyle(ButtonStyle.Primary)
-          .setCustomId('spikeRole__assignRole')
+          .setCustomId('spikeRole__assignRole'),
+        new ButtonBuilder()
+          .setLabel('Ping Role')
+          .setStyle(ButtonStyle.Danger)
+          .setCustomId('spikeRole__pingRole')
       );
       const {
         hasAdmin,

--- a/src/events/interactionCreate/index.ts
+++ b/src/events/interactionCreate/index.ts
@@ -1,4 +1,5 @@
 import { StringSelectMenuInteraction, ApplicationCommandOptionType } from 'discord.js';
+import { createSpikeRole } from '../../commands/spikeRoles';
 import { showStatusHelpMessage } from '../../commands/status/help';
 import {
   createStatus,
@@ -59,6 +60,9 @@ export default function ({ app, mixpanel, appCommands }: EventModule) {
             break;
           case 'statusStop__stopButton':
             deleteGuildStatus({ interaction, nessie: app, mixpanel });
+            break;
+          case 'spikeRole__createRole':
+            createSpikeRole(interaction);
             break;
           default:
             if (interaction.customId.includes('statusStart__confirmButton')) {

--- a/src/events/interactionCreate/index.ts
+++ b/src/events/interactionCreate/index.ts
@@ -1,5 +1,5 @@
 import { StringSelectMenuInteraction, ApplicationCommandOptionType } from 'discord.js';
-import { createSpikeRole } from '../../commands/spikeRoles';
+import { assignSpikeRole, createSpikeRole } from '../../commands/spikeRoles';
 import { showStatusHelpMessage } from '../../commands/status/help';
 import {
   createStatus,
@@ -63,6 +63,9 @@ export default function ({ app, mixpanel, appCommands }: EventModule) {
             break;
           case 'spikeRole__createRole':
             createSpikeRole(interaction);
+            break;
+          case 'spikeRole__assignRole':
+            assignSpikeRole(interaction);
             break;
           default:
             if (interaction.customId.includes('statusStart__confirmButton')) {

--- a/src/events/interactionCreate/index.ts
+++ b/src/events/interactionCreate/index.ts
@@ -1,5 +1,5 @@
 import { StringSelectMenuInteraction, ApplicationCommandOptionType } from 'discord.js';
-import { assignSpikeRole, createSpikeRole } from '../../commands/spikeRoles';
+import { assignSpikeRole, createSpikeRole, pingSpikeRole } from '../../commands/spikeRoles';
 import { showStatusHelpMessage } from '../../commands/status/help';
 import {
   createStatus,
@@ -66,6 +66,9 @@ export default function ({ app, mixpanel, appCommands }: EventModule) {
             break;
           case 'spikeRole__assignRole':
             assignSpikeRole(interaction);
+            break;
+          case 'spikeRole__pingRole':
+            pingSpikeRole(interaction);
             break;
           default:
             if (interaction.customId.includes('statusStart__confirmButton')) {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -412,9 +412,18 @@ export const checkMissingBotPermissions = (
     guild &&
     guild.members.me &&
     guild.members.me.permissions.has(PermissionFlagsBits.SendMessages, false);
+  const hasManageRoles =
+    guild &&
+    guild.members.me &&
+    guild.members.me.permissions.has(PermissionFlagsBits.ManageRoles, false);
 
   const hasMissingPermissions =
-    (!hasManageChannels || !hasViewChannel || !hasManageWebhooks || !hasSendMessages) && !hasAdmin; //Overrides missing permissions if nessie has Admin
+    (!hasManageChannels ||
+      !hasViewChannel ||
+      !hasManageWebhooks ||
+      !hasSendMessages ||
+      !hasManageRoles) &&
+    !hasAdmin; //Overrides missing permissions if nessie has Admin
 
   return {
     hasAdmin,
@@ -423,6 +432,7 @@ export const checkMissingBotPermissions = (
     hasSendMessages,
     hasViewChannel,
     hasMissingPermissions,
+    hasManageRoles,
   };
 };
 export const checkIfUserHasManageServer = (


### PR DESCRIPTION
#### Context
Full spike doc here: https://shizuka.notion.site/Spike-on-Necessary-Permissions-for-Map-Alerts-46cfc8b3917e492fa58755ae030e887d?pvs=4

<img width="422" alt="image" src="https://github.com/vexuas/nessie/assets/42207245/a9d51c07-fff1-46a1-b6e0-9d550a72a600">

#### Change
- Create spike roles command
- Add check for manage roles
- Wire up creating role
- Assign role
- Wire up ping
