### PR TITLE
Forgot to set ecosystem in dependabot file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: "" # See documentation for possible values
+  - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
       interval: "monthly"


### PR DESCRIPTION
#### Context
Forgot to set the ecosystem in #207. Set it to `npm` as that's what the documentation says to use for yarn

#### Change
- Forgot to set ecosystem to npm