### PR TITLE
Correctly use environment for sentry

### DIFF
--- a/src/services/instrument.ts
+++ b/src/services/instrument.ts
@@ -10,7 +10,7 @@ export const initializeSentry = () => {
 
   Sentry.init({
     dsn: SENTRY_DSN_KEY,
-    environment: process.env.ENV || 'dev',
+    environment: process.env.BOT_ENV || 'dev',
   });
 
   console.log('Sentry initialized.');


### PR DESCRIPTION
#### Context
I realised looking at the recent sentry logs that they were all tagged as `dev` environments. I apparently set it to look for ENV instead of BOT_ENV

#### Change
- Use BOT_ENV
