### PR TITLE
Add season command

### DIFF
--- a/src/commands/season/index.test.ts
+++ b/src/commands/season/index.test.ts
@@ -1,0 +1,117 @@
+import { format } from 'date-fns';
+import { SeasonAPISchema } from '../../schemas/season';
+import { formatEndDateCountdown, generateSeasonEmbed } from '../../utils/helpers';
+import { inlineCode } from 'discord.js';
+
+const mockSeasonData: SeasonAPISchema = {
+  info: {
+    season: 25,
+    title: 'Prodigy',
+    description:
+      'Target greatness and get ready to shoot your shot with a new Legend that has been a prodigy since his beginnings. Set your sights on the bullseye or close enough with an explosive new Bocek. And make every strike count in a returning favorite: Arenas. Add in Ranked updates, refreshed metas, and more, and this season will definitely be kicking off with a bang (no whimpers here).',
+    split: 1,
+    data: {
+      tagline: '\n\nTarget greatness.',
+      url: 'https://www.ea.com/games/apex-legends/prodigy',
+      image: 'Olympus',
+    },
+  },
+  dates: {
+    start: {
+      timestamp: 1746550800,
+      readable: '05-06-2025 17:00:00',
+      since: 3629687,
+      untilNext: 603913,
+    },
+    split: {
+      timestamp: 1750784400,
+      readable: '06-24-2025 17:00:00',
+      since: 0,
+      untilNext: 4232713,
+    },
+    end: {
+      timestamp: 1754413200,
+      readable: '08-05-2025 17:00:00',
+      rankedEnd: 1754411400,
+      rankedEndReadable: '08-05-2025 16:30:00',
+    },
+  },
+};
+
+describe('Season Command', () => {
+  it('generates an embed correctly', () => {
+    const embed = generateSeasonEmbed(mockSeasonData);
+
+    expect(embed).not.toBeUndefined();
+  });
+  it('displays the correct fields in the embed', () => {
+    const embed = generateSeasonEmbed(mockSeasonData);
+
+    expect(embed).not.toBeUndefined();
+    expect(embed.title).not.toBeUndefined();
+    expect(embed.color).not.toBeUndefined();
+    expect(embed.description).not.toBeUndefined();
+    expect(embed.image).not.toBeUndefined();
+    expect(embed.image?.url).not.toBeUndefined();
+    expect(embed.footer).not.toBeUndefined();
+    expect(embed.footer?.text).not.toBeUndefined();
+    expect(embed.fields).not.toBeUndefined();
+    expect(embed.fields?.length).toBe(2);
+  });
+  it('displays the correct title', () => {
+    const embed = generateSeasonEmbed(mockSeasonData);
+    const { season, title } = mockSeasonData.info;
+
+    expect(embed.title).toBe(`Season ${season} | ${title}`);
+  });
+  it('displays the correct description', () => {
+    const embed = generateSeasonEmbed(mockSeasonData);
+    const { split, description } = mockSeasonData.info;
+    const { start } = mockSeasonData.dates;
+
+    expect(embed.description).not.toBeUndefined();
+    expect(embed.description).toContain(description);
+    expect(embed.description).toContain(
+      `Started on: ${inlineCode(format(start.timestamp * 1000, 'dd MMM, h:mm a'))}`
+    );
+    expect(embed.description).toContain(`Current Split: ${inlineCode(split.toString())}`);
+  });
+  //TODO: Add test for different map url once getMapUrl is tested/refactored
+  it('displays the correct image url', () => {
+    const embed = generateSeasonEmbed(mockSeasonData);
+
+    expect(embed.image?.url).toBe('https://vexuas.b-cdn.net/apex_legend_maps/olympus.jpg');
+  });
+  it('displays the correct end date in the footer', () => {
+    const embed = generateSeasonEmbed(mockSeasonData);
+    const { end } = mockSeasonData.dates;
+
+    expect(embed.footer?.text).toBe(
+      `Season ends on ${format(end.rankedEnd * 1000, 'dd MMM, h:mm a')}`
+    );
+  });
+  it('displays the correct countdown in the Split field', () => {
+    const embed = generateSeasonEmbed(mockSeasonData);
+    const { split } = mockSeasonData.dates;
+
+    const splitEnd = formatEndDateCountdown({
+      endDate: split.timestamp * 1000,
+      currentDate: new Date('2025-06-18T16:10:49.193Z'),
+    });
+
+    expect(embed.fields && embed.fields[0].name).toBe('Split ends in');
+    expect(embed.fields && embed.fields[0].value).toContain(splitEnd);
+  });
+  it('displays the correct countdown in the Season field', () => {
+    const embed = generateSeasonEmbed(mockSeasonData);
+    const { end } = mockSeasonData.dates;
+
+    const seasonEnd = formatEndDateCountdown({
+      endDate: end.rankedEnd * 1000,
+      currentDate: new Date('2025-06-18T16:10:49.193Z'),
+    });
+
+    expect(embed.fields && embed.fields[1].name).toBe('Season ends in');
+    expect(embed.fields && embed.fields[1].value).toContain(seasonEnd);
+  });
+});

