### PR TITLE
Remove alerts information for now

### DIFF
--- a/src/commands/status/help/index.ts
+++ b/src/commands/status/help/index.ts
@@ -8,6 +8,8 @@ import {
   StringSelectMenuInteraction,
 } from 'discord.js';
 import { isEmpty } from 'lodash';
+import { Mixpanel } from 'mixpanel';
+import { sendAnalyticsEvent } from '../../../services/analytics';
 import {
   checkIfUserHasManageServer,
   checkMissingBotPermissions,
@@ -69,27 +71,31 @@ export const sendStatusHelpInformationInteraction = async ({
 };
 export const showStatusHelpMessage = async ({
   interaction,
+  mixpanel,
 }: {
   interaction: StringSelectMenuInteraction;
+  mixpanel?: Mixpanel | null;
 }) => {
   const value = !isEmpty(interaction.values) ? interaction.values[0] : null;
 
   switch (value) {
     case 'sectionDropdown__informationValue':
-      await showStatusHelpInformation({ interaction });
+      await showStatusHelpInformation({ interaction, mixpanel });
       break;
     case 'sectionDropdown__setupValue':
-      await showStatusHelpSetup({ interaction });
+      await showStatusHelpSetup({ interaction, mixpanel });
       break;
     case 'sectionDropdown__permissionsValue':
-      await showStatusHelpPermissions({ interaction });
+      await showStatusHelpPermissions({ interaction, mixpanel });
       break;
   }
 };
 export const showStatusHelpInformation = async ({
   interaction,
+  mixpanel,
 }: {
   interaction: StringSelectMenuInteraction;
+  mixpanel?: Mixpanel | null;
 }) => {
   const row = generateStatusHelpRow('information');
   const embed: APIEmbed = {
@@ -101,12 +107,23 @@ export const showStatusHelpInformation = async ({
     await interaction.message.edit({ embeds: [embed], components: [row] });
   } catch (error) {
     sendErrorLog({ error, interaction });
+  } finally {
+    mixpanel &&
+      sendAnalyticsEvent({
+        user: interaction.user,
+        channel: interaction.inGuild() ? interaction.channel : null,
+        guild: interaction.guild,
+        client: mixpanel,
+        eventName: 'Click status help information select menu',
+      });
   }
 };
 export const showStatusHelpSetup = async ({
   interaction,
+  mixpanel,
 }: {
   interaction: StringSelectMenuInteraction;
+  mixpanel?: Mixpanel | null;
 }) => {
   const row = generateStatusHelpRow('setup');
   // TODO: Add created roles after wiring up
@@ -125,12 +142,23 @@ export const showStatusHelpSetup = async ({
     await interaction.message.edit({ embeds: [embed], components: [row] });
   } catch (error) {
     sendErrorLog({ error, interaction });
+  } finally {
+    mixpanel &&
+      sendAnalyticsEvent({
+        user: interaction.user,
+        channel: interaction.inGuild() ? interaction.channel : null,
+        guild: interaction.guild,
+        client: mixpanel,
+        eventName: 'Click status help setup select menu',
+      });
   }
 };
 export const showStatusHelpPermissions = async ({
   interaction,
+  mixpanel,
 }: {
   interaction: StringSelectMenuInteraction;
+  mixpanel?: Mixpanel | null;
 }) => {
   const {
     hasAdmin,
@@ -174,5 +202,14 @@ export const showStatusHelpPermissions = async ({
     await interaction.message.edit({ embeds: [embed], components: [row] });
   } catch (error) {
     sendErrorLog({ error, interaction });
+  } finally {
+    mixpanel &&
+      sendAnalyticsEvent({
+        user: interaction.user,
+        channel: interaction.inGuild() ? interaction.channel : null,
+        guild: interaction.guild,
+        client: mixpanel,
+        eventName: 'Click status help permissions select menu',
+      });
   }
 };

--- a/src/commands/status/help/index.ts
+++ b/src/commands/status/help/index.ts
@@ -14,9 +14,9 @@ import {
   sendErrorLog,
 } from '../../../utils/helpers';
 
-const informationDescription = `This command will send automatic updates of Apex Legends Map Rotations. Currently Nessie supports:\n• Battle Royale Pubs\n• Battle Royale Ranked\n• Mixtape modes\n\n Automatic updates occur every ${bold(
+const informationDescription = `This command will send automatic updates of Apex Legends Map Rotations. Currently Nessie supports:\n• Battle Royale Pubs\n• Battle Royale Ranked\n\n Automatic updates occur every ${bold(
   '5'
-)} minutes.\n\nNessie also offers the option to get notified when a particular map starts.`;
+)} minutes.`;
 
 const generateStatusHelpRow = (defaultValue: 'information' | 'setup' | 'permissions') => {
   const row = new ActionRowBuilder<StringSelectMenuBuilder>().addComponents(
@@ -57,6 +57,7 @@ export const sendStatusHelpInformationInteraction = async ({
   try {
     const row = generateStatusHelpRow('information');
     const embed: APIEmbed = {
+      title: 'Information',
       description: informationDescription,
       color: 3447003,
     };
@@ -92,6 +93,7 @@ export const showStatusHelpInformation = async ({
 }) => {
   const row = generateStatusHelpRow('information');
   const embed: APIEmbed = {
+    title: 'Information',
     description: informationDescription,
     color: 3447003,
   };
@@ -109,6 +111,7 @@ export const showStatusHelpSetup = async ({
   const row = generateStatusHelpRow('setup');
   // TODO: Add created roles after wiring up
   const embed: APIEmbed = {
+    title: 'Setup',
     description: `To start an automatic map status, use ${inlineCode(
       '/status start'
     )}\n\nUpon choosing your game modes, Nessie will create a set of:\n• ${inlineCode(
@@ -141,6 +144,7 @@ export const showStatusHelpPermissions = async ({
 
   const row = generateStatusHelpRow('permissions');
   const embed: APIEmbed = {
+    title: 'Permissions',
     description: `Nessie requires certain permissions to properly create automatic updates. See the checklist below for the full list.`,
     fields: [
       {

--- a/src/events/interactionCreate/index.ts
+++ b/src/events/interactionCreate/index.ts
@@ -79,6 +79,7 @@ export default function ({ app, mixpanel, appCommands }: EventModule) {
           case 'statusHelp__sectionDropdown':
             await showStatusHelpMessage({
               interaction: interaction as StringSelectMenuInteraction,
+              mixpanel,
             });
             break;
         }


### PR DESCRIPTION
#### Context
Wanted to release some qol changes today so removing these map alerts information to unblock it. Added tracking events for the status help select menu interactions as well while I'm here

<img width="600" alt="image" src="https://github.com/vexuas/nessie/assets/42207245/b1d6f90d-b595-4b90-bf59-31e9eefbfbea">

<img width="591" alt="image" src="https://github.com/vexuas/nessie/assets/42207245/bd4969b4-49b4-4bbd-91b9-03fa683d0f3d">

<img width="474" alt="image" src="https://github.com/vexuas/nessie/assets/42207245/f1336ffc-fd2e-454b-a765-ab5729c80705">


#### Change
- Remove map alerts information
- Add mixpanel events for status help menu
