### PR TITLE
Cache season data in memory

### DIFF
--- a/src/commands/battleRoyale/index.ts
+++ b/src/commands/battleRoyale/index.ts
@@ -13,6 +13,8 @@ import {
 } from '../../utils/helpers';
 import { AppCommand, AppCommandOptions } from '../commands';
 
+//Cache season data as we don't want to abuse the API as well as only needing the end date anyway
+//Isn't the best way storing this in a variable but didn't want to overengineer and having it in the database for now
 let cachedSeason: SeasonAPISchema | null = null;
 
 export default {

--- a/src/commands/battleRoyale/index.ts
+++ b/src/commands/battleRoyale/index.ts
@@ -41,7 +41,7 @@ export default {
         case 'br_ranked':
           data = await getBattleRoyaleRanked();
           const season = cachedSeason ?? (await getSeasonInformation());
-          cachedSeason = season;
+          if (!cachedSeason) cachedSeason = season;
           //TODO: Figure out formatting for different timezones eventually
           const seasonEnd = formatSeasonEndCountdown({
             season,

--- a/src/commands/battleRoyale/index.ts
+++ b/src/commands/battleRoyale/index.ts
@@ -1,4 +1,5 @@
 import { SlashCommandBuilder } from 'discord.js';
+import { SeasonAPISchema } from '../../schemas/season';
 import {
   getBattleRoyalePubs,
   getBattleRoyaleRanked,
@@ -11,6 +12,8 @@ import {
   sendErrorLog,
 } from '../../utils/helpers';
 import { AppCommand, AppCommandOptions } from '../commands';
+
+let cachedSeason: SeasonAPISchema | null = null;
 
 export default {
   commandType: 'Maps',
@@ -37,7 +40,8 @@ export default {
           break;
         case 'br_ranked':
           data = await getBattleRoyaleRanked();
-          const season = await getSeasonInformation();
+          const season = cachedSeason ?? (await getSeasonInformation());
+          cachedSeason = season;
           //TODO: Figure out formatting for different timezones eventually
           const seasonEnd = formatSeasonEndCountdown({
             season,

--- a/src/commands/status/start/index.ts
+++ b/src/commands/status/start/index.ts
@@ -49,6 +49,8 @@ import { sendAnalyticsEvent } from '../../../services/analytics';
 import { MapRotationAPIObject } from '../../../schemas/mapRotation';
 import { SeasonAPISchema } from '../../../schemas/season';
 
+//Cache season data as we don't want to abuse the API as well as only needing the end date anyway
+//Isn't the best way storing this in a variable but didn't want to overengineer and having it in the database for now
 let cachedSeason: SeasonAPISchema | null = null;
 
 const errorNotification = {

--- a/src/commands/status/start/index.ts
+++ b/src/commands/status/start/index.ts
@@ -49,6 +49,8 @@ import { sendAnalyticsEvent } from '../../../services/analytics';
 import { MapRotationAPIObject } from '../../../schemas/mapRotation';
 import { SeasonAPISchema } from '../../../schemas/season';
 
+let cachedSeason: SeasonAPISchema | null = null;
+
 const errorNotification = {
   count: 0,
   message: '',
@@ -429,7 +431,8 @@ export const createStatus = async ({
     await interaction.message.edit({ embeds: [embedLoadingChannels], components: [] });
 
     const rotationData = await getRotationData();
-    const seasonData = await getSeasonInformation();
+    const seasonData = cachedSeason ?? (await getSeasonInformation());
+    cachedSeason = seasonData;
     const statusBattleRoyaleEmbed = generateBattleRoyaleStatusEmbeds(rotationData, seasonData);
     /**
      * Gets the @everyone role of the guild
@@ -550,7 +553,8 @@ export const scheduleStatus = (nessie: Client) => {
     try {
       if (allStatus) {
         const rotationData = await getRotationData();
-        const seasonData = await getSeasonInformation();
+        const seasonData = cachedSeason ?? (await getSeasonInformation());
+        cachedSeason = seasonData;
         const brStatusEmbeds = generateBattleRoyaleStatusEmbeds(rotationData, seasonData);
         const arenasStatusEmbeds = generateArenasStatusEmbeds(rotationData);
         allStatus.forEach(async (status, index) => {

--- a/src/commands/status/start/index.ts
+++ b/src/commands/status/start/index.ts
@@ -432,7 +432,7 @@ export const createStatus = async ({
 
     const rotationData = await getRotationData();
     const seasonData = cachedSeason ?? (await getSeasonInformation());
-    cachedSeason = seasonData;
+    if (!cachedSeason) cachedSeason = seasonData;
     const statusBattleRoyaleEmbed = generateBattleRoyaleStatusEmbeds(rotationData, seasonData);
     /**
      * Gets the @everyone role of the guild
@@ -554,7 +554,7 @@ export const scheduleStatus = (nessie: Client) => {
       if (allStatus) {
         const rotationData = await getRotationData();
         const seasonData = cachedSeason ?? (await getSeasonInformation());
-        cachedSeason = seasonData;
+        if (!cachedSeason) cachedSeason = seasonData;
         const brStatusEmbeds = generateBattleRoyaleStatusEmbeds(rotationData, seasonData);
         const arenasStatusEmbeds = generateArenasStatusEmbeds(rotationData);
         allStatus.forEach(async (status, index) => {


### PR DESCRIPTION
#### Card
https://serenityy.atlassian.net/browse/SER-109

#### Context
Even with permission to use the season API, I still don't want to hit it and potentially veer into abuse as this will be eventually used with the automatic status feature; where currently requests fire every 5 minutes. It's honestly still pretty far from it but I'd rather stay on the side of caution. Also since season data doesn't really change much, it's not as necessary to always get the most recent response.

I initially thought of storing it inside our database but figured since I don't really know exactly how I'm going to use the data fully atm, I opted to just store it in memory through a couple of local variables. I don't think it's as bad as it looks since my droplet should be able to handle a small change to memory size and we're only really updating if the data doesn't exist.

#### Change
- Create cached variable in br and status start files
- Only update cache if it doesnt exist
