### PR TITLE
Create season command

### DIFF
--- a/src/commands/mixtape/index.test.ts
+++ b/src/commands/mixtape/index.test.ts
@@ -33,7 +33,7 @@ const mockData: MapRotationMixtapeSchema = {
   },
 };
 
-describe('Ltm Command', () => {
+describe('Mixtape Command', () => {
   it('generates an embed correctly', () => {
     const embed = generateMixtapeEmbed(mockData);
 

--- a/src/commands/season/index.test.ts
+++ b/src/commands/season/index.test.ts
@@ -1,0 +1,106 @@
+import { format } from 'date-fns';
+import { cloneDeep } from 'lodash';
+import { generateSeasonEmbed } from '.';
+import { SeasonAPISchema } from '../../schemas/season';
+
+const mockData: SeasonAPISchema = {
+  info: {
+    season: 19,
+    title: 'Ignite',
+    description:
+      'Light the way with Conduit, the new support Legend whose shield-based abilities and infectious energy shine as the core of any squad.',
+    split: 1,
+    data: {
+      tagline: 'Time to shine.',
+      url: 'https://www.ea.com/games/apex-legends/ignite',
+      image: 'https://cdn.jumpmaster.xyz/Bot/Legends/Banners/Conduit.png',
+    },
+  },
+  dates: {
+    start: {
+      timestamp: 1698771600,
+      readable: '10-31-2023 17:00:00',
+      since: 1532743,
+      untilNext: 2704457,
+    },
+    split: {
+      timestamp: 1703008800,
+      readable: '12-19-2023 18:00:00',
+      since: 0,
+      untilNext: 7542857,
+    },
+    end: {
+      timestamp: 1707847200,
+      readable: '02-13-2024 18:00:00',
+      rankedEnd: 1707845400,
+      rankedEndReadable: '02-13-2024 17:30:00',
+    },
+  },
+};
+
+describe('Season Command', () => {
+  it('generates an embed correctly', () => {
+    const embed = generateSeasonEmbed(mockData);
+
+    expect(embed).not.toBeUndefined();
+  });
+  it('displays the correct fields in the embed', () => {
+    const embed = generateSeasonEmbed(mockData);
+
+    expect(embed.title).not.toBeUndefined();
+    expect(embed.color).not.toBeUndefined();
+    expect(embed.image).not.toBeUndefined();
+    expect(embed.image?.url).not.toBeUndefined();
+    expect(embed.fields).not.toBeUndefined();
+    expect(embed.fields?.length).toBe(2);
+  });
+  it('displays the correct title', () => {
+    const embed = generateSeasonEmbed(mockData);
+
+    expect(embed.title).toBe(`Season ${mockData.info.season} | ${mockData.info.title}`);
+  });
+  it('displays the correct description if season description is present', () => {
+    const embed = generateSeasonEmbed(mockData);
+
+    expect(embed.description).toContain(mockData.info.description);
+    expect(embed.description).toContain(
+      format(new Date(mockData.dates.start.readable), 'dd MMM yyyy, h:mm a')
+    );
+    expect(embed.description).toContain(mockData.info.split.toString());
+  });
+  it('displays the correct description if season description is not present', () => {
+    const _mockData: SeasonAPISchema = cloneDeep(mockData);
+    _mockData.info.description = undefined;
+
+    const embed = generateSeasonEmbed(_mockData);
+
+    expect(embed.description).not.toContain(mockData.info.description);
+    expect(embed.description).toContain(
+      format(new Date(mockData.dates.start.readable), 'dd MMM yyyy, h:mm a')
+    );
+    expect(embed.description).toContain(mockData.info.split.toString());
+  });
+  it('displays the correct image url', () => {
+    const embed = generateSeasonEmbed(mockData);
+
+    expect(embed.image?.url).toBe(mockData.info.data.image);
+  });
+  it('displays the correct value in the Split End field', () => {
+    const embed = generateSeasonEmbed(mockData);
+
+    expect(embed.fields && embed.fields[0].name).toBe('Split End');
+    expect(embed.fields && embed.fields[0].value).toContain(
+      format(new Date(mockData.dates.split.readable), 'dd MMM yyyy, h:mm a')
+    );
+    expect(embed.fields && embed.fields[0].value).toContain('31 days');
+  });
+  it('displays the correct value in the Season End field', () => {
+    const embed = generateSeasonEmbed(mockData);
+
+    expect(embed.fields && embed.fields[1].name).toBe('Season End');
+    expect(embed.fields && embed.fields[1].value).toContain(
+      format(new Date(mockData.dates.end.rankedEndReadable), 'dd MMM yyyy, h:mm a')
+    );
+    expect(embed.fields && embed.fields[1].value).toContain('87 days');
+  });
+});

--- a/src/commands/season/index.ts
+++ b/src/commands/season/index.ts
@@ -56,6 +56,7 @@ export default {
   async execute({ interaction }: AppCommandOptions) {
     try {
       const seasonData = await getSeasonInformation();
+      console.log(seasonData);
       if (!seasonData)
         return await interaction.reply('Unavailable to get season data, try again later!');
       const embed = generateSeasonEmbed(seasonData);

--- a/src/commands/season/index.tsx
+++ b/src/commands/season/index.tsx
@@ -1,6 +1,60 @@
-import { SlashCommandBuilder } from 'discord.js';
-import { sendErrorLog } from '../../utils/helpers';
+import { format } from 'date-fns';
+import { APIEmbed, SlashCommandBuilder } from 'discord.js';
+import { SeasonAPISchema } from '../../schemas/season';
+import { getSeasonInformation } from '../../services/adapters';
+import { formatEndDateCountdown, getEmbedColor, sendErrorLog } from '../../utils/helpers';
 import { AppCommand, AppCommandOptions } from '../commands';
+
+export const generateSeasonEmbed = (season: SeasonAPISchema) => {
+  const { info, dates } = season;
+  const embed: APIEmbed = {
+    title: `Season ${info.season} | ${info.title}`,
+    description: info.description ?? info.description,
+    color: getEmbedColor(),
+    image: {
+      url: info.data.image,
+    },
+    fields: [
+      {
+        name: 'Season Start',
+        value: '```xl\n\n' + format(new Date(dates.start.readable), 'dd MMM yyyy, h:mm a') + '```',
+      },
+      {
+        name: 'Current Split',
+        value: '```xl\n\n' + info.split.toString() + '```',
+        inline: true,
+      },
+      {
+        name: 'Split End',
+        value:
+          '```xl\n\n' +
+          `${format(
+            new Date(dates.split.readable),
+            'dd MMM yyyy, h:mm a'
+          )} | ${formatEndDateCountdown({
+            endDate: dates.split.timestamp * 1000,
+            currentDate: new Date(),
+          })}` +
+          '```',
+        inline: true,
+      },
+      {
+        name: 'Season End',
+        value:
+          '```xl\n\n' +
+          `${format(
+            new Date(dates.end.rankedEndReadable),
+            'dd MMM yyyy, h:mm a'
+          )} | ${formatEndDateCountdown({
+            endDate: dates.end.rankedEnd * 1000,
+            currentDate: new Date(),
+          })}` +
+          '```',
+      },
+    ],
+  };
+  return embed;
+};
 
 export default {
   commandType: 'Information',
@@ -9,7 +63,11 @@ export default {
     .setDescription('Displays information about the current season'),
   async execute({ interaction }: AppCommandOptions) {
     try {
-      await interaction.reply('season command');
+      const seasonData = await getSeasonInformation();
+      if (!seasonData)
+        return await interaction.reply('Unavailable to get season data, try again later!');
+      const embed = generateSeasonEmbed(seasonData);
+      await interaction.reply({ embeds: [embed] });
     } catch (error) {
       sendErrorLog({ error, interaction });
     }

--- a/src/commands/season/index.tsx
+++ b/src/commands/season/index.tsx
@@ -1,5 +1,5 @@
 import { format } from 'date-fns';
-import { APIEmbed, SlashCommandBuilder } from 'discord.js';
+import { APIEmbed, inlineCode, SlashCommandBuilder } from 'discord.js';
 import { SeasonAPISchema } from '../../schemas/season';
 import { getSeasonInformation } from '../../services/adapters';
 import { formatEndDateCountdown, getEmbedColor, sendErrorLog } from '../../utils/helpers';
@@ -9,21 +9,14 @@ export const generateSeasonEmbed = (season: SeasonAPISchema) => {
   const { info, dates } = season;
   const embed: APIEmbed = {
     title: `Season ${info.season} | ${info.title}`,
-    description: info.description ?? info.description,
+    description: `${info.description ?? ''}\n\nSeason Start: ${inlineCode(
+      format(new Date(dates.start.readable), 'dd MMM yyyy, h:mm a')
+    )}\nCurrent Split: ${inlineCode(info.split.toString())}`,
     color: getEmbedColor(),
     image: {
       url: info.data.image,
     },
     fields: [
-      {
-        name: 'Season Start',
-        value: '```xl\n\n' + format(new Date(dates.start.readable), 'dd MMM yyyy, h:mm a') + '```',
-      },
-      {
-        name: 'Current Split',
-        value: '```xl\n\n' + info.split.toString() + '```',
-        inline: true,
-      },
       {
         name: 'Split End',
         value:
@@ -31,12 +24,11 @@ export const generateSeasonEmbed = (season: SeasonAPISchema) => {
           `${format(
             new Date(dates.split.readable),
             'dd MMM yyyy, h:mm a'
-          )} | ${formatEndDateCountdown({
+          )} • ${formatEndDateCountdown({
             endDate: dates.split.timestamp * 1000,
             currentDate: new Date(),
           })}` +
           '```',
-        inline: true,
       },
       {
         name: 'Season End',
@@ -45,7 +37,7 @@ export const generateSeasonEmbed = (season: SeasonAPISchema) => {
           `${format(
             new Date(dates.end.rankedEndReadable),
             'dd MMM yyyy, h:mm a'
-          )} | ${formatEndDateCountdown({
+          )} • ${formatEndDateCountdown({
             endDate: dates.end.rankedEnd * 1000,
             currentDate: new Date(),
           })}` +

--- a/src/commands/season/index.tsx
+++ b/src/commands/season/index.tsx
@@ -1,0 +1,17 @@
+import { SlashCommandBuilder } from 'discord.js';
+import { sendErrorLog } from '../../utils/helpers';
+import { AppCommand, AppCommandOptions } from '../commands';
+
+export default {
+  commandType: 'Information',
+  data: new SlashCommandBuilder()
+    .setName('season')
+    .setDescription('Displays information about the current season'),
+  async execute({ interaction }: AppCommandOptions) {
+    try {
+      await interaction.reply('season command');
+    } catch (error) {
+      sendErrorLog({ error, interaction });
+    }
+  },
+} as AppCommand;

--- a/src/schemas/season.ts
+++ b/src/schemas/season.ts
@@ -2,6 +2,7 @@ export interface SeasonAPISchema {
   info: {
     season: number;
     title: string;
+    description?: string;
     split: number;
     data: {
       tagline: string;


### PR DESCRIPTION
#### Card
https://serenityy.atlassian.net/browse/SER-111

#### Context
Now that I've added split end to the ranked embed, it makes sense to just create a command entirely based around the current season information. Since the endpoint supports it, it would be a shame not to take advantage of it.

<img width="559" alt="image" src="https://github.com/vexuas/nessie/assets/42207245/2c2fca10-297f-4450-b652-53c3974e9272">

#### Change
- Create season command