### PR TITLE
Add more logging data to sentry 

### DIFF
--- a/src/commands/battleRoyale/index.ts
+++ b/src/commands/battleRoyale/index.ts
@@ -1,12 +1,13 @@
 import { SlashCommandBuilder } from 'discord.js';
-import // getBattleRoyalePubs,
-// getBattleRoyaleRanked,
-// getSeasonInformation,
-'../../services/adapters';
 import {
-  // formatEndDateCountdown,
-  // generatePubsEmbed,
-  // generateRankedEmbed,
+  getBattleRoyalePubs,
+  getBattleRoyaleRanked,
+  getSeasonInformation,
+} from '../../services/adapters';
+import {
+  formatEndDateCountdown,
+  generatePubsEmbed,
+  generateRankedEmbed,
   sendErrorLog,
 } from '../../utils/helpers';
 import { AppCommand, AppCommandOptions } from '../commands';
@@ -24,36 +25,35 @@ export default {
         .addChoices({ name: 'pubs', value: 'br_pubs' }, { name: 'ranked', value: 'br_ranked' })
     ),
   async execute({ interaction }: AppCommandOptions) {
-    // let data;
+    let data;
     let embed;
     const optionMode = interaction.options.getString('mode');
     try {
       await interaction.deferReply();
-      throw new Error('Test message');
-      // switch (optionMode) {
-      //   case 'br_pubs':
-      //     data = await getBattleRoyalePubs();
-      //     embed = generatePubsEmbed(data);
-      //     break;
-      //   case 'br_ranked':
-      //     data = await getBattleRoyaleRanked();
-      //     const season = await getSeasonInformation();
-      //     //TODO: Figure out formatting for different timezones eventually
-      //     const seasonEnd = season
-      //       ? formatEndDateCountdown({
-      //           endDate: season.dates.end.rankedEnd * 1000,
-      //           currentDate: new Date(),
-      //         })
-      //       : null;
-      //     const splitEnd = season
-      //       ? formatEndDateCountdown({
-      //           endDate: season.dates.split.timestamp * 1000,
-      //           currentDate: new Date(),
-      //         })
-      //       : null;
-      //     embed = generateRankedEmbed(data, 'Battle Royale', seasonEnd, splitEnd);
-      //     break;
-      // }
+      switch (optionMode) {
+        case 'br_pubs':
+          data = await getBattleRoyalePubs();
+          embed = generatePubsEmbed(data);
+          break;
+        case 'br_ranked':
+          data = await getBattleRoyaleRanked();
+          const season = await getSeasonInformation();
+          //TODO: Figure out formatting for different timezones eventually
+          const seasonEnd = season
+            ? formatEndDateCountdown({
+                endDate: season.dates.end.rankedEnd * 1000,
+                currentDate: new Date(),
+              })
+            : null;
+          const splitEnd = season
+            ? formatEndDateCountdown({
+                endDate: season.dates.split.timestamp * 1000,
+                currentDate: new Date(),
+              })
+            : null;
+          embed = generateRankedEmbed(data, 'Battle Royale', seasonEnd, splitEnd);
+          break;
+      }
       await interaction.editReply({ embeds: [embed] });
     } catch (error) {
       sendErrorLog({ error, interaction, option: optionMode });

--- a/src/commands/battleRoyale/index.ts
+++ b/src/commands/battleRoyale/index.ts
@@ -1,13 +1,12 @@
 import { SlashCommandBuilder } from 'discord.js';
+import // getBattleRoyalePubs,
+// getBattleRoyaleRanked,
+// getSeasonInformation,
+'../../services/adapters';
 import {
-  getBattleRoyalePubs,
-  getBattleRoyaleRanked,
-  getSeasonInformation,
-} from '../../services/adapters';
-import {
-  formatEndDateCountdown,
-  generatePubsEmbed,
-  generateRankedEmbed,
+  // formatEndDateCountdown,
+  // generatePubsEmbed,
+  // generateRankedEmbed,
   sendErrorLog,
 } from '../../utils/helpers';
 import { AppCommand, AppCommandOptions } from '../commands';
@@ -25,35 +24,36 @@ export default {
         .addChoices({ name: 'pubs', value: 'br_pubs' }, { name: 'ranked', value: 'br_ranked' })
     ),
   async execute({ interaction }: AppCommandOptions) {
-    let data;
+    // let data;
     let embed;
     const optionMode = interaction.options.getString('mode');
     try {
       await interaction.deferReply();
-      switch (optionMode) {
-        case 'br_pubs':
-          data = await getBattleRoyalePubs();
-          embed = generatePubsEmbed(data);
-          break;
-        case 'br_ranked':
-          data = await getBattleRoyaleRanked();
-          const season = await getSeasonInformation();
-          //TODO: Figure out formatting for different timezones eventually
-          const seasonEnd = season
-            ? formatEndDateCountdown({
-                endDate: season.dates.end.rankedEnd * 1000,
-                currentDate: new Date(),
-              })
-            : null;
-          const splitEnd = season
-            ? formatEndDateCountdown({
-                endDate: season.dates.split.timestamp * 1000,
-                currentDate: new Date(),
-              })
-            : null;
-          embed = generateRankedEmbed(data, 'Battle Royale', seasonEnd, splitEnd);
-          break;
-      }
+      throw new Error('Test message');
+      // switch (optionMode) {
+      //   case 'br_pubs':
+      //     data = await getBattleRoyalePubs();
+      //     embed = generatePubsEmbed(data);
+      //     break;
+      //   case 'br_ranked':
+      //     data = await getBattleRoyaleRanked();
+      //     const season = await getSeasonInformation();
+      //     //TODO: Figure out formatting for different timezones eventually
+      //     const seasonEnd = season
+      //       ? formatEndDateCountdown({
+      //           endDate: season.dates.end.rankedEnd * 1000,
+      //           currentDate: new Date(),
+      //         })
+      //       : null;
+      //     const splitEnd = season
+      //       ? formatEndDateCountdown({
+      //           endDate: season.dates.split.timestamp * 1000,
+      //           currentDate: new Date(),
+      //         })
+      //       : null;
+      //     embed = generateRankedEmbed(data, 'Battle Royale', seasonEnd, splitEnd);
+      //     break;
+      // }
       await interaction.editReply({ embeds: [embed] });
     } catch (error) {
       sendErrorLog({ error, interaction, option: optionMode });

--- a/src/commands/status/start/index.ts
+++ b/src/commands/status/start/index.ts
@@ -693,8 +693,7 @@ const handleStatusCycle = async ({
      */
     errorNotification.count = errorNotification.count + 1;
     errorNotification.message = error.message;
-    const uuid = uuidV4();
-    errorNotification.count <= 3 && (await sendStatusErrorLog({ nessie, uuid, error, status }));
+    errorNotification.count <= 3 && (await sendStatusErrorLog({ nessie, error, status }));
     if (errorNotification.count !== 0 && totalCount && index === totalCount - 1) {
       const errorEmbed = {
         title: 'Error Summary | Status Cycle',
@@ -751,8 +750,7 @@ const handleStatusCycle = async ({
             ],
           }));
       } catch (error) {
-        const uuid = uuidV4();
-        await sendStatusErrorLog({ nessie, uuid, error, status });
+        await sendStatusErrorLog({ nessie, error, status });
       }
     }
   }

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -136,6 +136,25 @@ export const sendErrorLog = async ({
 }) => {
   console.error(error);
   const errorID = captureException(error); // Sentry error logging
+  const title = customTitle
+    ? `Error | ${customTitle}`
+    : interaction
+    ? `Error | ${interaction.isCommand() ? capitalize(interaction.commandName) : ''}${
+        subCommand ? ` ${capitalize(subCommand)}` : ''
+      } Command`
+    : 'Error';
+  const commandOption = option ? option : '';
+  const interactionChannel = interaction?.channel as GuildChannel | undefined;
+  const interactionDetails = interaction
+    ? {
+        userId: interaction.user.id,
+        userName: interaction.user.username,
+        channelId: interaction.channelId,
+        channelName: interactionChannel ? interactionChannel.name : '-',
+        guildId: interaction.guild ? interaction.guild.id : '-',
+        guildName: interaction.guild ? interaction.guild.name : '-',
+      }
+    : null;
   if (interaction) {
     const errorEmbed = {
       description: `Oops something went wrong! D:\n\nError: ${
@@ -146,49 +165,42 @@ export const sendErrorLog = async ({
     await interaction.editReply({ embeds: [errorEmbed], components: [] });
   }
   if (ERROR_NOTIFICATION_WEBHOOK_URL && !isEmpty(ERROR_NOTIFICATION_WEBHOOK_URL)) {
-    const interactionChannel = interaction?.channel as GuildChannel | undefined;
     const notificationEmbed: APIEmbed = {
-      title: customTitle
-        ? `Error | ${customTitle}`
-        : interaction
-        ? `Error | ${interaction.isCommand() ? capitalize(interaction.commandName) : ''}${
-            subCommand ? ` ${capitalize(subCommand)}` : ''
-          } Command`
-        : 'Error',
+      title,
       color: getEmbedColor('#FF0000'),
       description: `uuid: ${errorID}\nError: ${
         error.message ? error.message : 'Unexpected Error'
-      }\n${option ? `Option: ${option}` : ''}`,
-      fields: interaction
+      }\n${commandOption}`,
+      fields: interactionDetails
         ? [
             {
               name: 'User',
-              value: interaction.user.username,
+              value: interactionDetails.userName,
               inline: true,
             },
             {
               name: 'User ID',
-              value: interaction.user.id,
+              value: interactionDetails.userId,
               inline: true,
             },
             {
               name: 'Channel',
-              value: interactionChannel ? interactionChannel.name : '-',
+              value: interactionDetails.channelName,
               inline: true,
             },
             {
               name: 'Channel ID',
-              value: interaction.channelId,
+              value: interactionDetails.channelId,
               inline: true,
             },
             {
               name: 'Guild',
-              value: interaction.guild ? interaction.guild.name : '-',
+              value: interactionDetails.guildName,
               inline: true,
             },
             {
               name: 'Guild ID',
-              value: interaction.guildId ? interaction.guildId : '-',
+              value: interactionDetails.guildId,
               inline: true,
             },
           ]

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -221,6 +221,7 @@ export const sendStatusErrorLog = async ({
   status: StatusRecord;
 }) => {
   const errorGuild = nessie.guilds.cache.get(status.guild_id);
+  captureException(error); // Sentry error logging
   const errorEmbed = {
     title: 'Error | Status Scheduler Cycle',
     color: 16711680,

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -20,7 +20,6 @@ import {
 } from '../config/environment';
 import { nessieLogo } from './constants';
 import { isEmpty } from 'lodash';
-import { v4 as uuidV4 } from 'uuid';
 import { inlineCode } from '@discordjs/builders';
 import { capitalize } from 'lodash';
 import { StatusRecord } from '../services/database';
@@ -136,8 +135,7 @@ export const sendErrorLog = async ({
   customTitle?: string;
 }) => {
   console.error(error);
-  const errorID = uuidV4();
-  const sentryId = captureException(error); // Sentry error logging
+  const errorID = captureException(error); // Sentry error logging
   if (interaction) {
     const errorEmbed = {
       description: `Oops something went wrong! D:\n\nError: ${
@@ -158,7 +156,7 @@ export const sendErrorLog = async ({
           } Command`
         : 'Error',
       color: getEmbedColor('#FF0000'),
-      description: `uuid: ${errorID}\nSentry ID: ${sentryId}\nError: ${
+      description: `uuid: ${errorID}\nError: ${
         error.message ? error.message : 'Unexpected Error'
       }\n${option ? `Option: ${option}` : ''}`,
       fields: interaction
@@ -211,21 +209,19 @@ export const sendErrorLog = async ({
  */
 export const sendStatusErrorLog = async ({
   nessie,
-  uuid,
   error,
   status,
 }: {
   nessie: Client;
-  uuid: string;
   error: any;
   status: StatusRecord;
 }) => {
   const errorGuild = nessie.guilds.cache.get(status.guild_id);
-  const sentryId = captureException(error); // Sentry error logging
+  const errorID = captureException(error); // Sentry error logging
   const errorEmbed = {
     title: 'Error | Status Scheduler Cycle',
     color: 16711680,
-    description: `uuid: ${uuid}\nSentry ID: ${sentryId}\nError: ${inlineCode(error.message)}`,
+    description: `uuid: ${errorID}\nError: ${inlineCode(error.message)}`,
     fields: [
       {
         name: 'Status ID',

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -135,7 +135,6 @@ export const sendErrorLog = async ({
   customTitle?: string;
 }) => {
   console.error(error);
-  const errorID = captureException(error); // Sentry error logging
   const title = customTitle
     ? `Error | ${customTitle}`
     : interaction
@@ -155,6 +154,14 @@ export const sendErrorLog = async ({
         guildName: interaction.guild ? interaction.guild.name : '-',
       }
     : null;
+
+  const errorID = captureException(error, {
+    extra: {
+      title,
+      commandOption,
+      interactionDetails,
+    },
+  }); // Sentry error logging
   if (interaction) {
     const errorEmbed = {
       description: `Oops something went wrong! D:\n\nError: ${

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -137,7 +137,7 @@ export const sendErrorLog = async ({
 }) => {
   console.error(error);
   const errorID = uuidV4();
-  captureException(error); // Sentry error logging
+  const sentryId = captureException(error); // Sentry error logging
   if (interaction) {
     const errorEmbed = {
       description: `Oops something went wrong! D:\n\nError: ${
@@ -158,7 +158,7 @@ export const sendErrorLog = async ({
           } Command`
         : 'Error',
       color: getEmbedColor('#FF0000'),
-      description: `uuid: ${errorID}\nError: ${
+      description: `uuid: ${errorID}\nSentry ID: ${sentryId}\nError: ${
         error.message ? error.message : 'Unexpected Error'
       }\n${option ? `Option: ${option}` : ''}`,
       fields: interaction
@@ -221,11 +221,11 @@ export const sendStatusErrorLog = async ({
   status: StatusRecord;
 }) => {
   const errorGuild = nessie.guilds.cache.get(status.guild_id);
-  captureException(error); // Sentry error logging
+  const sentryId = captureException(error); // Sentry error logging
   const errorEmbed = {
     title: 'Error | Status Scheduler Cycle',
     color: 16711680,
-    description: `uuid: ${uuid}\nError: ${inlineCode(error.message)}`,
+    description: `uuid: ${uuid}\nSentry ID: ${sentryId}\nError: ${inlineCode(error.message)}`,
     fields: [
       {
         name: 'Status ID',

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -146,20 +146,22 @@ export const sendErrorLog = async ({
   const interactionChannel = interaction?.channel as GuildChannel | undefined;
   const interactionDetails = interaction
     ? {
-        userId: interaction.user.id,
-        userName: interaction.user.username,
-        channelId: interaction.channelId,
-        channelName: interactionChannel ? interactionChannel.name : '-',
-        guildId: interaction.guild ? interaction.guild.id : '-',
-        guildName: interaction.guild ? interaction.guild.name : '-',
+        uuid: interaction.id,
+        user_id: interaction.user.id,
+        user_name: interaction.user.username,
+        channel_id: interaction.channelId,
+        channel_name: interactionChannel ? interactionChannel.name : '-',
+        guild_id: interaction.guild ? interaction.guild.id : '-',
+        guild_name: interaction.guild ? interaction.guild.name : '-',
       }
     : null;
 
   const errorID = captureException(error, {
     extra: {
       title,
-      commandOption,
-      interactionDetails,
+      command_option: commandOption,
+      interaction_details: interactionDetails,
+      type: 'interaction',
     },
   }); // Sentry error logging
   if (interaction) {
@@ -182,32 +184,32 @@ export const sendErrorLog = async ({
         ? [
             {
               name: 'User',
-              value: interactionDetails.userName,
+              value: interactionDetails.user_name,
               inline: true,
             },
             {
               name: 'User ID',
-              value: interactionDetails.userId,
+              value: interactionDetails.user_id,
               inline: true,
             },
             {
               name: 'Channel',
-              value: interactionDetails.channelName,
+              value: interactionDetails.channel_name,
               inline: true,
             },
             {
               name: 'Channel ID',
-              value: interactionDetails.channelId,
+              value: interactionDetails.channel_id,
               inline: true,
             },
             {
               name: 'Guild',
-              value: interactionDetails.guildName,
+              value: interactionDetails.guild_name,
               inline: true,
             },
             {
               name: 'Guild ID',
-              value: interactionDetails.guildId,
+              value: interactionDetails.guild_id,
               inline: true,
             },
           ]
@@ -236,9 +238,22 @@ export const sendStatusErrorLog = async ({
   status: StatusRecord;
 }) => {
   const errorGuild = nessie.guilds.cache.get(status.guild_id);
-  const errorID = captureException(error); // Sentry error logging
+  const title = 'Error | Status Scheduler Cycle';
+  const errorID = captureException(error, {
+    extra: {
+      title,
+      status_details: {
+        uuid: status.uuid,
+        guild_id: status.guild_id,
+        guild_name: errorGuild ? errorGuild.name : '-',
+        created_by: status.created_by,
+        game_modes: status.game_mode_selected,
+      },
+      type: 'status',
+    },
+  });
   const errorEmbed = {
-    title: 'Error | Status Scheduler Cycle',
+    title,
     color: 16711680,
     description: `uuid: ${errorID}\nError: ${inlineCode(error.message)}`,
     fields: [


### PR DESCRIPTION
#### Context
This is initially only to add sentry logging for the status error handler (which somehow is a different handler than the generic sendErrorLog, i have no idea what I'm smoking before) but I realise I might as well pass in more context data to the error logging in sentry

<img width="963" alt="image" src="https://github.com/user-attachments/assets/8e14ff9e-2796-45f2-a1bf-90496894b0ed" />

<img width="506" alt="image" src="https://github.com/user-attachments/assets/dd6b9a1b-5e82-48da-9a3e-c1b4eb6bd403" />


#### Change
- Add captureExpection to status error log
- Use sentry id as error uuid for embed
- Send additional data to sentry
