### PR TITLE
Wire up season end endpoint

### DIFF
--- a/src/commands/battleRoyale/index.test.ts
+++ b/src/commands/battleRoyale/index.test.ts
@@ -175,3 +175,17 @@ describe('Battle Royale Ranked Command', () => {
     expect(embed.fields && embed.fields[1].value).toContain('23 hr 58 mins 28 secs');
   });
 });
+
+describe('Season Information', () => {
+  it('shows the correct season end description', () => {
+    const embed = generateRankedEmbed(mockRankedData, 'Battle Royale', '30 days');
+
+    expect(embed.description).not.toBeUndefined();
+    expect(embed.description).toBe('Season ends in `30 days`');
+  });
+  it('does not show the season end description if seasonEnd is not present', () => {
+    const embed = generateRankedEmbed(mockRankedData);
+
+    expect(embed.description).toBeUndefined();
+  });
+});

--- a/src/commands/battleRoyale/index.ts
+++ b/src/commands/battleRoyale/index.ts
@@ -28,12 +28,12 @@ export default {
       switch (optionMode) {
         case 'br_pubs':
           data = await getBattleRoyalePubs();
-          await getSeasonInformation();
-          embed = generatePubsEmbed(data);
+          embed = generatePubsEmbed(data, 'Battle Royale');
           break;
         case 'br_ranked':
           data = await getBattleRoyaleRanked();
-          embed = generateRankedEmbed(data);
+          const season = await getSeasonInformation();
+          embed = generateRankedEmbed(data, 'Battle Royale', season);
           break;
       }
       await interaction.editReply({ embeds: [embed] });

--- a/src/commands/battleRoyale/index.ts
+++ b/src/commands/battleRoyale/index.ts
@@ -33,7 +33,7 @@ export default {
       switch (optionMode) {
         case 'br_pubs':
           data = await getBattleRoyalePubs();
-          embed = generatePubsEmbed(data, 'Battle Royale');
+          embed = generatePubsEmbed(data);
           break;
         case 'br_ranked':
           data = await getBattleRoyaleRanked();

--- a/src/commands/battleRoyale/index.ts
+++ b/src/commands/battleRoyale/index.ts
@@ -4,7 +4,12 @@ import {
   getBattleRoyaleRanked,
   getSeasonInformation,
 } from '../../services/adapters';
-import { generatePubsEmbed, generateRankedEmbed, sendErrorLog } from '../../utils/helpers';
+import {
+  formatSeasonEndCountdown,
+  generatePubsEmbed,
+  generateRankedEmbed,
+  sendErrorLog,
+} from '../../utils/helpers';
 import { AppCommand, AppCommandOptions } from '../commands';
 
 export default {
@@ -33,7 +38,11 @@ export default {
         case 'br_ranked':
           data = await getBattleRoyaleRanked();
           const season = await getSeasonInformation();
-          embed = generateRankedEmbed(data, 'Battle Royale', season);
+          const seasonEnd = formatSeasonEndCountdown({
+            seasonEnd: season.dates.End * 1000,
+            currentDate: new Date(),
+          });
+          embed = generateRankedEmbed(data, 'Battle Royale', seasonEnd);
           break;
       }
       await interaction.editReply({ embeds: [embed] });

--- a/src/commands/battleRoyale/index.ts
+++ b/src/commands/battleRoyale/index.ts
@@ -1,5 +1,9 @@
 import { SlashCommandBuilder } from 'discord.js';
-import { getBattleRoyalePubs, getBattleRoyaleRanked } from '../../services/adapters';
+import {
+  getBattleRoyalePubs,
+  getBattleRoyaleRanked,
+  getSeasonInformation,
+} from '../../services/adapters';
 import { generatePubsEmbed, generateRankedEmbed, sendErrorLog } from '../../utils/helpers';
 import { AppCommand, AppCommandOptions } from '../commands';
 
@@ -24,6 +28,7 @@ export default {
       switch (optionMode) {
         case 'br_pubs':
           data = await getBattleRoyalePubs();
+          await getSeasonInformation();
           embed = generatePubsEmbed(data);
           break;
         case 'br_ranked':

--- a/src/commands/battleRoyale/index.ts
+++ b/src/commands/battleRoyale/index.ts
@@ -38,6 +38,7 @@ export default {
         case 'br_ranked':
           data = await getBattleRoyaleRanked();
           const season = await getSeasonInformation();
+          //TODO: Figure out formatting for different timezones eventually
           const seasonEnd = formatSeasonEndCountdown({
             seasonEnd: season.dates.End * 1000,
             currentDate: new Date(),

--- a/src/commands/status/start/index.ts
+++ b/src/commands/status/start/index.ts
@@ -32,6 +32,7 @@ import {
   generateErrorEmbed,
   sendErrorLog,
   sendStatusErrorLog,
+  formatSeasonEndCountdown,
 } from '../../../utils/helpers';
 import { v4 as uuidV4 } from 'uuid';
 import { getRotationData, getSeasonInformation } from '../../../services/adapters';
@@ -161,7 +162,11 @@ const generateConfirmStatusMessage = ({
  */
 const generateBattleRoyaleStatusEmbeds = (data: MapRotationAPIObject, season: SeasonAPISchema) => {
   const battleRoyalePubsEmbed = generatePubsEmbed(data.battle_royale);
-  const battleRoyaleRankedEmbed = generateRankedEmbed(data.ranked, 'Battle Royale', season);
+  const seasonEnd = formatSeasonEndCountdown({
+    seasonEnd: season.dates.End * 1000,
+    currentDate: new Date(),
+  });
+  const battleRoyaleRankedEmbed = generateRankedEmbed(data.ranked, 'Battle Royale', seasonEnd);
   const informationEmbed = {
     description: '**Updates occur every 5 minutes**',
     color: 3447003,

--- a/src/schemas/season.ts
+++ b/src/schemas/season.ts
@@ -1,0 +1,12 @@
+export interface SeasonAPISchema {
+  info: {
+    ID: number;
+    Name: string;
+    Split: number;
+  };
+  dates: {
+    Start: number;
+    Split: number;
+    End: number;
+  };
+}

--- a/src/services/adapters.ts
+++ b/src/services/adapters.ts
@@ -12,11 +12,20 @@ import { SeasonAPISchema } from '../schemas/season';
 
 //Documentation on API: https://apexlegendsapi.com/documentation.php
 const url = `https://api.mozambiquehe.re/maprotation?version=2&auth=${ALS_API_KEY}`;
+//Less publicly known api to retrieve season data; kudos to @SDCore
+//No authentication + rate limited so we should be mindful in using this
+const seasonUrl = 'https://api.jumpmaster.xyz/seasons/Current';
 
 export async function getRotationData(): Promise<MapRotationAPIObject> {
   const response: string = (await got.get(url)).body;
   return JSON.parse(response);
 }
+export async function getSeasonInformation(): Promise<SeasonAPISchema> {
+  //
+  const response: string = (await got.get(seasonUrl)).body;
+  return JSON.parse(response);
+}
+
 export async function getBattleRoyalePubs(): Promise<MapRotationBattleRoyaleSchema> {
   const response = await getRotationData();
   return response.battle_royale;
@@ -36,8 +45,4 @@ export async function getArenasRanked(): Promise<MapRotationArenasRankedSchema> 
 export async function getMixtape(): Promise<MapRotationMixtapeSchema> {
   const response = await getRotationData();
   return response.ltm;
-}
-export async function getSeasonInformation(): Promise<SeasonAPISchema> {
-  const response: string = (await got.get('https://api.jumpmaster.xyz/seasons/Current')).body;
-  return JSON.parse(response);
 }

--- a/src/services/adapters.ts
+++ b/src/services/adapters.ts
@@ -36,3 +36,8 @@ export async function getMixtape(): Promise<MapRotationMixtapeSchema> {
   const response = await getRotationData();
   return response.ltm;
 }
+export async function getSeasonInformation(): Promise<any> {
+  const response: string = (await got.get('https://api.jumpmaster.xyz/seasons/Current')).body;
+  const r = JSON.parse(response);
+  console.log(r);
+}

--- a/src/services/adapters.ts
+++ b/src/services/adapters.ts
@@ -8,6 +8,7 @@ import {
   MapRotationMixtapeSchema,
   MapRotationRankedSchema,
 } from '../schemas/mapRotation';
+import { SeasonAPISchema } from '../schemas/season';
 
 //Documentation on API: https://apexlegendsapi.com/documentation.php
 const url = `https://api.mozambiquehe.re/maprotation?version=2&auth=${ALS_API_KEY}`;
@@ -36,8 +37,7 @@ export async function getMixtape(): Promise<MapRotationMixtapeSchema> {
   const response = await getRotationData();
   return response.ltm;
 }
-export async function getSeasonInformation(): Promise<any> {
+export async function getSeasonInformation(): Promise<SeasonAPISchema> {
   const response: string = (await got.get('https://api.jumpmaster.xyz/seasons/Current')).body;
-  const r = JSON.parse(response);
-  console.log(r);
+  return JSON.parse(response);
 }

--- a/src/services/adapters.ts
+++ b/src/services/adapters.ts
@@ -21,7 +21,6 @@ export async function getRotationData(): Promise<MapRotationAPIObject> {
   return JSON.parse(response);
 }
 export async function getSeasonInformation(): Promise<SeasonAPISchema> {
-  //
   const response: string = (await got.get(seasonUrl)).body;
   return JSON.parse(response);
 }

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -1,0 +1,56 @@
+import { formatSeasonEndCountdown } from './helpers';
+
+//TODO: Add tests for other helpers here too eventually
+describe('formatSeasonEndCountdown', () => {
+  const mockEndDate = 1698771600 * 1000; //Nov 1, 2023
+  const mockCurrentDate = 1696168373 * 1000; //Oct 1, 2023
+
+  it('returns the correct format when seasonEnd and currentDate are in epoch time', () => {
+    const result = formatSeasonEndCountdown({
+      seasonEnd: mockEndDate,
+      currentDate: mockCurrentDate,
+    });
+
+    expect(result).toBe('30 days');
+  });
+  it('returns the correct format when seasonEnd is in Date format and currentDate is in epoch time', () => {
+    const result = formatSeasonEndCountdown({
+      seasonEnd: new Date(mockEndDate),
+      currentDate: mockCurrentDate,
+    });
+
+    expect(result).toBe('30 days');
+  });
+  it('returns the correct format when seasonEnd is in epoch time and currentDate is in Date format', () => {
+    const result = formatSeasonEndCountdown({
+      seasonEnd: mockEndDate,
+      currentDate: new Date(mockCurrentDate),
+    });
+
+    expect(result).toBe('30 days');
+  });
+  it('returns the correct format when seasonEnd and currentDate are in Date format', () => {
+    const result = formatSeasonEndCountdown({
+      seasonEnd: new Date(mockEndDate),
+      currentDate: new Date(mockCurrentDate),
+    });
+
+    expect(result).toBe('30 days');
+  });
+  it('returns the correct format when seasonEnd is less than a day to currentDate', () => {
+    const result = formatSeasonEndCountdown({
+      seasonEnd: mockEndDate,
+      currentDate: 1698750279 * 1000,
+    });
+
+    expect(result).toBe('6 hours');
+  });
+  it('returns the correct format when seasonEnd has passed currentDate', () => {
+    const result = formatSeasonEndCountdown({
+      seasonEnd: new Date(mockCurrentDate - 3600000),
+      currentDate: mockCurrentDate,
+    });
+
+    expect(result).toBeNull();
+  });
+});

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -540,14 +540,8 @@ export const formatSeasonEndCountdown = ({
   const hasEnded = isBefore(seasonEnd, currentDate);
   if (hasEnded) return null;
 
-  const difference = differenceInMilliseconds(currentDate, seasonEnd);
-  if (difference > 259200000) {
-    return formatDistanceStrict(seasonEnd, currentDate, {
-      unit: 'day',
-    });
-  } else {
-    return formatDistanceStrict(seasonEnd, currentDate, {
-      unit: 'hour',
-    });
-  }
+  const difference = differenceInMilliseconds(seasonEnd, currentDate);
+  return formatDistanceStrict(seasonEnd, currentDate, {
+    unit: difference < 259200000 ? 'hour' : 'day', //Show hours when it's less than 3 days left
+  });
 };

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { format, formatDistanceStrict } from 'date-fns';
+import { format } from 'date-fns';
 import {
   AnySelectMenuInteraction,
   APIEmbed,
@@ -32,7 +32,6 @@ import {
 } from '../schemas/mapRotation';
 import { Mixpanel } from 'mixpanel';
 import { sendAnalyticsEvent } from '../services/analytics';
-import { SeasonAPISchema } from '../schemas/season';
 
 export const serverNotificationEmbed = async ({
   app,
@@ -359,7 +358,7 @@ export const generatePubsEmbed = (
 export const generateRankedEmbed = (
   data: MapRotationRankedSchema | MapRotationArenasRankedSchema,
   type = 'Battle Royale',
-  season?: SeasonAPISchema
+  seasonEnd?: string
 ) => {
   const embedData: any = {
     title: `${type} | Ranked`,
@@ -367,13 +366,7 @@ export const generateRankedEmbed = (
     image: {
       url: type === 'Battle Royale' ? getMapUrl(data.current.code) : data.current.asset,
     },
-    description: season
-      ? `Season ends in ${inlineCode(
-          formatDistanceStrict(season.dates.End * 1000, new Date(), {
-            unit: 'day',
-          })
-        )}`
-      : null,
+    description: seasonEnd ? `Season ends in ${inlineCode(seasonEnd)}` : undefined,
     fields: [
       {
         name: 'Current map',

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { format, formatDistanceStrict } from 'date-fns';
+import { differenceInMilliseconds, format, formatDistanceStrict, isBefore } from 'date-fns';
 import {
   AnySelectMenuInteraction,
   APIEmbed,
@@ -358,7 +358,7 @@ export const generatePubsEmbed = (
 export const generateRankedEmbed = (
   data: MapRotationRankedSchema | MapRotationArenasRankedSchema,
   type = 'Battle Royale',
-  seasonEnd?: string
+  seasonEnd?: string | null
 ) => {
   const embedData: any = {
     title: `${type} | Ranked`,
@@ -535,9 +535,19 @@ export const formatSeasonEndCountdown = ({
   currentDate = new Date(),
 }: {
   seasonEnd: number | Date;
-  currentDate?: Date;
-}) => {
-  return formatDistanceStrict(seasonEnd, currentDate, {
-    unit: 'day',
-  });
+  currentDate?: number | Date;
+}): string | null => {
+  const hasEnded = isBefore(seasonEnd, currentDate);
+  if (hasEnded) return null;
+
+  const difference = differenceInMilliseconds(currentDate, seasonEnd);
+  if (difference > 259200000) {
+    return formatDistanceStrict(seasonEnd, currentDate, {
+      unit: 'day',
+    });
+  } else {
+    return formatDistanceStrict(seasonEnd, currentDate, {
+      unit: 'hour',
+    });
+  }
 };

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -368,7 +368,11 @@ export const generateRankedEmbed = (
       url: type === 'Battle Royale' ? getMapUrl(data.current.code) : data.current.asset,
     },
     description: season
-      ? `Season ends in ${inlineCode(formatDistanceStrict(season.dates.End * 1000, new Date()))}`
+      ? `Season ends in ${inlineCode(
+          formatDistanceStrict(season.dates.End * 1000, new Date(), {
+            unit: 'day',
+          })
+        )}`
       : null,
     fields: [
       {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { format } from 'date-fns';
+import { format, formatDistanceStrict } from 'date-fns';
 import {
   AnySelectMenuInteraction,
   APIEmbed,
@@ -528,4 +528,16 @@ export const sendWrongUserWarning = async ({
       eventName: 'Click wrong user button',
     });
   interaction.editReply({ embeds: [wrongUserEmbed] });
+};
+
+export const formatSeasonEndCountdown = ({
+  seasonEnd,
+  currentDate = new Date(),
+}: {
+  seasonEnd: number | Date;
+  currentDate?: Date;
+}) => {
+  return formatDistanceStrict(seasonEnd, currentDate, {
+    unit: 'day',
+  });
 };

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -1,4 +1,4 @@
-import { format } from 'date-fns';
+import { format, formatDistanceStrict } from 'date-fns';
 import {
   AnySelectMenuInteraction,
   APIEmbed,
@@ -32,6 +32,7 @@ import {
 } from '../schemas/mapRotation';
 import { Mixpanel } from 'mixpanel';
 import { sendAnalyticsEvent } from '../services/analytics';
+import { SeasonAPISchema } from '../schemas/season';
 
 export const serverNotificationEmbed = async ({
   app,
@@ -357,7 +358,8 @@ export const generatePubsEmbed = (
  */
 export const generateRankedEmbed = (
   data: MapRotationRankedSchema | MapRotationArenasRankedSchema,
-  type = 'Battle Royale'
+  type = 'Battle Royale',
+  season?: SeasonAPISchema
 ) => {
   const embedData: any = {
     title: `${type} | Ranked`,
@@ -365,6 +367,9 @@ export const generateRankedEmbed = (
     image: {
       url: type === 'Battle Royale' ? getMapUrl(data.current.code) : data.current.asset,
     },
+    description: season
+      ? `Season ends in ${inlineCode(formatDistanceStrict(season.dates.End * 1000, new Date()))}`
+      : null,
     fields: [
       {
         name: 'Current map',


### PR DESCRIPTION
#### Card
https://serenityy.atlassian.net/browse/SER-107

#### Context
Ever since ranked maps started going into rotation instead of a fixed map all season, we were unable to show the end date of the season. As of now, the apex legends API doesn't return this data in any of its endpoints. I could just not support this at all but I did some digging and apparently there is another api that does return this, albeit a less public one.

I've wired this up and created the relevant adapters, schemas and handlers to support the feature in this pr. We should definitely give credit to the owner of this api in our readmes and help commands before releasing this tho

![image](https://github.com/vexuas/nessie/assets/42207245/dea73cb2-8a22-48c2-8765-b151490a7f71)

#### Change
- Create adapter
- Create schema
- Update embed helpers to support season
- Create formatSeasonEndCountdown helper

#### Considerations
I've tested this using my current system's timezone i.e. GMT+8 and the results return as expected. However the server nessie is hosted in uses UTC. Again the formatting should return fine but there's an issue here for users in different time zones as there would be a difference in the season countdown. We could either be explicit in our description and say it's set in UTC or a more engineered approach and somehow calculate the countdown based on the user/server timezone. The latter isn't a walk in the park as discord doesn't offer any way in telling us the timezone of a user let alone the interaction. I'll have to sleep on this, not yet sure what I'll decide on doing
