### PR TITLE
Update cdn to use digital ocean space

### DIFF
--- a/.github/workflows/deploy-prod.yml
+++ b/.github/workflows/deploy-prod.yml
@@ -46,7 +46,7 @@ jobs:
         env:
           DISCORD_WEBHOOK: ${{ secrets.DISCORD_NOTIFICATION_WEBHOOK }}
           DISCORD_USERNAME: 'Nessie Release Notification'
-          DISCORD_AVATAR: 'https://vexuas.b-cdn.net/Nessie_Logo_v2.png'
+          DISCORD_AVATAR: 'https://cdn.vexuas.com/Avatars/Nessie_Logo_v2.png'
         uses: Ilshidur/action-discord@0.3.2
         with:
           args: 'Successfully deployed `${{ github.ref_name }}` to production'

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="https://vexuas.b-cdn.net/Nessie_Logo_v2.png" width=120px/>
+  <img src="https://cdn.vexuas.com/Avatars/Nessie_Logo_v2.png" width=120px/>
 </div>
 
 # nessie <br>Apex Legends Map Status Discord Bot

--- a/src/commands/battleRoyale/index.test.ts
+++ b/src/commands/battleRoyale/index.test.ts
@@ -85,7 +85,9 @@ describe('Battle Royale Pubs Command', () => {
   it('displays the correct image url', () => {
     const embed = generatePubsEmbed(mockPubsData);
 
-    expect(embed.image?.url).toBe('https://vexuas.b-cdn.net/apex_legend_maps/worlds_edge.jpg');
+    expect(embed.image?.url).toBe(
+      'https://cdn.vexuas.com/nessie/apex_legends_maps/worlds_edge.jpg'
+    );
   });
   it('displays the correct map in the footer', () => {
     const embed = generatePubsEmbed(mockPubsData);
@@ -142,7 +144,9 @@ describe('Battle Royale Ranked Command', () => {
   it('displays the correct image url', () => {
     const embed = generateRankedEmbed(mockRankedData);
 
-    expect(embed.image?.url).toBe('https://vexuas.b-cdn.net/apex_legend_maps/worlds_edge.jpg');
+    expect(embed.image?.url).toBe(
+      'https://cdn.vexuas.com/nessie/apex_legends_maps/worlds_edge.jpg'
+    );
   });
   it('displays the correct map in the footer', () => {
     const embed = generateRankedEmbed(mockRankedData);

--- a/src/commands/season/index.test.ts
+++ b/src/commands/season/index.test.ts
@@ -80,7 +80,7 @@ describe('Season Command', () => {
   it('displays the correct image url', () => {
     const embed = generateSeasonEmbed(mockSeasonData);
 
-    expect(embed.image?.url).toBe('https://vexuas.b-cdn.net/apex_legend_maps/olympus.jpg');
+    expect(embed.image?.url).toBe('https://cdn.vexuas.com/nessie/apex_legends_maps/olympus.jpg');
   });
   it('displays the correct end date in the footer', () => {
     const embed = generateSeasonEmbed(mockSeasonData);

--- a/src/commands/season/index.test.ts
+++ b/src/commands/season/index.test.ts
@@ -91,24 +91,26 @@ describe('Season Command', () => {
     );
   });
   it('displays the correct countdown in the Split field', () => {
-    const embed = generateSeasonEmbed(mockSeasonData);
+    const mockDate = new Date('2025-06-18T16:10:49.193Z');
+    const embed = generateSeasonEmbed(mockSeasonData, mockDate);
     const { split } = mockSeasonData.dates;
 
     const splitEnd = formatEndDateCountdown({
       endDate: split.timestamp * 1000,
-      currentDate: new Date('2025-06-18T16:10:49.193Z'),
+      currentDate: mockDate,
     });
 
     expect(embed.fields && embed.fields[0].name).toBe('Split ends in');
     expect(embed.fields && embed.fields[0].value).toContain(splitEnd);
   });
   it('displays the correct countdown in the Season field', () => {
-    const embed = generateSeasonEmbed(mockSeasonData);
+    const mockDate = new Date('2025-06-18T16:10:49.193Z');
+    const embed = generateSeasonEmbed(mockSeasonData, mockDate);
     const { end } = mockSeasonData.dates;
 
     const seasonEnd = formatEndDateCountdown({
       endDate: end.rankedEnd * 1000,
-      currentDate: new Date('2025-06-18T16:10:49.193Z'),
+      currentDate: mockDate,
     });
 
     expect(embed.fields && embed.fields[1].name).toBe('Season ends in');

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,1 +1,1 @@
-export const nessieLogo = 'https://vexuas.b-cdn.net/Nessie_Logo_v2.png';
+export const nessieLogo = 'https://cdn.vexuas.com/Avatars/Nessie_Logo_v2.png';

--- a/src/utils/helpers.test.ts
+++ b/src/utils/helpers.test.ts
@@ -53,27 +53,27 @@ describe('pluralize', () => {
 describe('getMapUrl', () => {
   it('returns the correct url when map_code is kings_canyon_rotation', () => {
     const result = getMapUrl('kings_canyon_rotation');
-    expect(result).toBe('https://vexuas.b-cdn.net/apex_legend_maps/kings_canyon.jpg');
+    expect(result).toBe('https://cdn.vexuas.com/nessie/apex_legends_maps/kings_canyon.jpg');
   });
   it('returns the correct url when map_code is worlds_edge_rotation', () => {
     const result = getMapUrl('worlds_edge_rotation');
-    expect(result).toBe('https://vexuas.b-cdn.net/apex_legend_maps/worlds_edge.jpg');
+    expect(result).toBe('https://cdn.vexuas.com/nessie/apex_legends_maps/worlds_edge.jpg');
   });
   it('returns the correct url when map_code is olympus_rotation', () => {
     const result = getMapUrl('olympus_rotation');
-    expect(result).toBe('https://vexuas.b-cdn.net/apex_legend_maps/olympus.jpg');
+    expect(result).toBe('https://cdn.vexuas.com/nessie/apex_legends_maps/olympus.jpg');
   });
   it('returns the correct url when map_code is storm_point_rotation', () => {
     const result = getMapUrl('storm_point_rotation');
-    expect(result).toBe('https://vexuas.b-cdn.net/apex_legend_maps/storm_point.jpg');
+    expect(result).toBe('https://cdn.vexuas.com/nessie/apex_legends_maps/storm_point.jpg');
   });
   it('returns the correct url when map_code is broken_moon_rotation', () => {
     const result = getMapUrl('broken_moon_rotation');
-    expect(result).toBe('https://vexuas.b-cdn.net/apex_legend_maps/broken_moon.jpg');
+    expect(result).toBe('https://cdn.vexuas.com/nessie/apex_legends_maps/broken_moon.jpg');
   });
   it('returns the correct url when map_code is edistrict_rotation', () => {
     const result = getMapUrl('edistrict_rotation');
-    expect(result).toBe('https://vexuas.b-cdn.net/apex_legend_maps/e-district.png');
+    expect(result).toBe('https://cdn.vexuas.com/nessie/apex_legends_maps/e-district.png');
   });
   it('returns null when map_code is not any of the maps', () => {
     const result = getMapUrl('some_map');

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -428,7 +428,7 @@ export const generateRankedEmbed = (
   }
   return embedData;
 };
-export const generateSeasonEmbed = (seasonData: SeasonAPISchema) => {
+export const generateSeasonEmbed = (seasonData: SeasonAPISchema, currentDate?: Date) => {
   const {
     season: seasonNumber,
     title,
@@ -440,11 +440,11 @@ export const generateSeasonEmbed = (seasonData: SeasonAPISchema) => {
 
   const seasonEnd = formatEndDateCountdown({
     endDate: end.rankedEnd * 1000,
-    currentDate: new Date(),
+    currentDate: currentDate ?? new Date(),
   });
   const splitEnd = formatEndDateCountdown({
     endDate: split.timestamp * 1000,
-    currentDate: new Date(),
+    currentDate: currentDate ?? new Date(),
   });
 
   const embed: APIEmbed = {

--- a/src/utils/helpers.ts
+++ b/src/utils/helpers.ts
@@ -38,8 +38,7 @@ export const serverNotificationEmbed = async ({
   guild: Guild;
   type: 'join' | 'leave';
 }): Promise<APIEmbed> => {
-  const defaultIcon =
-    'https://cdn.discordapp.com/attachments/248430185463021569/614789995596742656/Wallpaper2.png';
+  const defaultIcon = 'https://cdn.vexuas.com/Avatars/you_got_that.png';
   const guildIcon = guild.icon && guild.iconURL();
   const guildOwner =
     type === 'join'
@@ -306,17 +305,17 @@ export const generateAnnouncementMessage = (prefix: string) => {
 export const getMapUrl = (map_code: string): string | null => {
   switch (map_code) {
     case 'kings_canyon_rotation':
-      return 'https://vexuas.b-cdn.net/apex_legend_maps/kings_canyon.jpg';
+      return 'https://cdn.vexuas.com/nessie/apex_legends_maps/kings_canyon.jpg';
     case 'worlds_edge_rotation':
-      return 'https://vexuas.b-cdn.net/apex_legend_maps/worlds_edge.jpg';
+      return 'https://cdn.vexuas.com/nessie/apex_legends_maps/worlds_edge.jpg';
     case 'olympus_rotation':
-      return 'https://vexuas.b-cdn.net/apex_legend_maps/olympus.jpg';
+      return 'https://cdn.vexuas.com/nessie/apex_legends_maps/olympus.jpg';
     case 'storm_point_rotation':
-      return 'https://vexuas.b-cdn.net/apex_legend_maps/storm_point.jpg';
+      return 'https://cdn.vexuas.com/nessie/apex_legends_maps/storm_point.jpg';
     case 'broken_moon_rotation':
-      return 'https://vexuas.b-cdn.net/apex_legend_maps/broken_moon.jpg';
+      return 'https://cdn.vexuas.com/nessie/apex_legends_maps/broken_moon.jpg';
     case 'edistrict_rotation':
-      return 'https://vexuas.b-cdn.net/apex_legend_maps/e-district.png';
+      return 'https://cdn.vexuas.com/nessie/apex_legends_maps/e-district.png';
     default:
       return null;
   }


### PR DESCRIPTION
#### Context
I was trying to deploy nessie-web using digitalocean spaces when I realised it offers a CDN too. I'm currently using bunny cdn which has been pretty good but since I'm going to be using spaces anyway for deployment, probably best to have everything I use for infra in one place. I've moved all the files already so would just need to update each of my projects to point to the new cdn url

#### Change
- Update cdn urls to new DO space
