### PR TITLE
Add split end to ranked embed

### DIFF
--- a/src/commands/battleRoyale/index.ts
+++ b/src/commands/battleRoyale/index.ts
@@ -7,6 +7,7 @@ import {
 } from '../../services/adapters';
 import {
   formatSeasonEndCountdown,
+  formatSplitEndCountdown,
   generatePubsEmbed,
   generateRankedEmbed,
   sendErrorLog,
@@ -49,7 +50,11 @@ export default {
             season,
             currentDate: new Date(),
           });
-          embed = generateRankedEmbed(data, 'Battle Royale', seasonEnd);
+          const splitEnd = formatSplitEndCountdown({
+            season,
+            currentDate: new Date(),
+          });
+          embed = generateRankedEmbed(data, 'Battle Royale', seasonEnd, splitEnd);
           break;
       }
       await interaction.editReply({ embeds: [embed] });

--- a/src/commands/battleRoyale/index.ts
+++ b/src/commands/battleRoyale/index.ts
@@ -6,8 +6,7 @@ import {
   getSeasonInformation,
 } from '../../services/adapters';
 import {
-  formatSeasonEndCountdown,
-  formatSplitEndCountdown,
+  formatEndDateCountdown,
   generatePubsEmbed,
   generateRankedEmbed,
   sendErrorLog,
@@ -46,14 +45,18 @@ export default {
           const season = cachedSeason ?? (await getSeasonInformation());
           if (!cachedSeason) cachedSeason = season;
           //TODO: Figure out formatting for different timezones eventually
-          const seasonEnd = formatSeasonEndCountdown({
-            season,
-            currentDate: new Date(),
-          });
-          const splitEnd = formatSplitEndCountdown({
-            season,
-            currentDate: new Date(),
-          });
+          const seasonEnd = season
+            ? formatEndDateCountdown({
+                endDate: season.dates.end.rankedEnd * 1000,
+                currentDate: new Date(),
+              })
+            : null;
+          const splitEnd = season
+            ? formatEndDateCountdown({
+                endDate: season.dates.split.timestamp * 1000,
+                currentDate: new Date(),
+              })
+            : null;
           embed = generateRankedEmbed(data, 'Battle Royale', seasonEnd, splitEnd);
           break;
       }

--- a/src/commands/status/start/index.ts
+++ b/src/commands/status/start/index.ts
@@ -32,7 +32,7 @@ import {
   generateErrorEmbed,
   sendErrorLog,
   sendStatusErrorLog,
-  formatSeasonEndCountdown,
+  formatEndDateCountdown,
   pluralize,
 } from '../../../utils/helpers';
 import { v4 as uuidV4 } from 'uuid';
@@ -187,11 +187,24 @@ const generateBattleRoyaleStatusEmbeds = (
   season: SeasonAPISchema | null
 ) => {
   const battleRoyalePubsEmbed = generatePubsEmbed(data.battle_royale);
-  const seasonEnd = formatSeasonEndCountdown({
-    season,
-    currentDate: new Date(),
-  });
-  const battleRoyaleRankedEmbed = generateRankedEmbed(data.ranked, 'Battle Royale', seasonEnd);
+  const seasonEnd = season
+    ? formatEndDateCountdown({
+        endDate: season.dates.end.rankedEnd * 1000,
+        currentDate: new Date(),
+      })
+    : null;
+  const splitEnd = season
+    ? formatEndDateCountdown({
+        endDate: season.dates.split.timestamp * 1000,
+        currentDate: new Date(),
+      })
+    : null;
+  const battleRoyaleRankedEmbed = generateRankedEmbed(
+    data.ranked,
+    'Battle Royale',
+    seasonEnd,
+    splitEnd
+  );
   const informationEmbed = {
     description: '**Updates occur every 5 minutes**',
     color: 3447003,

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -1,69 +1,38 @@
-import { formatSeasonEndCountdown, pluralize } from './helpers';
+import { formatEndDateCountdown, pluralize } from './helpers';
 
 //TODO: Add tests for other helpers here too eventually
-describe('formatSeasonEndCountdown', () => {
-  const mockSeason = {
-    info: {
-      season: 18,
-      title: 'Resurrection',
-      split: 2,
-      data: {
-        tagline: 'Death is Reborn.',
-        url: 'https://www.ea.com/games/apex-legends/resurrection',
-        image: 'https://cdn.jumpmaster.xyz/Bot/Legends/Banners/Revenant.png',
-      },
-    },
-    dates: {
-      start: {
-        timestamp: 1691514000,
-        readable: '08-08-2023 17:00:00',
-        since: 5221210,
-        untilNext: 0,
-      },
-      split: {
-        timestamp: 1695142800,
-        readable: '09-19-2023 17:00:00',
-        since: 1592410,
-        untilNext: 2036390,
-      },
-      end: {
-        timestamp: 1698771600,
-        readable: '10-31-2023 17:00:00',
-        rankedEnd: 1698769800,
-        rankedEndReadable: '10-31-2023 16:30:00',
-      },
-    },
-  };
+describe('formatEndDateCountdown', () => {
+  const mockEndDate = 1698769800 * 1000;
   const mockCurrentDate = 1696168373 * 1000; //Oct 1, 2023
 
-  it('returns the correct format when season end and currentDate are in epoch time', () => {
-    const result = formatSeasonEndCountdown({
-      season: mockSeason,
+  it('returns the correct format when endDate and currentDate are in epoch time', () => {
+    const result = formatEndDateCountdown({
+      endDate: mockEndDate,
       currentDate: mockCurrentDate,
     });
 
     expect(result).toBe('30 days');
   });
   it('returns the correct format when season end is in epoch time and currentDate is in Date format', () => {
-    const result = formatSeasonEndCountdown({
-      season: mockSeason,
+    const result = formatEndDateCountdown({
+      endDate: mockEndDate,
       currentDate: new Date(mockCurrentDate),
     });
 
     expect(result).toBe('30 days');
   });
   it('returns the correct format when season end is less than a day to currentDate', () => {
-    const result = formatSeasonEndCountdown({
-      season: mockSeason,
+    const result = formatEndDateCountdown({
+      endDate: mockEndDate,
       currentDate: 1698750279 * 1000,
     });
 
     expect(result).toBe('5 hours');
   });
   it('returns the correct format when currentDate has passed season end', () => {
-    const result = formatSeasonEndCountdown({
-      season: mockSeason,
-      currentDate: (mockSeason.dates.end.rankedEnd + 360000) * 1000,
+    const result = formatEndDateCountdown({
+      endDate: mockEndDate,
+      currentDate: (mockEndDate + 360000) * 1000,
     });
 
     expect(result).toBeUndefined();

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -359,7 +359,8 @@ export const generatePubsEmbed = (
 export const generateRankedEmbed = (
   data: MapRotationRankedSchema | MapRotationArenasRankedSchema,
   type = 'Battle Royale',
-  seasonEnd?: string
+  seasonEnd?: string,
+  splitEnd?: string
 ) => {
   const embedData: any = {
     title: `${type} | Ranked`,
@@ -367,7 +368,12 @@ export const generateRankedEmbed = (
     image: {
       url: type === 'Battle Royale' ? getMapUrl(data.current.code) : data.current.asset,
     },
-    description: seasonEnd ? `Season ends in ${inlineCode(seasonEnd)}` : undefined,
+    description:
+      splitEnd || seasonEnd
+        ? `${splitEnd ? `Split ends in ${inlineCode(splitEnd)}\n` : ''}${
+            seasonEnd ? `Season ends in ${inlineCode(seasonEnd)}` : ''
+          }`
+        : undefined,
     fields: [
       {
         name: 'Current map',

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -32,7 +32,6 @@ import {
 } from '../schemas/mapRotation';
 import { Mixpanel } from 'mixpanel';
 import { sendAnalyticsEvent } from '../services/analytics';
-import { SeasonAPISchema } from '../schemas/season';
 
 export const serverNotificationEmbed = async ({
   app,
@@ -359,8 +358,8 @@ export const generatePubsEmbed = (
 export const generateRankedEmbed = (
   data: MapRotationRankedSchema | MapRotationArenasRankedSchema,
   type = 'Battle Royale',
-  seasonEnd?: string,
-  splitEnd?: string
+  seasonEnd?: string | null,
+  splitEnd?: string | null
 ) => {
   const embedData: any = {
     title: `${type} | Ranked`,
@@ -537,38 +536,18 @@ export const sendWrongUserWarning = async ({
   interaction.editReply({ embeds: [wrongUserEmbed] });
 };
 
-export const formatSeasonEndCountdown = ({
-  season,
+export const formatEndDateCountdown = ({
+  endDate,
   currentDate = new Date(),
 }: {
-  season: SeasonAPISchema | null;
+  endDate: number;
   currentDate?: number | Date;
 }): string | undefined => {
-  if (!season) return;
-  const seasonEnd = season.dates.end.rankedEnd * 1000;
-  const hasEnded = isBefore(seasonEnd, currentDate);
+  const hasEnded = isBefore(endDate, currentDate);
   if (hasEnded) return;
 
-  const difference = differenceInMilliseconds(seasonEnd, currentDate);
-  return formatDistanceStrict(seasonEnd, currentDate, {
-    unit: difference < 259200000 ? 'hour' : 'day', //Show hours when it's less than 3 days left
-  });
-};
-
-export const formatSplitEndCountdown = ({
-  season,
-  currentDate = new Date(),
-}: {
-  season: SeasonAPISchema | null;
-  currentDate?: number | Date;
-}): string | undefined => {
-  if (!season) return;
-  const splitEnd = season.dates.split.timestamp * 1000;
-  const hasEnded = isBefore(splitEnd, currentDate);
-  if (hasEnded) return;
-
-  const difference = differenceInMilliseconds(splitEnd, currentDate);
-  return formatDistanceStrict(splitEnd, currentDate, {
+  const difference = differenceInMilliseconds(endDate, currentDate);
+  return formatDistanceStrict(endDate, currentDate, {
     unit: difference < 259200000 ? 'hour' : 'day', //Show hours when it's less than 3 days left
   });
 };

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -549,5 +549,23 @@ export const formatSeasonEndCountdown = ({
   });
 };
 
+export const formatSplitEndCountdown = ({
+  season,
+  currentDate = new Date(),
+}: {
+  season: SeasonAPISchema | null;
+  currentDate?: number | Date;
+}): string | undefined => {
+  if (!season) return;
+  const splitEnd = season.dates.split.timestamp * 1000;
+  const hasEnded = isBefore(splitEnd, currentDate);
+  if (hasEnded) return;
+
+  const difference = differenceInMilliseconds(splitEnd, currentDate);
+  return formatDistanceStrict(splitEnd, currentDate, {
+    unit: difference < 259200000 ? 'hour' : 'day', //Show hours when it's less than 3 days left
+  });
+};
+
 export const pluralize = (count: number, text: string) =>
   `${count} ${text}${count !== 1 ? 's' : ''}`;

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -370,7 +370,7 @@ export const generateRankedEmbed = (
     },
     description:
       splitEnd || seasonEnd
-        ? `${splitEnd ? `Split ends in ${inlineCode(splitEnd)}\n` : ''}${
+        ? `${splitEnd ? `Split ends in ${inlineCode(splitEnd)} • ` : ''}${
             seasonEnd ? `Season ends in ${inlineCode(seasonEnd)}` : ''
           }`
         : undefined,


### PR DESCRIPTION
#### Card
https://serenityy.atlassian.net/browse/SER-120

#### Context
I was holding off adding split end when I hooked up the season end last time; primarily cuz I had no idea what it would look like. Now with the new season I'm more confident on how the data looks like hence adding this in. Might end up creating that season information command as well

![image](https://github.com/vexuas/nessie/assets/42207245/dbae9b92-c148-4b8b-b1dd-1ebcfe4b554a)

#### Change
- Standardize formatSeasonEndCountdown helper to take in date instead
- Add split description in ranked embed
