### PR TITLE
Add SDCore to list of sources

### DIFF
--- a/src/commands/about/index.ts
+++ b/src/commands/about/index.ts
@@ -8,10 +8,13 @@ import { nessieLogo } from '../../utils/constants';
 export const generateAboutEmbed = (app?: Client): APIEmbed => {
   const embed = {
     title: 'Info',
-    description: `Hi there! I’m Nessie and I provide an easy way to get status updates of Map Rotations in Apex Legends! Hope that you can find me useful (◕ᴗ◕✿)\n\nTry out my cool feature: **Automatic Map Updates**! To check out what it is, use \`/status help\`!\n\nAll my data is extracted from the great works of ${hyperlink(
+    description: `Hi there! I’m Nessie and I provide an easy way to get status updates of Map Rotations in Apex Legends! Hope that you can find me useful (◕ᴗ◕✿)\n\nTry out my cool feature: **Automatic Map Updates**! To check out what it is, use \`/status help\`!\n\nAll my data is extracted from the great works of:\n• ${hyperlink(
       'Apex Legends API',
       'https://apexlegendsapi.com'
-    )}. Go support them too, it’s a cool project!`,
+    )}\n• ${hyperlink(
+      '@SDCore',
+      'https://github.com/SDCore'
+    )}\n Go support them too, they have really cool projects!`,
     color: getEmbedColor(),
     thumbnail: {
       url: nessieLogo,


### PR DESCRIPTION
#### Card
https://serenityy.atlassian.net/browse/SER-110

#### Context
Season API is really useful and we can potentially do quite a bit with it. It's the least we can do is to add attribution to show our support. I've asked SDCore about it and he's cool with having his github as the link.

![image](https://github.com/vexuas/nessie/assets/42207245/fd8344de-c540-4c8e-bd30-7bedd6efb5ef)

#### Change
- ADD SDCore to about command