### PR TITLE
Use v2 of season endpoint

### DIFF
--- a/src/commands/battleRoyale/index.ts
+++ b/src/commands/battleRoyale/index.ts
@@ -38,6 +38,7 @@ export default {
         case 'br_ranked':
           data = await getBattleRoyaleRanked();
           const season = await getSeasonInformation();
+          console.log(season);
           //TODO: Figure out formatting for different timezones eventually
           const seasonEnd = season
             ? formatSeasonEndCountdown({

--- a/src/commands/battleRoyale/index.ts
+++ b/src/commands/battleRoyale/index.ts
@@ -38,14 +38,11 @@ export default {
         case 'br_ranked':
           data = await getBattleRoyaleRanked();
           const season = await getSeasonInformation();
-          console.log(season);
           //TODO: Figure out formatting for different timezones eventually
-          const seasonEnd = season
-            ? formatSeasonEndCountdown({
-                seasonEnd: season.dates.end.rankedEnd * 1000,
-                currentDate: new Date(),
-              })
-            : null;
+          const seasonEnd = formatSeasonEndCountdown({
+            season,
+            currentDate: new Date(),
+          });
           embed = generateRankedEmbed(data, 'Battle Royale', seasonEnd);
           break;
       }

--- a/src/commands/battleRoyale/index.ts
+++ b/src/commands/battleRoyale/index.ts
@@ -42,7 +42,7 @@ export default {
           //TODO: Figure out formatting for different timezones eventually
           const seasonEnd = season
             ? formatSeasonEndCountdown({
-                seasonEnd: season.dates.End * 1000,
+                seasonEnd: season.dates.end.rankedEnd * 1000,
                 currentDate: new Date(),
               })
             : null;

--- a/src/commands/status/start/index.ts
+++ b/src/commands/status/start/index.ts
@@ -170,7 +170,7 @@ const generateBattleRoyaleStatusEmbeds = (
   const battleRoyalePubsEmbed = generatePubsEmbed(data.battle_royale);
   const seasonEnd = season
     ? formatSeasonEndCountdown({
-        seasonEnd: season.dates.End * 1000,
+        seasonEnd: season.dates.end.rankedEnd * 1000,
         currentDate: new Date(),
       })
     : null;

--- a/src/commands/status/start/index.ts
+++ b/src/commands/status/start/index.ts
@@ -168,12 +168,10 @@ const generateBattleRoyaleStatusEmbeds = (
   season: SeasonAPISchema | null
 ) => {
   const battleRoyalePubsEmbed = generatePubsEmbed(data.battle_royale);
-  const seasonEnd = season
-    ? formatSeasonEndCountdown({
-        seasonEnd: season.dates.end.rankedEnd * 1000,
-        currentDate: new Date(),
-      })
-    : null;
+  const seasonEnd = formatSeasonEndCountdown({
+    season,
+    currentDate: new Date(),
+  });
   const battleRoyaleRankedEmbed = generateRankedEmbed(data.ranked, 'Battle Royale', seasonEnd);
   const informationEmbed = {
     description: '**Updates occur every 5 minutes**',

--- a/src/schemas/season.ts
+++ b/src/schemas/season.ts
@@ -1,12 +1,32 @@
 export interface SeasonAPISchema {
   info: {
-    ID: number;
-    Name: string;
-    Split: number;
+    season: number;
+    title: string;
+    split: number;
+    data: {
+      tagline: string;
+      url: string;
+      image: string;
+    };
   };
   dates: {
-    Start: number;
-    Split: number;
-    End: number;
+    start: {
+      timestamp: number;
+      readable: string;
+      since: number;
+      untilNext: number;
+    };
+    split: {
+      timestamp: number;
+      readable: string;
+      since: number;
+      untilNext: number;
+    };
+    end: {
+      timestamp: number;
+      readable: string;
+      rankedEnd: number;
+      rankedEndReadable: string;
+    };
   };
 }

--- a/src/services/adapters.ts
+++ b/src/services/adapters.ts
@@ -15,7 +15,7 @@ import { sendErrorLog } from '../utils/helpers';
 const url = `https://api.mozambiquehe.re/maprotation?version=2&auth=${ALS_API_KEY}`;
 //Less publicly known api to retrieve season data; kudos to @SDCore
 //No authentication + rate limited so we should be mindful in using this
-const seasonUrl = 'https://api.jumpmaster.xyz/seasons/Current';
+const seasonUrl = 'https://api.jumpmaster.xyz/seasons/Current?version=2';
 
 export async function getRotationData(): Promise<MapRotationAPIObject> {
   const response: string = (await got.get(url)).body;

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -2,55 +2,70 @@ import { formatSeasonEndCountdown } from './helpers';
 
 //TODO: Add tests for other helpers here too eventually
 describe('formatSeasonEndCountdown', () => {
-  const mockEndDate = 1698771600 * 1000; //Nov 1, 2023
+  const mockSeason = {
+    info: {
+      season: 18,
+      title: 'Resurrection',
+      split: 2,
+      data: {
+        tagline: 'Death is Reborn.',
+        url: 'https://www.ea.com/games/apex-legends/resurrection',
+        image: 'https://cdn.jumpmaster.xyz/Bot/Legends/Banners/Revenant.png',
+      },
+    },
+    dates: {
+      start: {
+        timestamp: 1691514000,
+        readable: '08-08-2023 17:00:00',
+        since: 5221210,
+        untilNext: 0,
+      },
+      split: {
+        timestamp: 1695142800,
+        readable: '09-19-2023 17:00:00',
+        since: 1592410,
+        untilNext: 2036390,
+      },
+      end: {
+        timestamp: 1698771600,
+        readable: '10-31-2023 17:00:00',
+        rankedEnd: 1698769800,
+        rankedEndReadable: '10-31-2023 16:30:00',
+      },
+    },
+  };
   const mockCurrentDate = 1696168373 * 1000; //Oct 1, 2023
 
-  it('returns the correct format when seasonEnd and currentDate are in epoch time', () => {
+  it('returns the correct format when season end and currentDate are in epoch time', () => {
     const result = formatSeasonEndCountdown({
-      seasonEnd: mockEndDate,
+      season: mockSeason,
       currentDate: mockCurrentDate,
     });
 
     expect(result).toBe('30 days');
   });
-  it('returns the correct format when seasonEnd is in Date format and currentDate is in epoch time', () => {
+  it('returns the correct format when season end is in epoch time and currentDate is in Date format', () => {
     const result = formatSeasonEndCountdown({
-      seasonEnd: new Date(mockEndDate),
-      currentDate: mockCurrentDate,
-    });
-
-    expect(result).toBe('30 days');
-  });
-  it('returns the correct format when seasonEnd is in epoch time and currentDate is in Date format', () => {
-    const result = formatSeasonEndCountdown({
-      seasonEnd: mockEndDate,
+      season: mockSeason,
       currentDate: new Date(mockCurrentDate),
     });
 
     expect(result).toBe('30 days');
   });
-  it('returns the correct format when seasonEnd and currentDate are in Date format', () => {
+  it('returns the correct format when season end is less than a day to currentDate', () => {
     const result = formatSeasonEndCountdown({
-      seasonEnd: new Date(mockEndDate),
-      currentDate: new Date(mockCurrentDate),
-    });
-
-    expect(result).toBe('30 days');
-  });
-  it('returns the correct format when seasonEnd is less than a day to currentDate', () => {
-    const result = formatSeasonEndCountdown({
-      seasonEnd: mockEndDate,
+      season: mockSeason,
       currentDate: 1698750279 * 1000,
     });
 
-    expect(result).toBe('6 hours');
+    expect(result).toBe('5 hours');
   });
-  it('returns the correct format when seasonEnd has passed currentDate', () => {
+  it('returns the correct format when currentDate has passed season end', () => {
     const result = formatSeasonEndCountdown({
-      seasonEnd: new Date(mockCurrentDate - 3600000),
-      currentDate: mockCurrentDate,
+      season: mockSeason,
+      currentDate: (mockSeason.dates.end.rankedEnd + 360000) * 1000,
     });
 
-    expect(result).toBeNull();
+    expect(result).toBeUndefined();
   });
 });

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -32,6 +32,7 @@ import {
 } from '../schemas/mapRotation';
 import { Mixpanel } from 'mixpanel';
 import { sendAnalyticsEvent } from '../services/analytics';
+import { SeasonAPISchema } from '../schemas/season';
 
 export const serverNotificationEmbed = async ({
   app,
@@ -358,7 +359,7 @@ export const generatePubsEmbed = (
 export const generateRankedEmbed = (
   data: MapRotationRankedSchema | MapRotationArenasRankedSchema,
   type = 'Battle Royale',
-  seasonEnd?: string | null
+  seasonEnd?: string
 ) => {
   const embedData: any = {
     title: `${type} | Ranked`,
@@ -531,14 +532,16 @@ export const sendWrongUserWarning = async ({
 };
 
 export const formatSeasonEndCountdown = ({
-  seasonEnd,
+  season,
   currentDate = new Date(),
 }: {
-  seasonEnd: number | Date;
+  season: SeasonAPISchema | null;
   currentDate?: number | Date;
-}): string | null => {
+}): string | undefined => {
+  if (!season) return;
+  const seasonEnd = season.dates.end.rankedEnd * 1000;
   const hasEnded = isBefore(seasonEnd, currentDate);
-  if (hasEnded) return null;
+  if (hasEnded) return;
 
   const difference = differenceInMilliseconds(seasonEnd, currentDate);
   return formatDistanceStrict(seasonEnd, currentDate, {


### PR DESCRIPTION
#### Card
https://serenityy.atlassian.net/browse/SER-113

#### Context
Apparently there's a v2 of the season endpoint which has a lot more detailed data and better structure. I've updated the adapters and schemas accordingly as well as some refactors to its format helper.

Kudos to @SDCore for the information!

Doesn't really have a change to UI from the previous version:
![image](https://github.com/vexuas/nessie/assets/42207245/36b78128-0795-4927-b8b4-12206ca02520)

#### Change
- Update adapter
- Update schema
- Refactor season format helper
- Update tests

#### Considerations
Might be interesting to see what we can cook up with all the detailed season data but I'll probably look into that after this current season ends since not really sure what's a proper ux for the splits atm