--- a/src/commands/season/index.ts
+++ b/src/commands/season/index.ts
@@ -1,8 +1,14 @@
-import { APIEmbed, SlashCommandBuilder } from 'discord.js';
-import { getEmbedColor, getMapUrl, sendErrorLog } from '../../utils/helpers';
+import { APIEmbed, inlineCode, SlashCommandBuilder } from 'discord.js';
+import {
+  formatEndDateCountdown,
+  getEmbedColor,
+  getMapUrl,
+  sendErrorLog,
+} from '../../utils/helpers';
 import { AppCommand, AppCommandOptions } from '../commands';
 import { getSeasonInformation } from '../../services/adapters';
 import { snakeCase } from 'lodash';
+import { format } from 'date-fns';
 
 export default {
   commandType: 'Information',
@@ -18,30 +24,41 @@ export default {
         season: seasonNumber,
         title,
         description,
+        split,
         data: { image },
       } = season.info;
-      console.log(season);
 
-      // const seasonEnd = formatEndDateCountdown({
-      //   endDate: season.dates.end.rankedEnd * 1000,
-      //   currentDate: new Date(),
-      // });
-      // const splitEnd = formatEndDateCountdown({
-      //   endDate: season.dates.split.timestamp * 1000,
-      //   currentDate: new Date(),
-      // });
+      const seasonEnd = formatEndDateCountdown({
+        endDate: season.dates.end.rankedEnd * 1000,
+        currentDate: new Date(),
+      });
+      const splitEnd = formatEndDateCountdown({
+        endDate: season.dates.split.timestamp * 1000,
+        currentDate: new Date(),
+      });
 
       const embed: APIEmbed = {
         title: `Season ${seasonNumber} | ${title}`,
         color: getEmbedColor(),
-        description,
+        description: `${description}\n\nStarted on: ${inlineCode(
+          format(season.dates.start.timestamp * 1000, 'dd MMM, h:mm a')
+        )}\nCurrent Split: ${inlineCode(split.toString())}`,
         image: {
           url: getMapUrl(`${snakeCase(image)}_rotation`) ?? '',
         },
+        footer: {
+          text: `Season ends on ${format(season.dates.end.rankedEnd * 1000, 'dd MMM, h:mm a')}`,
+        },
         fields: [
           {
-            name: '',
-            value: '',
+            name: 'Split ends in',
+            value: '```fix\n\n' + splitEnd + '```',
+            inline: true,
+          },
+          {
+            name: 'Season ends in',
+            value: '```fix\n\n' + seasonEnd + '```',
+            inline: true,
           },
         ],
       };

--- a/src/commands/season/index.ts
+++ b/src/commands/season/index.ts
@@ -1,7 +1,8 @@
 import { APIEmbed, SlashCommandBuilder } from 'discord.js';
-import { getEmbedColor, sendErrorLog } from '../../utils/helpers';
+import { getEmbedColor, getMapUrl, sendErrorLog } from '../../utils/helpers';
 import { AppCommand, AppCommandOptions } from '../commands';
 import { getSeasonInformation } from '../../services/adapters';
+import { snakeCase } from 'lodash';
 
 export default {
   commandType: 'Information',
@@ -16,8 +17,10 @@ export default {
       const {
         season: seasonNumber,
         title,
-        data: { url },
+        description,
+        data: { image },
       } = season.info;
+      console.log(season);
 
       // const seasonEnd = formatEndDateCountdown({
       //   endDate: season.dates.end.rankedEnd * 1000,
@@ -31,9 +34,16 @@ export default {
       const embed: APIEmbed = {
         title: `Season ${seasonNumber} | ${title}`,
         color: getEmbedColor(),
+        description,
         image: {
-          url,
+          url: getMapUrl(`${snakeCase(image)}_rotation`) ?? '',
         },
+        fields: [
+          {
+            name: '',
+            value: '',
+          },
+        ],
       };
 
       await interaction.editReply({ embeds: [embed] });

--- a/src/commands/season/index.ts
+++ b/src/commands/season/index.ts
@@ -1,0 +1,18 @@
+import { SlashCommandBuilder } from 'discord.js';
+import { sendErrorLog } from '../../utils/helpers';
+import { AppCommand, AppCommandOptions } from '../commands';
+
+export default {
+  commandType: 'Information',
+  data: new SlashCommandBuilder()
+    .setName('season')
+    .setDescription('Shows information of the current season'),
+  async execute({ interaction }: AppCommandOptions) {
+    try {
+      await interaction.deferReply();
+      await interaction.editReply({ embeds: [] });
+    } catch (error) {
+      sendErrorLog({ error, interaction });
+    }
+  },
+} as AppCommand;

--- a/src/commands/season/index.ts
+++ b/src/commands/season/index.ts
@@ -1,6 +1,7 @@
-import { SlashCommandBuilder } from 'discord.js';
-import { sendErrorLog } from '../../utils/helpers';
+import { APIEmbed, SlashCommandBuilder } from 'discord.js';
+import { getEmbedColor, sendErrorLog } from '../../utils/helpers';
 import { AppCommand, AppCommandOptions } from '../commands';
+import { getSeasonInformation } from '../../services/adapters';
 
 export default {
   commandType: 'Information',
@@ -10,7 +11,32 @@ export default {
   async execute({ interaction }: AppCommandOptions) {
     try {
       await interaction.deferReply();
-      await interaction.editReply({ embeds: [] });
+      const season = await getSeasonInformation();
+      if (!season) return;
+      const {
+        season: seasonNumber,
+        title,
+        data: { url },
+      } = season.info;
+
+      // const seasonEnd = formatEndDateCountdown({
+      //   endDate: season.dates.end.rankedEnd * 1000,
+      //   currentDate: new Date(),
+      // });
+      // const splitEnd = formatEndDateCountdown({
+      //   endDate: season.dates.split.timestamp * 1000,
+      //   currentDate: new Date(),
+      // });
+
+      const embed: APIEmbed = {
+        title: `Season ${seasonNumber} | ${title}`,
+        color: getEmbedColor(),
+        image: {
+          url,
+        },
+      };
+
+      await interaction.editReply({ embeds: [embed] });
     } catch (error) {
       sendErrorLog({ error, interaction });
     }

--- a/src/commands/season/index.ts
+++ b/src/commands/season/index.ts
@@ -1,14 +1,7 @@
-import { APIEmbed, inlineCode, SlashCommandBuilder } from 'discord.js';
-import {
-  formatEndDateCountdown,
-  getEmbedColor,
-  getMapUrl,
-  sendErrorLog,
-} from '../../utils/helpers';
+import { SlashCommandBuilder } from 'discord.js';
+import { generateSeasonEmbed, sendErrorLog } from '../../utils/helpers';
 import { AppCommand, AppCommandOptions } from '../commands';
 import { getSeasonInformation } from '../../services/adapters';
-import { snakeCase } from 'lodash';
-import { format } from 'date-fns';
 
 export default {
   commandType: 'Information',
@@ -20,48 +13,8 @@ export default {
       await interaction.deferReply();
       const season = await getSeasonInformation();
       if (!season) return;
-      const {
-        season: seasonNumber,
-        title,
-        description,
-        split,
-        data: { image },
-      } = season.info;
 
-      const seasonEnd = formatEndDateCountdown({
-        endDate: season.dates.end.rankedEnd * 1000,
-        currentDate: new Date(),
-      });
-      const splitEnd = formatEndDateCountdown({
-        endDate: season.dates.split.timestamp * 1000,
-        currentDate: new Date(),
-      });
-
-      const embed: APIEmbed = {
-        title: `Season ${seasonNumber} | ${title}`,
-        color: getEmbedColor(),
-        description: `${description}\n\nStarted on: ${inlineCode(
-          format(season.dates.start.timestamp * 1000, 'dd MMM, h:mm a')
-        )}\nCurrent Split: ${inlineCode(split.toString())}`,
-        image: {
-          url: getMapUrl(`${snakeCase(image)}_rotation`) ?? '',
-        },
-        footer: {
-          text: `Season ends on ${format(season.dates.end.rankedEnd * 1000, 'dd MMM, h:mm a')}`,
-        },
-        fields: [
-          {
-            name: 'Split ends in',
-            value: '```fix\n\n' + splitEnd + '```',
-            inline: true,
-          },
-          {
-            name: 'Season ends in',
-            value: '```fix\n\n' + seasonEnd + '```',
-            inline: true,
-          },
-        ],
-      };
+      const embed = generateSeasonEmbed(season);
 
       await interaction.editReply({ embeds: [embed] });
     } catch (error) {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -19,7 +19,7 @@ import {
   ERROR_NOTIFICATION_WEBHOOK_URL,
 } from '../config/environment';
 import { nessieLogo } from './constants';
-import { isEmpty } from 'lodash';
+import { isEmpty, snakeCase } from 'lodash';
 import { inlineCode } from '@discordjs/builders';
 import { capitalize } from 'lodash';
 import { StatusRecord } from '../services/database';
@@ -27,6 +27,7 @@ import { MapRotationBattleRoyaleSchema, MapRotationRankedSchema } from '../schem
 import { Mixpanel } from 'mixpanel';
 import { sendAnalyticsEvent } from '../services/analytics';
 import { captureException } from '@sentry/node';
+import { SeasonAPISchema } from '../schemas/season';
 
 export const serverNotificationEmbed = async ({
   app,
@@ -427,6 +428,52 @@ export const generateRankedEmbed = (
     };
   }
   return embedData;
+};
+export const generateSeasonEmbed = (seasonData: SeasonAPISchema) => {
+  const {
+    season: seasonNumber,
+    title,
+    description,
+    split: splitNumber,
+    data: { image },
+  } = seasonData.info;
+  const { start, end, split } = seasonData.dates;
+
+  const seasonEnd = formatEndDateCountdown({
+    endDate: end.rankedEnd * 1000,
+    currentDate: new Date(),
+  });
+  const splitEnd = formatEndDateCountdown({
+    endDate: split.timestamp * 1000,
+    currentDate: new Date(),
+  });
+
+  const embed: APIEmbed = {
+    title: `Season ${seasonNumber} | ${title}`,
+    color: getEmbedColor(),
+    description: `${description}\n\nStarted on: ${inlineCode(
+      format(start.timestamp * 1000, 'dd MMM, h:mm a')
+    )}\nCurrent Split: ${inlineCode(splitNumber.toString())}`,
+    image: {
+      url: getMapUrl(`${snakeCase(image)}_rotation`) ?? '',
+    },
+    footer: {
+      text: `Season ends on ${format(end.rankedEnd * 1000, 'dd MMM, h:mm a')}`,
+    },
+    fields: [
+      {
+        name: 'Split ends in',
+        value: '```fix\n\n' + splitEnd + '```',
+        inline: true,
+      },
+      {
+        name: 'Season ends in',
+        value: '```fix\n\n' + seasonEnd + '```',
+        inline: true,
+      },
+    ],
+  };
+  return embed;
 };
 //TODO: Refactor this someday
 export const checkMissingBotPermissions = (


### PR DESCRIPTION
#### Context
Always wanted to do this when I first wired up the season API but got busy doing other stuff. Since I've been pretty active updating nessie, I finally got around into creating this season command. It pretty much just shows the current season's information like season number, title, no of days left for the split and season, etc. 

This would probably the last update in a while as I'll be focusing more on yagi and nessie's website.

<img width="530" alt="image" src="https://github.com/user-attachments/assets/0c146cf5-4576-4612-b0d3-25978c3b970d" />


#### Change
- Create season command
- Add layout
- Add tests