### PR TITLE
Remove arenas embed generation for status cycles

### DIFF
--- a/src/commands/mixtape/index.ts
+++ b/src/commands/mixtape/index.ts
@@ -39,7 +39,6 @@ export default {
     try {
       await interaction.deferReply();
       const data = await getMixtape();
-      console.log(data);
       const embed = generateMixtapeEmbed(data);
       await interaction.editReply({ embeds: [embed] });
     } catch (error) {

--- a/src/commands/status/start/index.ts
+++ b/src/commands/status/start/index.ts
@@ -220,18 +220,13 @@ const generateBattleRoyaleStatusEmbeds = (
  * Initially was pubs but data shows that br is overwhelmingly more popular than arenas
  * Had to split it between br and arenas after seeing that
  */
-const generateArenasStatusEmbeds = (data: MapRotationAPIObject) => {
-  const arenasPubsEmbed = generatePubsEmbed(data.arenas, 'Arenas');
-  const arenasRankedEmbed = generateRankedEmbed(data.arenasRanked, 'Arenas');
-  const informationEmbed = {
-    description: '**Updates occur every 5 minutes**',
-    color: 3447003,
-    timestamp: new Date(Date.now()).toISOString(),
-    footer: {
-      text: 'Last Update',
-    },
+const generateArenasStatusEmbeds = () => {
+  const embedData: APIEmbed = {
+    title: 'Arenas are no longer supported',
+    color: 16711680,
+    description: 'To delete this channel, use /status stop'
   };
-  return [informationEmbed, arenasRankedEmbed, arenasPubsEmbed];
+  return [embedData];
 };
 /**
  * Handler for when a user initiates the /status start command
@@ -575,7 +570,7 @@ export const createStatus = async ({
  * More detailed explanation here: https://shizuka.notion.site/Spike-on-Status-Time-Taken-0c26284152f04a169c546fe7b582a658
  */
 export const scheduleStatus = (nessie: Client) => {
-  return new Scheduler('5 */5 * * * *', async () => {
+  return new Scheduler('10 */1 * * * *', async () => {
     errorNotification.count = 0;
     errorNotification.message = '';
     const startTime = Date.now();
@@ -586,7 +581,7 @@ export const scheduleStatus = (nessie: Client) => {
         const seasonData = cachedSeason ?? (await getSeasonInformation());
         if (!cachedSeason) cachedSeason = seasonData;
         const brStatusEmbeds = generateBattleRoyaleStatusEmbeds(rotationData, seasonData);
-        const arenasStatusEmbeds = generateArenasStatusEmbeds(rotationData);
+        const arenasStatusEmbeds = generateArenasStatusEmbeds();
         allStatus.forEach(async (status, index) => {
           await handleStatusCycle({
             nessie,

--- a/src/commands/status/start/index.ts
+++ b/src/commands/status/start/index.ts
@@ -219,6 +219,7 @@ const generateBattleRoyaleStatusEmbeds = (
  * Generates relevant embeds for the status arenas channel
  * Initially was pubs but data shows that br is overwhelmingly more popular than arenas
  * Had to split it between br and arenas after seeing that
+ * TODO: As of April 2024, the API does not return arenas data anymore. Clean this up when you get the time
  */
 const generateArenasStatusEmbeds = () => {
   const embedData: APIEmbed = {
@@ -581,7 +582,7 @@ export const scheduleStatus = (nessie: Client) => {
         const seasonData = cachedSeason ?? (await getSeasonInformation());
         if (!cachedSeason) cachedSeason = seasonData;
         const brStatusEmbeds = generateBattleRoyaleStatusEmbeds(rotationData, seasonData);
-        const arenasStatusEmbeds = generateArenasStatusEmbeds();
+        const arenasStatusEmbeds = generateArenasStatusEmbeds(); //TODO: Clean this up eventually
         allStatus.forEach(async (status, index) => {
           await handleStatusCycle({
             nessie,


### PR DESCRIPTION
#### Context
Looks like the API has stopped returning arenas data so our legacy arenas code in the status cycle has been breaking. Noticed this when our error logs were spamming since last night; thought it was an issue with the API being down but apparently it was just gone now. I've taken the embed out now and replace it with an error one instead saying arenas is no longer supported but we should really start cleaning up arenas code soon

![image](https://github.com/vexuas/nessie/assets/42207245/52159dea-79fa-4c6b-a159-0e2eae725076)

#### Change
- Remove embeds generation for status arenas
