### PR TITLE
Release/2023 09 20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,21 @@
+# v2.0.8 (Wed Sep 20 2023)
+
+#### 🔧 Tweaks
+
+- Remove alerts information for now [#179](https://github.com/vexuas/nessie/pull/179) ([@vexuas](https://github.com/vexuas))
+- Replace ltm with mixtape [#178](https://github.com/vexuas/nessie/pull/178) ([@vexuas](https://github.com/vexuas))
+- Update status help layout [#176](https://github.com/vexuas/nessie/pull/176) ([@vexuas](https://github.com/vexuas))
+
+#### 🏠 Internal
+
+- Release/2023 08 20 [#175](https://github.com/vexuas/nessie/pull/175) ([@vexuas](https://github.com/vexuas))
+
+#### Authors: 1
+
+- Gabriel R ([@vexuas](https://github.com/vexuas))
+
+---
+
 # v2.0.7 (Sun Aug 20 2023)
 
 #### 🔧 Tweaks

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "nessie",
-  "version": "2.0.7",
+  "version": "2.0.8",
   "description": "Apex Legends Map Rotation Discord Bot",
   "license": "MIT",
   "scripts": {

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,1 +1,1 @@
-export const BOT_VERSION = "2.0.7";export const BOT_UPDATED_AT = "20-Aug-2023"
+export const BOT_VERSION = "2.0.8";export const BOT_UPDATED_AT = "20-Sep-2023"


### PR DESCRIPTION
# v2.0.8 (Wed Sep 20 2023)

#### 🔧 Tweaks

- Remove alerts information for now [#179](https://github.com/vexuas/nessie/pull/179) ([@vexuas](https://github.com/vexuas))
- Replace ltm with mixtape [#178](https://github.com/vexuas/nessie/pull/178) ([@vexuas](https://github.com/vexuas))
- Update status help layout [#176](https://github.com/vexuas/nessie/pull/176) ([@vexuas](https://github.com/vexuas))

#### 🏠 Internal

- Release/2023 08 20 [#175](https://github.com/vexuas/nessie/pull/175) ([@vexuas](https://github.com/vexuas))

#### Authors: 1

- Gabriel R ([@vexuas](https://github.com/vexuas))