### PR TITLE
Add migration step in production deployment

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -34,10 +34,12 @@ jobs:
             git branch | grep -v "develop" | xargs git branch -D            
             git checkout tags/${{ github.ref_name }} -b prod/${{ github.ref_name }}
             echo "${{ secrets.ENVIRONMENT_PROD }}" > src/config/environment.ts
+            echo "${{ secrets.CONFIG_PROD }}" > config/default.json
             yarn update:version
             yarn install
             rm -R dist
             yarn build
+            yarn migrate:up
             pm2 start deploy.config.js --env prod
 
       - name: Send notification to Discord

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ If you want to use Nessie for your own projects, you would need the following be
 
 - Have a Discord Application created from the [Discord Dev Portal](https://discordjs.guide/preparations/setting-up-a-bot-application.html#creating-your-bot)
 - Have the Discord Application [invited to a Discord Server](https://discordjs.guide/preparations/adding-your-bot-to-servers.html#bot-invite-links)
-- [Node](https://heynode.com/tutorial/install-nodejs-locally-nvm/) with a version of at least v20.0.0
+- [Node](https://heynode.com/tutorial/install-nodejs-locally-nvm/) with a version of at least v20.11.0
 - [Yarn](https://classic.yarnpkg.com/lang/en/docs/install/#mac-stable)
 - [Homebrew](https://brew.sh/)
 - An API key generated from https://apexlegendsapi.com/
@@ -133,7 +133,7 @@ Full list [here](https://shizuka.notion.site/To-dos-and-Nice-to-Have-s-4946e00c7
 - Research multithreading
 - ~~CircleCi Integration~~ [Using github actions]
 - ~~Metabase Integration~~ [Using Trevor instead]
-- Datadog Integration
+- ~~Datadog Integration~~ [Using Sentry instead]
 
 ## Contributing
 


### PR DESCRIPTION
#### Context
Best to run pending migrations every time we deploy to prod

#### Change
- Update readme
- Update deploy-prod worklfow

#### Considerations
I'm putting a lot of faith on this but to be safe, I backed up nessie's prod database using https://snapshooter.com/
