### PR TITLE
Only edit status stop message if its not in status channel

### DIFF
--- a/src/commands/status/stop/index.ts
+++ b/src/commands/status/stop/index.ts
@@ -159,7 +159,10 @@ export const deleteGuildStatus = async ({
         description: `Automatic map status successfully deleted!`,
         color: 3066993,
       };
-      await interaction.message.edit({ embeds: [embedSuccess], components: [] });
+      battleRoyaleStatusChannel &&
+        interaction.channelId !== battleRoyaleStatusChannel.id &&
+        (await interaction.message.edit({ embeds: [embedSuccess], components: [] }));
+
       //Sends status deletion log after everything is done
       const statusLogChannel = nessie.channels.cache.get('976863441526595644');
       const statusLogEmbed = {


### PR DESCRIPTION
#### Context
There is an error that occurs sometimes when a user stops a status within the status channel itself. The issue comes from us trying to edit the interaction with a success message when the status channel already gets deleted. I've fixed now by only editing the message if it's not in the status channel

![image](https://github.com/vexuas/nessie/assets/42207245/b2fa9a15-e290-4c2b-94b5-9ef672096356)

<img width="381" alt="image" src="https://github.com/vexuas/nessie/assets/42207245/6ac7f845-5384-46d0-b862-ad6a714d7060">

#### Change
- Only edit status stop message if its not in status channel

#### Considerations
I only put the condition on battle royale status channels since there's only a couple of arenas still active. I'll figure out how to deal with mixtape later when it's actually implemented
