### PR TITLE
Move status logs as env variables

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "config:bot": "echo \"//Bot Configuration; Required\nexport const BOT_TOKEN = '';\nexport const BOT_ID = '';\nexport const GUILD_ID = '';\n\" >> src/config/environment.ts",
     "config:als": "echo \"//API key to retrieve apex data\nexport const ALS_API_KEY = '';\n\" >> src/config/environment.ts",
     "config:env": "echo \"//Environment\nexport const ENV = 'dev';\n\" >> src/config/environment.ts",
-    "config:notification": "echo \"//Notifications\nexport const GUILD_NOTIFICATION_WEBHOOK_URL = '';\nexport const ERROR_NOTIFICATION_WEBHOOK_URL = '';\nexport const BOOT_NOTIFICATION_CHANNEL_ID = '';\n\" >> src/config/environment.ts",
+    "config:notification": "echo \"//Notifications\nexport const GUILD_NOTIFICATION_WEBHOOK_URL = '';\nexport const ERROR_NOTIFICATION_WEBHOOK_URL = '';\nexport const STATUS_LOG_WEBHOOK_URL = '';\nexport const BOOT_NOTIFICATION_CHANNEL_ID = '';\n\" >> src/config/environment.ts",
     "config:database": "echo \"//Database\nexport const DATABASE_CONFIG = null;\n\" >> src/config/environment.ts",
     "config:product": "echo \"//Product Tracking\nexport const MIXPANEL_ID = '';\n\" >> src/config/environment.ts",
     "config:topgg": "echo \"//TopGG Tracking\nexport const TOP_GG_TOKEN = '';\n\" >> src/config/environment.ts",

--- a/src/commands/battleRoyale/index.ts
+++ b/src/commands/battleRoyale/index.ts
@@ -39,10 +39,12 @@ export default {
           data = await getBattleRoyaleRanked();
           const season = await getSeasonInformation();
           //TODO: Figure out formatting for different timezones eventually
-          const seasonEnd = formatSeasonEndCountdown({
-            seasonEnd: season.dates.End * 1000,
-            currentDate: new Date(),
-          });
+          const seasonEnd = season
+            ? formatSeasonEndCountdown({
+                seasonEnd: season.dates.End * 1000,
+                currentDate: new Date(),
+              })
+            : null;
           embed = generateRankedEmbed(data, 'Battle Royale', seasonEnd);
           break;
       }

--- a/src/commands/status/start/index.ts
+++ b/src/commands/status/start/index.ts
@@ -163,12 +163,17 @@ const generateConfirmStatusMessage = ({
  * Initially was pubs but data shows that br is overwhelmingly more popular than arenas
  * Had to split it between br and arenas after seeing that
  */
-const generateBattleRoyaleStatusEmbeds = (data: MapRotationAPIObject, season: SeasonAPISchema) => {
+const generateBattleRoyaleStatusEmbeds = (
+  data: MapRotationAPIObject,
+  season: SeasonAPISchema | null
+) => {
   const battleRoyalePubsEmbed = generatePubsEmbed(data.battle_royale);
-  const seasonEnd = formatSeasonEndCountdown({
-    seasonEnd: season.dates.End * 1000,
-    currentDate: new Date(),
-  });
+  const seasonEnd = season
+    ? formatSeasonEndCountdown({
+        seasonEnd: season.dates.End * 1000,
+        currentDate: new Date(),
+      })
+    : null;
   const battleRoyaleRankedEmbed = generateRankedEmbed(data.ranked, 'Battle Royale', seasonEnd);
   const informationEmbed = {
     description: '**Updates occur every 5 minutes**',

--- a/src/services/adapters.ts
+++ b/src/services/adapters.ts
@@ -9,6 +9,7 @@ import {
   MapRotationRankedSchema,
 } from '../schemas/mapRotation';
 import { SeasonAPISchema } from '../schemas/season';
+import { sendErrorLog } from '../utils/helpers';
 
 //Documentation on API: https://apexlegendsapi.com/documentation.php
 const url = `https://api.mozambiquehe.re/maprotation?version=2&auth=${ALS_API_KEY}`;
@@ -20,9 +21,14 @@ export async function getRotationData(): Promise<MapRotationAPIObject> {
   const response: string = (await got.get(url)).body;
   return JSON.parse(response);
 }
-export async function getSeasonInformation(): Promise<SeasonAPISchema> {
-  const response: string = (await got.get(seasonUrl)).body;
-  return JSON.parse(response);
+export async function getSeasonInformation(): Promise<SeasonAPISchema | null> {
+  try {
+    const response: string = (await got.get(seasonUrl)).body;
+    return JSON.parse(response);
+  } catch (error) {
+    sendErrorLog({ error });
+    return null;
+  }
 }
 
 export async function getBattleRoyalePubs(): Promise<MapRotationBattleRoyaleSchema> {


### PR DESCRIPTION
#### Context
There's still some hardcoded logging features that points towards my discord channels. I think these are probably the last instances of it. Similar to the guild notifications, this will use webhooks that are specified in the `environment` config. 

Also noticed that the season endpoint was erroring out while implementing this. We don't really want this to block the actual map rotaiton embeds so made it return null whenever it does fail

Previously:
![image](https://github.com/vexuas/nessie/assets/42207245/4fdcee64-8017-4961-afca-3720af75f513)

After:
![image](https://github.com/vexuas/nessie/assets/42207245/d59ef2c1-80c4-48fa-a885-735db975b8c6)

![image](https://github.com/vexuas/nessie/assets/42207245/69fc02b6-5490-4524-a72d-2ee79dacdf96)

#### Change
- Add variable to config setup
- Refactor status logs
- Return null if season information adapter errors
