### PR TITLE
Remove arenas code

### DIFF
--- a/src/commands/status/start/index.ts
+++ b/src/commands/status/start/index.ts
@@ -92,9 +92,7 @@ const generateGameModeSelectionMessage = (status?: StatusRecord | null) => {
       title: 'Status | Start',
       description: `There's currently an existing automated map status active in:${
         status.br_channel_id ? `\n• <#${status.br_channel_id}>` : ''
-      }${status.arenas_channel_id ? `\n• <#${status.arenas_channel_id}>` : ''}\n\nCreated at ${
-        status.created_at
-      } by ${status.created_by}`,
+      }\n\nCreated at ${status.created_at} by ${status.created_by}`,
       color: 3447003,
     };
   }
@@ -118,6 +116,7 @@ const generateConfirmStatusMessage = ({
   const isBattleRoyaleSelected = !!interaction.values.find(
     (value) => value === 'gameModeDropdown__battleRoyaleValue'
   );
+  // TODO: Support mixtape eventually
   const isMixtapeSelected = !!interaction.values.find(
     (value) => value === 'gameModeDropdown__mixtapeValue'
   );
@@ -205,20 +204,6 @@ const generateBattleRoyaleStatusEmbeds = (
     },
   };
   return [informationEmbed, battleRoyaleRankedEmbed, battleRoyalePubsEmbed];
-};
-/**
- * Generates relevant embeds for the status arenas channel
- * Initially was pubs but data shows that br is overwhelmingly more popular than arenas
- * Had to split it between br and arenas after seeing that
- * TODO: As of April 2024, the API does not return arenas data anymore. Clean this up when you get the time
- */
-const generateArenasStatusEmbeds = () => {
-  const embedData: APIEmbed = {
-    title: 'Arenas are no longer supported',
-    color: 16711680,
-    description: 'To delete this channel, use /status stop',
-  };
-  return [embedData];
 };
 /**
  * Handler for when a user initiates the /status start command
@@ -571,7 +556,6 @@ export const scheduleStatus = (nessie: Client) => {
         const rotationData = await getRotationData();
         const seasonData = await getSeasonInformation();
         const brStatusEmbeds = generateBattleRoyaleStatusEmbeds(rotationData, seasonData);
-        const arenasStatusEmbeds = generateArenasStatusEmbeds(); //TODO: Clean this up eventually
         allStatus.forEach(async (status, index) => {
           await handleStatusCycle({
             nessie,
@@ -580,7 +564,6 @@ export const scheduleStatus = (nessie: Client) => {
             startTime,
             totalCount: allStatus.length,
             brStatusEmbeds,
-            arenasStatusEmbeds,
           });
         });
       }
@@ -611,7 +594,6 @@ export const scheduleStatus = (nessie: Client) => {
             nessie,
             status,
             brStatusEmbeds: errorEmbed,
-            arenasStatusEmbeds: errorEmbed,
             index,
           });
         });
@@ -638,7 +620,6 @@ const handleStatusCycle = async ({
   startTime,
   totalCount,
   brStatusEmbeds,
-  arenasStatusEmbeds,
 }: {
   nessie: Client;
   status: StatusRecord;
@@ -646,7 +627,6 @@ const handleStatusCycle = async ({
   startTime?: number;
   totalCount?: number;
   brStatusEmbeds: APIEmbed[];
-  arenasStatusEmbeds: APIEmbed[];
 }) => {
   try {
     const brWebhook =
@@ -656,20 +636,8 @@ const handleStatusCycle = async ({
         id: status.br_webhook_id,
         token: status.br_webhook_token,
       });
-    const arenasWebhook =
-      status.arenas_webhook_id &&
-      status.arenas_webhook_token &&
-      new WebhookClient({
-        id: status.arenas_webhook_id,
-        token: status.arenas_webhook_token,
-      });
     if (brWebhook) {
       await brWebhook.editMessage(status.br_message_id, { embeds: brStatusEmbeds });
-    }
-    if (arenasWebhook) {
-      await arenasWebhook.editMessage(status.arenas_message_id, {
-        embeds: arenasStatusEmbeds,
-      });
     }
     /**
      * Logs health of status after the last guild gets done
@@ -727,12 +695,9 @@ const handleStatusCycle = async ({
         //Might have to revamp these when we have to do sharding
         const battleRoyaleStatusChannel =
           status.br_channel_id && nessie.channels.cache.get(status.br_channel_id);
-        const arenasStatusChannel =
-          status.arenas_channel_id && nessie.channels.cache.get(status.arenas_channel_id);
         const categoryStatusChannel =
           status.category_channel_id && nessie.channels.cache.get(status.category_channel_id);
         battleRoyaleStatusChannel && (await battleRoyaleStatusChannel.delete());
-        arenasStatusChannel && (await arenasStatusChannel.delete());
         categoryStatusChannel && (await categoryStatusChannel.delete());
         const originalChannel = (await nessie.channels.fetch(
           status.original_channel_id

--- a/src/commands/status/stop/index.ts
+++ b/src/commands/status/stop/index.ts
@@ -54,8 +54,8 @@ export const sendStopInteraction = async ({
       description: status
         ? `By confirming below, Nessie will stop all existing map status and **delete**:\n• <#${
             status.category_channel_id
-          }>${status.br_channel_id ? `\n• <#${status.br_channel_id}>` : ''}${
-            status.arenas_channel_id ? `\n• <#${status.arenas_channel_id}>` : ''
+          }>${
+            status.br_channel_id ? `\n• <#${status.br_channel_id}>` : ''
           }\n• Webhooks under each status channel\n\nThis status was created at ${
             status.created_at
           } by ${status.created_by}`
@@ -140,7 +140,6 @@ const sendStatusStopLog = async (interaction: ButtonInteraction) => {
  * - Edits initial message with a success message
  *
  * We don't need to delete the webhooks as they'll be automatically deleted along with its channels
- * TODO: Remove arenas code once we cleanup arenas in our database
  */
 export const deleteGuildStatus = async ({
   interaction,
@@ -162,13 +161,10 @@ export const deleteGuildStatus = async ({
       await interaction.message.edit({ embeds: [embedLoading], components: [] });
       const battleRoyaleStatusChannel =
         status.br_channel_id && (await nessie.channels.fetch(status.br_channel_id));
-      const arenasStatusChannel =
-        status.arenas_channel_id && (await nessie.channels.fetch(status.arenas_channel_id));
       const categoryStatusChannel =
         status.category_channel_id && (await nessie.channels.fetch(status.category_channel_id));
 
       battleRoyaleStatusChannel && (await battleRoyaleStatusChannel.delete());
-      arenasStatusChannel && (await arenasStatusChannel.delete());
       categoryStatusChannel && (await categoryStatusChannel.delete());
 
       const embedSuccess = {

--- a/src/schemas/mapRotation.ts
+++ b/src/schemas/mapRotation.ts
@@ -1,8 +1,6 @@
 export interface MapRotationAPIObject {
   battle_royale: MapRotationBattleRoyaleSchema;
-  arenas: MapRotationArenasSchema;
   ranked: MapRotationRankedSchema;
-  arenasRanked: MapRotationArenasRankedSchema;
   ltm: MapRotationMixtapeSchema;
 }
 interface MapRotationCurrentSchema {
@@ -42,15 +40,7 @@ export interface MapRotationBattleRoyaleSchema {
   current: MapRotationCurrentSchema;
   next: MapRotationNextSchema;
 }
-export interface MapRotationArenasSchema {
-  current: MapRotationCurrentSchema;
-  next: MapRotationNextSchema;
-}
 export interface MapRotationRankedSchema {
-  current: MapRotationCurrentSchema;
-  next?: MapRotationNextSchema;
-}
-export interface MapRotationArenasRankedSchema {
   current: MapRotationCurrentSchema;
   next?: MapRotationNextSchema;
 }

--- a/src/services/adapters.ts
+++ b/src/services/adapters.ts
@@ -2,8 +2,6 @@ import got from 'got';
 import { ALS_API_KEY } from '../config/environment';
 import {
   MapRotationAPIObject,
-  MapRotationArenasRankedSchema,
-  MapRotationArenasSchema,
   MapRotationBattleRoyaleSchema,
   MapRotationMixtapeSchema,
   MapRotationRankedSchema,
@@ -48,14 +46,6 @@ export async function getBattleRoyalePubs(): Promise<MapRotationBattleRoyaleSche
 export async function getBattleRoyaleRanked(): Promise<MapRotationRankedSchema> {
   const response = await getRotationData();
   return response.ranked;
-}
-export async function getArenasPubs(): Promise<MapRotationArenasSchema> {
-  const response = await getRotationData();
-  return response.arenas;
-}
-export async function getArenasRanked(): Promise<MapRotationArenasRankedSchema> {
-  const response = await getRotationData();
-  return response.arenasRanked;
 }
 export async function getMixtape(): Promise<MapRotationMixtapeSchema> {
   const response = await getRotationData();

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -23,12 +23,7 @@ import { isEmpty } from 'lodash';
 import { inlineCode } from '@discordjs/builders';
 import { capitalize } from 'lodash';
 import { StatusRecord } from '../services/database';
-import {
-  MapRotationArenasRankedSchema,
-  MapRotationArenasSchema,
-  MapRotationBattleRoyaleSchema,
-  MapRotationRankedSchema,
-} from '../schemas/mapRotation';
+import { MapRotationBattleRoyaleSchema, MapRotationRankedSchema } from '../schemas/mapRotation';
 import { Mixpanel } from 'mixpanel';
 import { sendAnalyticsEvent } from '../services/analytics';
 import { captureException } from '@sentry/node';
@@ -350,7 +345,7 @@ export const getCountdown = (timer: string) => {
  * As discord embed has a timestamp propery, I added the remianing milliseconds to the current date
  */
 export const generatePubsEmbed = (
-  data?: MapRotationBattleRoyaleSchema | MapRotationArenasSchema,
+  data?: MapRotationBattleRoyaleSchema,
   type = 'Battle Royale'
 ): APIEmbed => {
   if (!data)
@@ -389,7 +384,7 @@ export const generatePubsEmbed = (
  * Fairly simple, don't need any fancy timers and footers
  */
 export const generateRankedEmbed = (
-  data?: MapRotationRankedSchema | MapRotationArenasRankedSchema,
+  data?: MapRotationRankedSchema,
   type = 'Battle Royale',
   seasonEnd?: string | null,
   splitEnd?: string | null


### PR DESCRIPTION
#### Context
Nessie hasn't been supporting arenas for a while now, even so the API doesn't even return data for it. Deleting all the related code for it in this pr except for the database schema since I still need to figure out a way to properly perform migrations.

#### Change
- Delete arenas code in status start
- Delete arenas code in status stop
- Delete arenas code in schemas and adapters
- Delete arenas code in helpers

#### Considerations
There are still 30 guilds that somehow have arenas status channels but just gonna let them be without any handling since that's only 2% of the total userbase. They'll just have to manually delete the arenas channel + webhook if they stop their statuses

<img width="1021" alt="image" src="https://github.com/user-attachments/assets/6377d873-cce5-4c24-bb89-720b277fc31e" />

