### PR TITLE
Add fallback if guild member count doesn't exist in guild notification

### DIFF
--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -71,7 +71,7 @@ export const serverNotificationEmbed = async ({
       },
       {
         name: 'Members',
-        value: guild.memberCount.toString(),
+        value: guild.memberCount ? guild.memberCount.toString() : '-',
         inline: true,
       },
     ],


### PR DESCRIPTION
#### Card

It may be helpful to include a link to the ticket to help for better context

#### Context
I noticed this happening lately but not really sure what exactly it was. With #261 tho, it pinpointed the exact issue which was guild member count not existing during guild notification. Not really sure why this is undefined, maybe nessie joined a server when it was offline? Doesn't really matter since this pr should prevent this error from ever happening again

<img width="1014" alt="image" src="https://github.com/user-attachments/assets/b7d6ba05-8023-4476-8c00-15323a281880" />


#### Change
- Ad fallback if guild member count does not exist in guild notification
